### PR TITLE
datapath-windows: Fix INF file for Server 2019

### DIFF
--- a/datapath-windows/ovsext/ovsext.inf
+++ b/datapath-windows/ovsext/ovsext.inf
@@ -12,10 +12,16 @@ DriverVer   = 10/10/2013,1.0.0.0
 PnpLockdown = 1
 
 [Manufacturer]
-%OVS%=OVS,NTamd64,NTamd64.10.0...16299
+%OVS%=OVS,NTamd64,NTamd64.10.0...19044
 
-; Model section for Windows 1709 (Build 16299) or newer
-[OVS.NTamd64.10.0...16299]
+; Model section for Windows 10 21H2 (build 19044) or newer. This also includes
+; Server 2022 and Windows 11. These OS will use run from driver store (DIRID 13).
+; 
+; According to the documentation, run from driver store (DIRID 13) should work
+; with build 16299 or 17134 or later. In reality, the service installation fails
+; on Server 2019 (build 17763). Windows 10 21H2 (build 19044) is the oldest non-LTSC
+; build which is still supported.
+[OVS.NTamd64.10.0...19044]
 %DBO_OVSE_Desc% = OVS_Install, DBO_OVSE
 
 ; Model section for older versions of Windows


### PR DESCRIPTION
Run from driver store (using DIRID 13) does not work on Windows Server 2019.

Update the OS build targeting in the INF file to use the fallback (DIRID 12) also for Server 2019.
