### PR TITLE
OpenSSL DLLs are missing in build output

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -94,7 +94,7 @@ jobs:
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/sbin
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/bin
           cp /C/OpenSSL-Win64/libcrypto-1_1-x64.dll /C/openvswitch/usr/bin
-          cp /C/OpenSSL-Win64/libcrypto-1_1-x64.dll /C/openvswitch/usr/bin/sbin
+          cp /C/OpenSSL-Win64/libcrypto-1_1-x64.dll /C/openvswitch/usr/sbin
           cp /C/OpenSSL-Win64/libssl-1_1-x64.dll /C/openvswitch/usr/bin
           cp /C/OpenSSL-Win64/libssl-1_1-x64.dll /C/openvswitch/usr/sbin
           mkdir /C/openvswitch/driver

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -93,6 +93,10 @@ jobs:
           make install
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/sbin
           cp ./PTHREADS-BUILT/bin/pthreadVC3.dll /C/openvswitch/usr/bin
+          cp /C/OpenSSL-Win64/libcrypto-1_1-x64.dll /C/openvswitch/usr/bin
+          cp /C/OpenSSL-Win64/libcrypto-1_1-x64.dll /C/openvswitch/usr/bin/sbin
+          cp /C/OpenSSL-Win64/libssl-1_1-x64.dll /C/openvswitch/usr/bin
+          cp /C/OpenSSL-Win64/libssl-1_1-x64.dll /C/openvswitch/usr/sbin
           mkdir /C/openvswitch/driver
           cp ./datapath-windows/x64/Win10${{ matrix.target }}/package/* /C/openvswitch/driver
           cp ./datapath-windows/x64/Win10${{ matrix.target }}/package.cer /C/openvswitch/driver


### PR DESCRIPTION
updated workflow to copy OpenSSL DLLs to c:\openvswitch\usr\bin and c:\openvswitch\usr\sbin