### PR TITLE
Windows: define _NO_CRT_STDIO_INLINE

### DIFF
--- a/datapath-windows/ovsext/precomp.h
+++ b/datapath-windows/ovsext/precomp.h
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+/*
+* define _NO_CRT_STDIO_INLINE
+* This this a workaround for a issue with Visual Studio 2019
+* (noticed first with VS 16.10).
+* LNK errors like this: 
+* __stdio_common_vswprintf referenced in function _vsnwprintf_l	
+*/
+#define  _NO_CRT_STDIO_INLINE 1
+
 #include <ndis.h>
 #include <netiodef.h>
 #include <intsafe.h>


### PR DESCRIPTION
This is a workaround for a issue with Visual Studio 2019 (noticed first after update to VS 16.10).

Without it we will have LNK errors in windows datapath like this: 

```
Error LNK2019	unresolved external symbol __stdio_common_vswprintf referenced in function _vsnwprintf_l
Error LNK2019	unresolved external symbol __stdio_common_vsprintf referenced in function _vsnprintf
```



