### PR TITLE
fix BSOD in kernel driver

### DIFF
--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -407,7 +407,10 @@ _MapNlAttrToOvsPktExec(PNL_MSG_HDR nlMsgHdr, PNL_ATTR *nlAttrs,
     execute->actionsLen = NlAttrGetSize(nlAttrs[OVS_PACKET_ATTR_ACTIONS]);
 
     ASSERT(keyAttrs[OVS_KEY_ATTR_IN_PORT]);
-    execute->inPort = NlAttrGetU32(keyAttrs[OVS_KEY_ATTR_IN_PORT]);
+    if (keyAttrs[OVS_KEY_ATTR_IN_PORT]) {
+        execute->inPort = NlAttrGetU32(keyAttrs[OVS_KEY_ATTR_IN_PORT]);
+    }
+
     execute->keyAttrs = keyAttrs;
 
     if (nlAttrs[OVS_PACKET_ATTR_MRU]) {


### PR DESCRIPTION
In case OVS_KEY_ATTR_IN_PORT is not in netlink attributes a BSOD will occur.