### PR TITLE
datapath-windows: Improve INF file of Windows driver

### DIFF
--- a/datapath-windows/ovsext/ovsext.inf
+++ b/datapath-windows/ovsext/ovsext.inf
@@ -8,47 +8,55 @@ Class       = NetService
 ClassGUID   = {4D36E974-E325-11CE-BFC1-08002BE10318}
 Provider    = %OVS%
 CatalogFile = DBO_OVSE.cat
-DriverVer   = 10/10/2013,1.0
+DriverVer   = 10/10/2013,1.0.0.0
+PnpLockdown = 1
 
 [Manufacturer]
-%OVS%=OVS,NTx86,NTia64,NTamd64
+%OVS%=OVS,NTamd64,NTamd64.10.0...16299
 
-[OVS.NTx86]
-%DBO_OVSE_Desc%=Install, DBO_OVSE
+; Model section for Windows 1709 (Build 16299) or newer
+[OVS.NTamd64.10.0...16299]
+%DBO_OVSE_Desc% = OVS_Install, DBO_OVSE
 
-[OVS.NTia64]
-%DBO_OVSE_Desc%=Install, DBO_OVSE
-
+; Model section for older versions of Windows
 [OVS.NTamd64]
-%DBO_OVSE_Desc%=Install, DBO_OVSE
+%DBO_OVSE_Desc% = OVS_Install_Fallback, DBO_OVSE
 
 ;-------------------------------------------------------------------------
 ; Installation Section
 ;-------------------------------------------------------------------------
-[Install]
-AddReg=Inst_Ndi
-Characteristics=0x40000
-NetCfgInstanceId="{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
-Copyfiles = DBO_OVSE.copyfiles.sys
+[OVS_Install]
+AddReg           = OVS_Install_Ndi
+Characteristics  = 0x40000
+NetCfgInstanceId = "{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
+Copyfiles        = OVS_Install_Files
+
+[OVS_Install_Fallback]
+AddReg           = OVS_Install_Ndi
+Characteristics  = 0x40000
+NetCfgInstanceId = "{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
+Copyfiles        = OVS_Install_Fallback_Files
 
 [SourceDisksNames]
-1=%DBO_OVSE_Desc%,"",,
+1 = %DBO_OVSE_Desc%
 
 [SourceDisksFiles]
-DBO_OVSE.sys=1
+DBO_OVSE.sys = 1
 
 [DestinationDirs]
-DefaultDestDir=12
-DBO_OVSE.copyfiles.sys=12
+OVS_Install_Files          = 13
+OVS_Install_Fallback_Files = 12
 
-[DBO_OVSE.copyfiles.sys]
+[OVS_Install_Files]
 DBO_OVSE.sys,,,2
 
+[OVS_Install_Fallback_Files]
+DBO_OVSE.sys,,,2
 
 ;-------------------------------------------------------------------------
 ; Ndi installation support
 ;-------------------------------------------------------------------------
-[Inst_Ndi]
+[OVS_Install_Ndi]
 HKR, Ndi,Service,,"DBO_OVSE"
 HKR, Ndi,CoServices,0x00010000,"DBO_OVSE"
 HKR, Ndi,HelpText,,%DBO_OVSE_HelpText%
@@ -60,13 +68,27 @@ HKR, Ndi\Interfaces, FilterMediaTypes,,"vmnetextension"
 HKR, Ndi,FilterRunType, 0x00010001, 2 ; optional
 
 ;-------------------------------------------------------------------------
-; Service installation support, common.EventLog here is to demonstrate how to
-; write an enent log
+; Service installation
 ;-------------------------------------------------------------------------
-[Install.Services]
-AddService=DBO_OVSE,,DBO_OVSE_Service_Inst;, common.EventLog
+[OVS_Install.Services]
+AddService = DBO_OVSE,,OVS_Install_AddService
 
-[DBO_OVSE_Service_Inst]
+[OVS_Install_AddService]
+DisplayName     = %DBO_OVSE_Desc%
+ServiceType     = 1 ;SERVICE_KERNEL_DRIVER
+StartType       = 1 ;SERVICE_SYSTEM_START
+ErrorControl    = 1 ;SERVICE_ERROR_NORMAL
+ServiceBinary   = %13%\DBO_OVSE.sys
+LoadOrderGroup  = NDIS
+Description     = %DBO_OVSE_Desc%
+
+[OVS_Install.Remove.Services]
+DelService=DBO_OVSE,0x200
+
+[OVS_Install_Fallback.Services]
+AddService = DBO_OVSE,,OVS_Install_Fallback_AddService
+
+[OVS_Install_Fallback_AddService]
 DisplayName     = %DBO_OVSE_Desc%
 ServiceType     = 1 ;SERVICE_KERNEL_DRIVER
 StartType       = 1 ;SERVICE_SYSTEM_START
@@ -75,7 +97,7 @@ ServiceBinary   = %12%\DBO_OVSE.sys
 LoadOrderGroup  = NDIS
 Description     = %DBO_OVSE_Desc%
 
-[Install.Remove.Services]
+[OVS_Install_Fallback.Remove.Services]
 DelService=DBO_OVSE,0x200
 
 [Strings]


### PR DESCRIPTION
Improve the INF file of the Windows driver such that it
- passes verification with the latest Windows Driver Kit (`infverif /w`)
- supports run from driver store for newer versions of Windows
- does not contain references to 32-Bit x86 and Itanium