### PR TITLE
Build with SSL enabled

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,7 +45,8 @@ jobs:
       - name: install openssl
         shell: cmd
         run: |
-            choco install openssl  -y --params "/InstallDir:C:\OpenSSL-Win64"
+            choco install openssl -y
+            mklink /j C:\OpenSSL-Win64 "c:\Program Files\OpenSSL-Win64"
       - name: configure python in Windows cmdline
         shell: cmd
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program Files/OpenSSL-Win64" ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program\ Files/OpenSSL-Win64" ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="/C/Program\ Files/OpenSSL-Win64" ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl=c:/OpenSSL-Win64 ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest
@@ -45,7 +45,7 @@ jobs:
       - name: install openssl
         shell: cmd
         run: |
-            choco install openssl -y
+            choco install openssl  -y --params "/InstallDir:C:\OpenSSL-Win64"
       - name: configure python in Windows cmdline
         shell: cmd
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -93,6 +93,7 @@ jobs:
           make install
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/sbin
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/bin
+          mkdir /C/openvswitch/driver
           cp ./datapath-windows/x64/Win10${{ matrix.target }}/package/* /C/openvswitch/driver
           cp ./datapath-windows/x64/Win10${{ matrix.target }}/package.cer /C/openvswitch/driver
           cp ./datapath-windows/misc/* /C/openvswitch/driver

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -99,5 +99,5 @@ jobs:
       - name: upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: openswitch-windows-${{ join(matrix.*, '-') }}
+          name: openvswitch-windows-${{ join(matrix.*, '-') }}
           path: c:\openvswitch

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program\\ Files/OpenSSL-Win64" ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="/C/Program\ Files/OpenSSL-Win64" ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=${{ matrix.targetVersion }} --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl=C:/OpenSSL-Win64 ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest
@@ -19,10 +19,8 @@ jobs:
           # run only one job for windows, as more than one be enough currently to verify
           # PRs
           # tests are not enabled as they take very long and a lot of them will fail          
-          - opts: --disable-ssl
-            targetVersion: Win10
-            target: Release
-
+          - target: Release
+          
     defaults:
       run:
          shell: msys2 {0}         
@@ -44,6 +42,10 @@ jobs:
       # pypiwin32 has to be installed with a Windows python version therefore
       # this step will configure python first on Windows and exports
       # its location for MSYS bash.  
+      - name: install openssl
+        shell: cmd
+        run: |
+            choco install openssl -y
       - name: configure python in Windows cmdline
         shell: cmd
         run: |
@@ -90,6 +92,10 @@ jobs:
           make install
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/sbin
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/bin
+          cp ./datapath-windows/x64/Win10${{ matrix.target }}/package/* /C/openvswitch/driver
+          cp ./datapath-windows/x64/Win10${{ matrix.target }}/package.cer /C/openvswitch/driver
+          cp ./datapath-windows/misc/* /C/openvswitch/driver
+      
       - name: upload build artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl=c:/OpenSSL-Win64 ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="c:/OpenSSL-Win64/" ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl=C:/OpenSSL-Win64 ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program Files/OpenSSL-Win64" ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="c:/OpenSSL-Win64/" ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl=c:/OpenSSL-Win64 ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     name: windows ${{ join(matrix.*, ' ') }}
     env:
-      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program\ Files/OpenSSL-Win64" ${{ matrix.opts }}
+      OPTS: --with-vstudiotarget=${{ matrix.target }} --with-vstudiotargetver=Win10 --prefix=C:/openvswitch/usr --localstatedir=C:/ProgramData/openvswitch/var --sysconfdir=C:/ProgramData/openvswitch/etc --enable-ssl --with-openssl="C:/Program\\ Files/OpenSSL-Win64" ${{ matrix.opts }}
       TESTSUITE: ${{ matrix.testsuite }}
     
     runs-on: windows-latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,15 @@ init:
 
     mkdir C:\openvswitch\driver
 
-    $source = "https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe"
+    $source = "https://slproweb.com/download/Win64OpenSSL-1_1_1s.exe"
 
-    $destination = "C:\ovs-build-downloads\Win64OpenSSL-1_0_2u.exe"
+    $destination = "C:\ovs-build-downloads\Win64OpenSSL-1_1_1s.exe"
 
     Invoke-WebRequest $source -OutFile $destination
 
     cd C:\ovs-build-downloads
 
-    .\Win64OpenSSL-1_0_2u.exe /silent /verysilent /sp- /suppressmsgboxes
+    .\Win64OpenSSL-1_1_1s.exe /silent /verysilent /sp- /suppressmsgboxes
 
     Start-Sleep -s 30
 

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -81,7 +81,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
                 SSL_INCLUDES="-I$ssldir/include"
                 SSL_LDFLAGS="-L$ssldir/lib"
                 if test "$WIN32" = "yes"; then
-                    SSL_LIBS="-lssleay32 -llibeay32"
+                    SSL_LIBS="-llibcrypto -llibssl"
                     SSL_DIR=/$(echo ${ssldir} | ${SED} -e 's/://')
                 else
                     SSL_LIBS="-lssl -lcrypto"


### PR DESCRIPTION
Updated build workflow to build with ssl enabled and removed unneccessary matrix settings as build for windows < Win10 is deprecated by driver sdk.