### PR TITLE
Updated Windows Build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -292,6 +292,7 @@ jobs:
           ln -s "$pythonLocation\python" /ucrt64/bin/python3      
       - name: prepare
         run:  | 
+          -test -e "/usr/bin/link || mv /usr/bin/link /usr/bin/link_off
           source ~/.visualstudio.sh 
           ./.ci/windows-prepare.sh
       - name: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -237,7 +237,7 @@ jobs:
     
     # linking on latest VS 2019 don't work, most propably due to a VS 2019 issue since VS 16.10
     runs-on: windows-2016
-    timeout-minutes: 60
+    timeout-minutes: 90
     
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -237,16 +237,17 @@ jobs:
     
     # linking on latest VS 2019 don't work, most propably due to a VS 2019 issue since VS 16.10
     runs-on: windows-2016
-    timeout-minutes: 90
+    timeout-minutes: 60
     
     strategy:
       fail-fast: false
       matrix:
         include:
-          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8        
-          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8.1            
+          # run only one job for windows, as more than one be enough currently to verify
+          # PRs
+          # tests are not enabled as they take very long and a lot of them will fail to          
           - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win10
-            testsuite: 1-5
+          
     defaults:
       run:
          shell: msys2 {0}         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -292,7 +292,7 @@ jobs:
           ln -s "$pythonLocation\python" /ucrt64/bin/python3      
       - name: prepare
         run:  | 
-          -test -e "/usr/bin/link || mv /usr/bin/link /usr/bin/link_off
+          -test -e "/usr/bin/link" || mv /usr/bin/link /usr/bin/link_off
           source ~/.visualstudio.sh 
           ./.ci/windows-prepare.sh
       - name: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -292,7 +292,7 @@ jobs:
           ln -s "$pythonLocation\python" /ucrt64/bin/python3      
       - name: prepare
         run:  | 
-          -test -e "/usr/bin/link" || mv /usr/bin/link /usr/bin/link_off
+          [[ -f /usr/bin/link ]] && mv /usr/bin/link /usr/bin/link_off
           source ~/.visualstudio.sh 
           ./.ci/windows-prepare.sh
       - name: build


### PR DESCRIPTION
Improvements of Windows Build:
* run only one test for Win 10 in PRs
* disable tests (takes to long currently and a lot of them are failing)
* make sure that VS link ist used and not link from msys