### PR TITLE
Windows ovsext: back multiple Hyper-V switches (multi-datapath L2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ target_link_directories(ovs-vsctl PRIVATE ${OVS_EXT_LIBDIRS})
 target_link_libraries(ovs-vsctl PRIVATE openvswitch libssl libcrypto pthreadVC3 ${OVS_SYS_LIBS})
 
 # ovs-dpctl drives the dpif layer directly -- the test tool for dpif-windows
-# ("ovs-dpctl show windows@<dp>" routes straight to dpif_windows_class).
+# ("ovs-dpctl show system@<dp>" routes straight to dpif_windows_class).
 add_executable(ovs-dpctl utilities/ovs-dpctl.c)
 ovs_setup(ovs-dpctl)
 target_link_directories(ovs-dpctl PRIVATE ${OVS_EXT_LIBDIRS})

--- a/datapath-windows/build-driver.ps1
+++ b/datapath-windows/build-driver.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+  Dev build for the dbosoft OVS Hyper-V forwarding extension (DBO_OVSE.sys).
+
+.DESCRIPTION
+  Wraps the MSBuild invocation with the two settings the WDK 10.0.26100 build
+  on this machine needs:
+    -p:Version=...                a concrete DriverVer version, because the
+                                  vcxproj's <Inf><TimeStamp>$(Version)</TimeStamp>
+                                  is empty and stampinf.exe rejects an empty -v.
+    -p:SkipPackageVerification    skips the DPVerifier/InfVerif step, whose x86
+                                  InfVerif.dll is not present in this WDK install.
+                                  (Verification is a packaging lint, not a build
+                                  or signing requirement.)
+
+  Produces a test-signed package under:
+    ovsext\x64\<Config>\package\   and   x64\<Config>\package\
+
+.EXAMPLE
+  pwsh -File build-driver.ps1                 # Win10Debug (checked, asserts on)
+  pwsh -File build-driver.ps1 -Config Win10Release
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Win10Debug', 'Win10Release')]
+    [string]$Config = 'Win10Debug',
+    # Dev DriverVer must outrank the eryph-shipped 3.3.90 in the test VM so
+    # pnputil/PnP prefers our build when superseding the installed extension.
+    [string]$Version = '3.99.0.0',
+    [switch]$Rebuild
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Pin VS2022 (-version '[17.0,18.0)'): the VS18 toolset ships a broken
+# Microsoft.DriverKit.Build.Tasks.18.0.dll in this WDK install, so its MSBuild
+# cannot run the WDK targets.  VS2022's 17.0 DriverKit tasks work.
+$msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+    -version '[17.0,18.0)' -requires Microsoft.Component.MSBuild `
+    -find 'MSBuild\**\Bin\MSBuild.exe' | Select-Object -First 1
+if (-not $msbuild) { throw 'VS2022 MSBuild.exe not found via vswhere.' }
+Write-Host "MSBuild: $msbuild" -ForegroundColor DarkGray
+
+$target = if ($Rebuild) { 'Rebuild' } else { 'Build' }
+
+$msbuildArgs = @(
+    (Join-Path $here 'ovsext.sln')
+    "-t:$target"
+    "-p:Configuration=$Config"
+    '-p:Platform=x64'
+    "-p:Version=$Version"
+    '-p:SkipPackageVerification=true'
+    '-m'
+    '-nologo'
+)
+
+& $msbuild @msbuildArgs
+
+if ($LASTEXITCODE -ne 0) { throw "Build failed ($LASTEXITCODE)." }
+
+$pkg = Join-Path $here "x64\$Config\package"
+Write-Host "`nPackage: $pkg" -ForegroundColor Green
+Get-ChildItem $pkg -ErrorAction SilentlyContinue | Select-Object Name, Length, LastWriteTime

--- a/datapath-windows/deploy-driver.ps1
+++ b/datapath-windows/deploy-driver.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+  Hot-swap the freshly built DBO_OVSE.sys into the ovs-kerneldev test VM and
+  reload it, without a reboot.
+
+.DESCRIPTION
+  Iteration loop for kernel driver dev. Assumes ONE-TIME setup is already done on
+  the VM (see datapath-windows/test-catlet and project memory):
+    * WDKTestCert imported into LocalMachine\Root + TrustedPublisher
+    * testsigning active at runtime (VBS disabled + rebooted once)
+    * our package staged once via `pnputil /add-driver ovsext.inf` so its catalog
+      is registered and the DBO_OVSE service ImagePath points at our ovsext.inf_*
+      DriverStore folder.
+
+  Because the .sys is embedded test-signed and testsigning is active, we can simply
+  overwrite the bound .sys in place after unloading it. Sequence that works:
+    1. (optional) stop nested guests so the switch is quiescent
+    2. Disable-VMSwitchExtension  -> detach the filter
+    3. Stop-Service DBO_OVSE      -> unload image, unlock the .sys
+    4. overwrite the bound .sys (path read from the service ImagePath)
+    5. Start-Service DBO_OVSE; Enable-VMSwitchExtension -> reattach with new code
+    6. verify Running + hash match
+    7. (optional) restart nested guests
+
+.EXAMPLE
+  pwsh -File deploy-driver.ps1                 # build already done; swap + reload
+  pwsh -File deploy-driver.ps1 -Build          # build first, then swap
+#>
+[CmdletBinding()]
+param(
+    [switch]$Build,
+    [string]$Alias   = 'ovs-kerneldev',
+    [string]$VmId    = '80cfe34e-d27d-4c77-89f7-79608f901cb8',
+    [string[]]$NestedVMs = @('ub1','ub2'),
+    [switch]$KeepNestedRunning
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ssh  = Join-Path $env:WINDIR 'System32\OpenSSH\ssh.exe'
+$egs  = "$env:USERPROFILE\AppData\Local\Eryph\egs-tool\bin\egs-tool.exe"
+$pkg  = Join-Path $here 'x64\Win10Debug\package'
+
+function Invoke-Remote([string]$script) {
+    $enc = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+    & $ssh -o BatchMode=yes -o ConnectTimeout=25 $Alias "powershell -NoProfile -EncodedCommand $enc"
+    if ($LASTEXITCODE -ne 0) { throw "remote command failed ($LASTEXITCODE)" }
+}
+
+if ($Build) {
+    & (Join-Path $here 'build-driver.ps1')
+    if ($LASTEXITCODE -ne 0) { throw 'build failed' }
+}
+
+$localHash = (Get-FileHash (Join-Path $pkg 'DBO_OVSE.sys') -Algorithm SHA256).Hash
+Write-Host "local DBO_OVSE.sys = $localHash" -ForegroundColor DarkGray
+
+# stage the fresh files (egs-tool: scp-over-proxy hangs; upload-* does not).
+Invoke-Remote 'Get-ChildItem C:\ovs-test\driver -File -EA SilentlyContinue | Remove-Item -Force'
+& $egs upload-directory $VmId $pkg 'C:\ovs-test\driver' | Select-Object -Last 1
+
+$stopList = if ($KeepNestedRunning) { '@()' } else { "@('" + ($NestedVMs -join "','") + "')" }
+$startBackLit = if ($KeepNestedRunning) { '$false' } else { '$true' }
+
+$swap = @"
+`$ErrorActionPreference='Continue'
+`$ext = 'dbosoft Open vSwitch Extension'
+`$sw  = (Get-VMSwitch | Get-VMSwitchExtension | Where-Object Name -eq `$ext | Select-Object -First 1).SwitchName
+`$nested = $stopList
+if (`$nested.Count) { Get-VM `$nested -EA SilentlyContinue | Stop-VM -Force -TurnOff -EA SilentlyContinue }
+Disable-VMSwitchExtension -VMSwitchName `$sw -Name `$ext -EA Continue | Out-Null
+Stop-Service DBO_OVSE -Force -EA Continue
+Start-Sleep 2
+`$bound = ((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\DBO_OVSE').ImagePath) -replace '^\\SystemRoot','C:\Windows'
+Copy-Item C:\ovs-test\driver\DBO_OVSE.sys `$bound -Force
+Copy-Item C:\ovs-test\driver\dbo_ovse.cat (Split-Path `$bound) -Force -EA SilentlyContinue
+`$h = (Get-FileHash `$bound -Algorithm SHA256).Hash
+"bound hash = `$h"
+"HASH MATCH = " + (`$h -eq '$localHash')
+Start-Service DBO_OVSE -EA Continue
+Enable-VMSwitchExtension -VMSwitchName `$sw -Name `$ext -EA Continue | Out-Null
+Start-Sleep 2
+"driver state = " + (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+Get-VMSwitch | Get-VMSwitchExtension | Where-Object Name -eq `$ext | Select-Object Enabled,Running | Format-List
+if ($startBackLit -and `$nested.Count) { Start-VM `$nested -EA SilentlyContinue }
+"@
+Invoke-Remote $swap
+Write-Host "`nDeploy complete." -ForegroundColor Green

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2095,7 +2095,8 @@ OvsOutputUserspaceAction(OvsForwardingContext *ovsFwdCtx,
                                   ovsFwdCtx->curNbl,
                                   NET_BUFFER_LIST_FIRST_NB(ovsFwdCtx->curNbl),
                                   isRecv,
-                                  layers);
+                                  layers,
+                                  ovsFwdCtx->switchContext->dpNo);
     if (elem) {
         LIST_ENTRY missedPackets;
         InitializeListHead(&missedPackets);

--- a/datapath-windows/ovsext/Conntrack-related.c
+++ b/datapath-windows/ovsext/Conntrack-related.c
@@ -352,6 +352,7 @@ OvsCleanupCtRelated(VOID)
     KeWaitForSingleObject(ctRelThreadCtx.threadObject, Executive,
                           KernelMode, FALSE, NULL);
     ObDereferenceObject(ctRelThreadCtx.threadObject);
+    ctRelThreadCtx.threadObject = NULL;
 
     if (ovsCtRelatedTable) {
         OvsCtRelatedFlush();

--- a/datapath-windows/ovsext/Conntrack-related.c
+++ b/datapath-windows/ovsext/Conntrack-related.c
@@ -282,14 +282,14 @@ OvsCtRelatedEntryCleaner(PVOID data)
  *----------------------------------------------------------------------------
  */
 NTSTATUS
-OvsInitCtRelated(POVS_SWITCH_CONTEXT context)
+OvsInitCtRelated(NDIS_HANDLE ndisFilterHandle)
 {
     NTSTATUS status;
     HANDLE threadHandle = NULL;
     ctTotalRelatedEntries = 0;
 
     /* Init the sync-lock */
-    ovsCtRelatedLockObj = NdisAllocateRWLock(context->NdisFilterHandle);
+    ovsCtRelatedLockObj = NdisAllocateRWLock(ndisFilterHandle);
     if (ovsCtRelatedLockObj == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -341,6 +341,9 @@ VOID
 OvsCleanupCtRelated(VOID)
 {
     LOCK_STATE_EX lockState;
+    if (ctRelThreadCtx.threadObject == NULL) {
+        return;
+    }
     NdisAcquireRWLockWrite(ovsCtRelatedLockObj, &lockState, 0);
     ctRelThreadCtx.exit = 1;
     KeSetEvent(&ctRelThreadCtx.event, 0, FALSE);

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -52,7 +52,7 @@ MapNlToCtTuple(POVS_MESSAGE msgIn, PNL_ATTR attr,
  *----------------------------------------------------------------------------
  */
 NTSTATUS
-OvsInitConntrack(POVS_SWITCH_CONTEXT context)
+OvsInitConntrack(NDIS_HANDLE ndisFilterHandle)
 {
     NTSTATUS status = STATUS_SUCCESS;
     HANDLE threadHandle = NULL;
@@ -77,7 +77,7 @@ OvsInitConntrack(POVS_SWITCH_CONTEXT context)
 
     for (UINT32 i = 0; i < CT_HASH_TABLE_SIZE; i++) {
         InitializeListHead(&ovsConntrackTable[i]);
-        ovsCtBucketLock[i] = NdisAllocateRWLock(context->NdisFilterHandle);
+        ovsCtBucketLock[i] = NdisAllocateRWLock(ndisFilterHandle);
         if (ovsCtBucketLock[i] == NULL) {
             status = STATUS_INSUFFICIENT_RESOURCES;
             numBucketLocks = i;
@@ -104,6 +104,12 @@ OvsInitConntrack(POVS_SWITCH_CONTEXT context)
                                         CT_MAX_ZONE, OVS_CT_POOL_TAG);
     if (zoneInfo == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
+        ctThreadCtx.exit = 1;
+        KeSetEvent(&ctThreadCtx.event, 0, FALSE);
+        KeWaitForSingleObject(ctThreadCtx.threadObject, Executive,
+                              KernelMode, FALSE, NULL);
+        ObDereferenceObject(ctThreadCtx.threadObject);
+        ctThreadCtx.threadObject = NULL;
         goto freeBucketLock;
     }
 
@@ -118,6 +124,7 @@ OvsInitConntrack(POVS_SWITCH_CONTEXT context)
 
     if (status != STATUS_SUCCESS) {
         OvsCleanupConntrack();
+        return status;
     }
     return STATUS_SUCCESS;
 
@@ -144,11 +151,15 @@ freeTable:
 VOID
 OvsCleanupConntrack(VOID)
 {
+    if (ctThreadCtx.threadObject == NULL) {
+        return;
+    }
     ctThreadCtx.exit = 1;
     KeSetEvent(&ctThreadCtx.event, 0, FALSE);
     KeWaitForSingleObject(ctThreadCtx.threadObject, Executive,
                           KernelMode, FALSE, NULL);
     ObDereferenceObject(ctThreadCtx.threadObject);
+    ctThreadCtx.threadObject = NULL;
 
     /* Force flush all entries before removing */
     OvsCtFlush(0, NULL);

--- a/datapath-windows/ovsext/Conntrack.h
+++ b/datapath-windows/ovsext/Conntrack.h
@@ -177,7 +177,7 @@ const TCPHdr* OvsGetTcpHeader(PNET_BUFFER_LIST nbl, OVS_PACKET_HDR_INFO *layers,
                                      VOID *storage, UINT32 *tcpPayloadLen);
 
 VOID OvsCleanupConntrack(VOID);
-NTSTATUS OvsInitConntrack(POVS_SWITCH_CONTEXT context);
+NTSTATUS OvsInitConntrack(NDIS_HANDLE ndisFilterHandle);
 
 NDIS_STATUS OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                                       OvsFlowKey *key,
@@ -213,7 +213,7 @@ NTSTATUS OvsCreateNlMsgFromCtEntry(POVS_CT_ENTRY entry,
                                    UINT32 dpIfIndex);
 
 /* Tracking related connections */
-NTSTATUS OvsInitCtRelated(POVS_SWITCH_CONTEXT context);
+NTSTATUS OvsInitCtRelated(NDIS_HANDLE ndisFilterHandle);
 VOID OvsCleanupCtRelated(VOID);
 NDIS_STATUS OvsCtRelatedEntryCreate(UINT8 ipProto,
                                     UINT16 dl_type,

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -596,17 +596,22 @@ POVS_OPEN_INSTANCE
 OvsGetOpenInstance(PFILE_OBJECT fileObject,
                    UINT32 dpNo)
 {
-    LOCK_STATE_EX lockState;
     POVS_OPEN_INSTANCE instance = (POVS_OPEN_INSTANCE)fileObject->FsContext;
+    POVS_SWITCH_CONTEXT switchContext;
     ASSERT(instance);
     ASSERT(instance->fileObject == fileObject);
-    NdisAcquireRWLockWrite(gOvsSwitchContext->dispatchLock, &lockState, 0);
 
-    if (gOvsSwitchContext->dpNo != dpNo) {
-        instance = NULL;
+    /*
+     * The datapath reference is only an existence gate: the open instance
+     * returned belongs to the file object, not to the switch context, so the
+     * reference is released immediately. A NULL means no such datapath.
+     */
+    switchContext = OvsAcquireDatapathByNumber(dpNo);
+    if (switchContext == NULL) {
+        return NULL;
     }
+    OvsReleaseSwitchContext(switchContext);
 
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
     return instance;
 }
 

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -402,7 +402,8 @@ static NTSTATUS ValidateNetlinkCmd(UINT32 devOp,
                                    POVS_OPEN_INSTANCE instance,
                                    POVS_MESSAGE ovsMsg,
                                    UINT32 ovsMgsLength,
-                                   NETLINK_FAMILY *nlFamilyOps);
+                                   NETLINK_FAMILY *nlFamilyOps,
+                                   POVS_SWITCH_CONTEXT datapath);
 static NTSTATUS InvokeNetlinkCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                                         NETLINK_FAMILY *nlFamilyOps,
                                         UINT32 *replyLen);
@@ -800,6 +801,7 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
     POVS_MESSAGE ovsMsg;
     UINT32 ovsMsgLength = 0;
     NETLINK_FAMILY *nlFamilyOps;
+    POVS_SWITCH_CONTEXT dpCtx = NULL;
     OVS_USER_PARAMS_CONTEXT usrParamsCtx;
 
 #pragma warning(suppress: 28118)
@@ -849,7 +851,7 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
             InitUserParamsCtx(irp, instance, 0, NULL,
                               inputBuffer, inputBufferLen,
                               outputBuffer, outputBufferLen,
-                              &usrParamsCtx);
+                              NULL, &usrParamsCtx);
 
             ASSERT(outputBuffer);
         } else {
@@ -1022,13 +1024,16 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
         goto done;
     }
 
+    /* Resolve the datapath that the request targets, if any. */
+    dpCtx = OvsAcquireDatapathByNumber(ovsMsg->ovsHdr.dp_ifindex);
+
     /*
      * For read operation, avoid duplicate validation since 'ovsMsg' is either
      * "artificial" or was copied from a previously validated 'ovsMsg'.
      */
     if (devOp != OVS_READ_DEV_OP) {
         status = ValidateNetlinkCmd(devOp, instance, ovsMsg,
-                                    ovsMsgLength, nlFamilyOps);
+                                    ovsMsgLength, nlFamilyOps, dpCtx);
         if (status != STATUS_SUCCESS) {
             goto done;
         }
@@ -1037,11 +1042,14 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
     InitUserParamsCtx(irp, instance, devOp, ovsMsg,
                       inputBuffer, inputBufferLen,
                       outputBuffer, outputBufferLen,
-                      &usrParamsCtx);
+                      dpCtx, &usrParamsCtx);
 
     status = InvokeNetlinkCmdHandler(&usrParamsCtx, nlFamilyOps, &replyLen);
 
 done:
+    if (dpCtx != NULL) {
+        OvsReleaseSwitchContext(dpCtx);
+    }
     OvsReleaseSwitchContext(gOvsSwitchContext);
 
 exit:
@@ -1064,7 +1072,8 @@ ValidateNetlinkCmd(UINT32 devOp,
                    POVS_OPEN_INSTANCE instance,
                    POVS_MESSAGE ovsMsg,
                    UINT32 ovsMsgLength,
-                   NETLINK_FAMILY *nlFamilyOps)
+                   NETLINK_FAMILY *nlFamilyOps,
+                   POVS_SWITCH_CONTEXT datapath)
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
     UINT16 i;
@@ -1115,8 +1124,7 @@ ValidateNetlinkCmd(UINT32 devOp,
 
             /* Validate the DP for commands that require a DP. */
             if (nlFamilyOps->cmds[i].validateDpIndex == TRUE) {
-                if (ovsMsg->ovsHdr.dp_ifindex !=
-                                          (INT)gOvsSwitchContext->dpNo) {
+                if (datapath == NULL) {
                     status = STATUS_INVALID_PARAMETER;
                     goto done;
                 }

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -1733,7 +1733,7 @@ OvsPortFillInfo(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         ASSERT(FALSE);
         return STATUS_UNSUCCESSFUL;
     }
-    msgOutTmp.ovsHdr.dp_ifindex = gOvsSwitchContext->dpNo;
+    msgOutTmp.ovsHdr.dp_ifindex = eventEntry->dpNo;
 
     ok = NlMsgPutHead(nlBuf, (PCHAR)&msgOutTmp, sizeof msgOutTmp);
     if (!ok) {
@@ -1923,7 +1923,7 @@ OvsSockPropCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     if(!NlFillOvsMsg(&nlBuf, msgIn->nlMsg.nlmsgType, NLM_F_MULTI,
                       msgIn->nlMsg.nlmsgSeq, msgIn->nlMsg.nlmsgPid,
                       msgIn->genlMsg.cmd, msgIn->genlMsg.version,
-                      gOvsSwitchContext->dpNo)){
+                      msgIn->ovsHdr.dp_ifindex)){
         return STATUS_INVALID_BUFFER_SIZE;
     }
 

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -1310,6 +1310,8 @@ OvsDpFillInfo(POVS_SWITCH_CONTEXT ovsSwitchContext,
     writeOk = NlMsgPutHead(nlBuf, (PCHAR)&msgOutTmp, sizeof msgOutTmp);
     if (writeOk) {
         writeOk = NlMsgPutTailString(nlBuf, OVS_DP_ATTR_NAME,
+                                     ovsSwitchContext->dpGuidName[0] ?
+                                     ovsSwitchContext->dpGuidName :
                                      OVS_SYSTEM_DP_NAME);
     }
     if (writeOk) {

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -1483,6 +1483,8 @@ HandleGetDpDump(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         NL_BUFFER nlBuf;
         NTSTATUS status;
         POVS_MESSAGE msgIn = instance->dumpState.ovsMsg;
+        POVS_SWITCH_CONTEXT switchContext;
+        UINT32 nextSlot = 0;
 
         ASSERT(usrParamsCtx->devOp == OVS_READ_DEV_OP);
 
@@ -1491,16 +1493,26 @@ HandleGetDpDump(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
             return STATUS_INVALID_DEVICE_STATE;
         }
 
-        /* Dump state must have been deleted after previous dump operation. */
-        ASSERT(instance->dumpState.index[0] == 0);
-
         /* Output buffer has been validated while validating read dev op. */
         ASSERT(msgOut != NULL && usrParamsCtx->outputLength >= sizeof *msgOut);
+
+        /*
+         * 'index[0]' is the registry slot at which to resume the scan. Emit the
+         * next live datapath as one record; an empty reply signals the end.
+         */
+        switchContext = OvsAcquireNextDatapath(instance->dumpState.index[0],
+                                               &nextSlot);
+        if (switchContext == NULL) {
+            *replyLen = 0;
+            FreeUserDumpState(instance);
+            return STATUS_SUCCESS;
+        }
 
         NlBufInit(&nlBuf, usrParamsCtx->outputBuffer,
                   usrParamsCtx->outputLength);
 
-        status = OvsDpFillInfo(gOvsSwitchContext, msgIn, &nlBuf);
+        status = OvsDpFillInfo(switchContext, msgIn, &nlBuf);
+        OvsReleaseSwitchContext(switchContext);
 
         if (status != STATUS_SUCCESS) {
             *replyLen = 0;
@@ -1508,12 +1520,8 @@ HandleGetDpDump(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
             return status;
         }
 
-        /* Increment the dump index. */
-        instance->dumpState.index[0] = 1;
+        instance->dumpState.index[0] = nextSlot;
         *replyLen = msgOut->nlMsg.nlmsgLen;
-
-        /* Free up the dump state, since there's no more data to continue. */
-        FreeUserDumpState(instance);
     }
 
     return STATUS_SUCCESS;

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -482,6 +482,7 @@ OvsInit()
 
     gOvsCtrlLock = &ovsCtrlLockObj;
     NdisAllocateSpinLock(gOvsCtrlLock);
+    OvsInitDatapathRegistry();
     OvsInitEventQueue();
 
     status = OvsPerCpuDataInit();
@@ -494,6 +495,7 @@ OvsCleanup()
 {
     OvsPerCpuDataCleanup();
     OvsCleanupEventQueue();
+    OvsCleanupDatapathRegistry();
     if (gOvsCtrlLock) {
         NdisFreeSpinLock(gOvsCtrlLock);
         gOvsCtrlLock = NULL;
@@ -802,6 +804,7 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
     UINT32 ovsMsgLength = 0;
     NETLINK_FAMILY *nlFamilyOps;
     POVS_SWITCH_CONTEXT dpCtx = NULL;
+    POVS_SWITCH_CONTEXT defaultDpCtx = NULL;
     OVS_USER_PARAMS_CONTEXT usrParamsCtx;
 
 #pragma warning(suppress: 28118)
@@ -828,13 +831,10 @@ OvsDeviceControl(PDEVICE_OBJECT deviceObject,
     outputBufferLen = irpSp->Parameters.DeviceIoControl.OutputBufferLength;
     inputBuffer = irp->AssociatedIrp.SystemBuffer;
 
-    /* Check if the extension is enabled. */
-    if (NULL == gOvsSwitchContext) {
-        status = STATUS_NOT_FOUND;
-        goto exit;
-    }
-
-    if (!OvsAcquireSwitchContext()) {
+    /* Hold the default datapath for the request's duration; this also tells us
+     * the extension is enabled. */
+    defaultDpCtx = OvsAcquireSwitchContext();
+    if (defaultDpCtx == NULL) {
         status = STATUS_NOT_FOUND;
         goto exit;
     }
@@ -1050,7 +1050,7 @@ done:
     if (dpCtx != NULL) {
         OvsReleaseSwitchContext(dpCtx);
     }
-    OvsReleaseSwitchContext(gOvsSwitchContext);
+    OvsReleaseSwitchContext(defaultDpCtx);
 
 exit:
     /* Should not complete a pending IRP unless proceesing is completed. */

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -482,8 +482,14 @@ OvsInit()
 
     gOvsCtrlLock = &ovsCtrlLockObj;
     NdisAllocateSpinLock(gOvsCtrlLock);
-    OvsInitDatapathRegistry();
+    /* Init the event queue before the (fallible) datapath registry so that the
+     * OvsCleanup() teardown on a registry-init failure is safe (it frees the
+     * event-queue locks unconditionally). */
     OvsInitEventQueue();
+    status = OvsInitDatapathRegistry();
+    if (status != NDIS_STATUS_SUCCESS) {
+        return status;
+    }
 
     status = OvsPerCpuDataInit();
 

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -1545,6 +1545,7 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     NTSTATUS status = STATUS_SUCCESS;
     NL_BUFFER nlBuf;
     NL_ERROR nlError = NL_ERROR_SUCCESS;
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     static const NL_POLICY ovsDatapathSetPolicy[] = {
         [OVS_DP_ATTR_NAME] = { .type = NL_A_STRING, .maxLen = IFNAMSIZ },
         [OVS_DP_ATTR_UPCALL_PID] = { .type = NL_A_U32, .optional = TRUE },
@@ -1584,6 +1585,13 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     NlBufInit(&nlBuf, usrParamsCtx->outputBuffer, usrParamsCtx->outputLength);
 
+    /* The request's dp_ifindex was resolved to switchContext in
+     * OvsDeviceControl; a NULL context means no such datapath. */
+    if (switchContext == NULL) {
+        nlError = NL_ERROR_NODEV;
+        goto cleanup;
+    }
+
     if (dpAttrs[OVS_DP_ATTR_NAME] != NULL) {
         if (!OvsCompareString(NlAttrGet(dpAttrs[OVS_DP_ATTR_NAME]),
                               OVS_SYSTEM_DP_NAME)) {
@@ -1597,9 +1605,6 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
             nlError = NL_ERROR_NODEV;
             goto cleanup;
         }
-    } else if ((UINT32)msgIn->ovsHdr.dp_ifindex != gOvsSwitchContext->dpNo) {
-        nlError = NL_ERROR_NODEV;
-        goto cleanup;
     }
 
     if (usrParamsCtx->ovsMsg->genlMsg.cmd == OVS_DP_CMD_NEW) {
@@ -1607,7 +1612,7 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         goto cleanup;
     }
 
-    status = OvsDpFillInfo(gOvsSwitchContext, msgIn, &nlBuf);
+    status = OvsDpFillInfo(switchContext, msgIn, &nlBuf);
 
     *replyLen = NlBufSize(&nlBuf);
 

--- a/datapath-windows/ovsext/Datapath.h
+++ b/datapath-windows/ovsext/Datapath.h
@@ -42,6 +42,8 @@ typedef struct _OVS_DEVICE_EXTENSION {
 typedef struct _OVS_USER_PACKET_QUEUE OVS_USER_PACKET_QUEUE,
                                       *POVS_USER_PACKET_QUEUE;
 
+typedef struct _OVS_SWITCH_CONTEXT OVS_SWITCH_CONTEXT, *POVS_SWITCH_CONTEXT;
+
 /*
  * Private context for each handle on the device.
  */
@@ -100,6 +102,8 @@ typedef struct _OVS_USER_PARAMS_CONTEXT {
     PVOID outputBuffer;  /* Output buffer specified by userspace for reading
                           * data. Maybe NULL. */
     UINT32 outputLength; /* Length of output buffer. */
+    POVS_SWITCH_CONTEXT switchContext; /* Datapath addressed by the request, or
+                                        * NULL if it addresses none. */
 } OVS_USER_PARAMS_CONTEXT, *POVS_USER_PARAMS_CONTEXT;
 
 static __inline VOID
@@ -111,6 +115,7 @@ InitUserParamsCtx(PIRP irp,
                   UINT32 inputLength,
                   PVOID outputBuffer,
                   UINT32 outputLength,
+                  POVS_SWITCH_CONTEXT switchContext,
                   POVS_USER_PARAMS_CONTEXT usrParamsCtx)
 {
     usrParamsCtx->irp = irp;
@@ -121,6 +126,7 @@ InitUserParamsCtx(PIRP irp,
     usrParamsCtx->inputLength = inputLength;
     usrParamsCtx->outputBuffer = outputBuffer;
     usrParamsCtx->outputLength = outputLength;
+    usrParamsCtx->switchContext = switchContext;
 }
 
 NTSTATUS InitUserDumpState(POVS_OPEN_INSTANCE instance,

--- a/datapath-windows/ovsext/DpInternal.h
+++ b/datapath-windows/ovsext/DpInternal.h
@@ -364,6 +364,7 @@ typedef struct _OVS_VPORT_EVENT_ENTRY {
     UINT32 upcallPid;
     CHAR ovsName[OVS_MAX_PORT_NAME_LENGTH];
     UINT32 type;
+    UINT32 dpNo;
 } OVS_VPORT_EVENT_ENTRY, *POVS_VPORT_EVENT_ENTRY;
 
 #pragma pack(pop)

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -46,6 +46,7 @@ NDIS_HANDLE gOvsExtDriverHandle;
  * function.
  */
 extern POVS_SWITCH_CONTEXT gOvsSwitchContext;
+extern PDEVICE_OBJECT gOvsDeviceObject;
 
 static PWCHAR ovsExtFriendlyName = L"dbosoft Open vSwitch Extension";
 static PWCHAR ovsExtServiceName = L"DBO_OVSE";
@@ -160,6 +161,18 @@ DriverEntry(PDRIVER_OBJECT driverObject,
         goto cleanup;
     }
 
+    /*
+     * The tunnel WFP callouts are a host-global resource independent of any
+     * switch, so they are set up once at driver load rather than per attach.
+     */
+    status = OvsInitTunnelFilter(gOvsExtDriverObject, gOvsDeviceObject);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
 cleanup:
     if (status != NDIS_STATUS_SUCCESS){
         OvsCleanup();
@@ -178,6 +191,12 @@ VOID
 OvsExtUnload(struct _DRIVER_OBJECT *driverObject)
 {
     UNREFERENCED_PARAMETER(driverObject);
+
+    /*
+     * Tear down the tunnel WFP callouts (set up once in DriverEntry) before the
+     * NDIS device and filter-driver registration they were created against.
+     */
+    OvsUninitTunnelFilter(gOvsExtDriverObject);
 
     OvsDeleteDeviceObject();
 

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -18,6 +18,7 @@
 #include "Switch.h"
 #include "User.h"
 #include "Datapath.h"
+#include "IpHelper.h"
 
 #ifdef OVS_DBG_MOD
 #undef OVS_DBG_MOD
@@ -173,6 +174,20 @@ DriverEntry(PDRIVER_OBJECT driverObject,
         goto cleanup;
     }
 
+    /*
+     * The IP helper (host route/neighbor tracking thread and notifications) is
+     * a host-global resource independent of any switch, so it is set up once at
+     * driver load rather than per attach.
+     */
+    status = OvsInitIpHelper(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
 cleanup:
     if (status != NDIS_STATUS_SUCCESS){
         OvsCleanup();
@@ -197,6 +212,12 @@ OvsExtUnload(struct _DRIVER_OBJECT *driverObject)
      * NDIS device and filter-driver registration they were created against.
      */
     OvsUninitTunnelFilter(gOvsExtDriverObject);
+
+    /*
+     * Tear down the IP helper (set up once in DriverEntry) before the
+     * filter-driver registration whose handle its lock was allocated against.
+     */
+    OvsCleanupIpHelper();
 
     OvsDeleteDeviceObject();
 

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -19,6 +19,10 @@
 #include "User.h"
 #include "Datapath.h"
 #include "IpHelper.h"
+#include "Conntrack.h"
+#include "IpFragment.h"
+#include "Ip6Fragment.h"
+#include "Meter.h"
 
 #ifdef OVS_DBG_MOD
 #undef OVS_DBG_MOD
@@ -188,6 +192,71 @@ DriverEntry(PDRIVER_OBJECT driverObject,
         goto cleanup;
     }
 
+    /*
+     * Conntrack, connection-tracking helpers, IPv4/IPv6 fragment reassembly and
+     * the meter table are host-global subsystems (static tables and cleaner
+     * threads), so they are set up once at driver load rather than per attach.
+     */
+    status = OvsInitConntrack(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsCleanupIpHelper();
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
+    status = OvsInitCtRelated(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsCleanupConntrack();
+        OvsCleanupIpHelper();
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
+    status = OvsInitIpFragment(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsCleanupCtRelated();
+        OvsCleanupConntrack();
+        OvsCleanupIpHelper();
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
+    status = OvsInitIp6Fragment(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsCleanupIpFragment();
+        OvsCleanupCtRelated();
+        OvsCleanupConntrack();
+        OvsCleanupIpHelper();
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
+    status = OvsInitMeter(gOvsExtDriverHandle);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OvsCleanupIp6Fragment();
+        OvsCleanupIpFragment();
+        OvsCleanupCtRelated();
+        OvsCleanupConntrack();
+        OvsCleanupIpHelper();
+        OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsDeleteDeviceObject();
+        NdisFDeregisterFilterDriver(gOvsExtDriverHandle);
+        gOvsExtDriverHandle = NULL;
+        goto cleanup;
+    }
+
 cleanup:
     if (status != NDIS_STATUS_SUCCESS){
         OvsCleanup();
@@ -214,10 +283,15 @@ OvsExtUnload(struct _DRIVER_OBJECT *driverObject)
     OvsUninitTunnelFilter(gOvsExtDriverObject);
 
     /*
-     * Tear down the IP helper (set up once in DriverEntry) before the
-     * filter-driver registration whose handle its lock was allocated against.
+     * Tear down the driver-load-scoped subsystems before the filter-driver
+     * registration whose handle their locks were allocated against.
      */
     OvsCleanupIpHelper();
+    OvsCleanupMeter();
+    OvsCleanupIp6Fragment();
+    OvsCleanupIpFragment();
+    OvsCleanupCtRelated();
+    OvsCleanupConntrack();
 
     OvsDeleteDeviceObject();
 

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -284,14 +284,17 @@ OvsExtUnload(struct _DRIVER_OBJECT *driverObject)
 
     /*
      * Tear down the driver-load-scoped subsystems before the filter-driver
-     * registration whose handle their locks were allocated against.
+     * registration whose handle their locks were allocated against, in the
+     * reverse of the DriverEntry init order (IpHelper, Conntrack, CtRelated,
+     * IpFragment, Ip6Fragment, Meter) so IpHelper -- whose worker thread can run
+     * the forwarding path -- is stopped last.
      */
-    OvsCleanupIpHelper();
     OvsCleanupMeter();
     OvsCleanupIp6Fragment();
     OvsCleanupIpFragment();
     OvsCleanupCtRelated();
     OvsCleanupConntrack();
+    OvsCleanupIpHelper();
 
     OvsDeleteDeviceObject();
 

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -3007,7 +3007,7 @@ OvsPutFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
     }
 
     dpNo = put->dpNo;
-    if (switchContext->dpNo != dpNo) {
+    if (switchContext == NULL || switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
@@ -3181,7 +3181,7 @@ OvsGetFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
     }
 
     dpNo = getInput->dpNo;
-    if (switchContext->dpNo != dpNo) {
+    if (switchContext == NULL || switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
@@ -3212,7 +3212,7 @@ OvsFlushFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
     OVS_DATAPATH *datapath = NULL;
     LOCK_STATE_EX dpLockState;
 
-    if (switchContext->dpNo != dpNo) {
+    if (switchContext == NULL || switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -34,7 +34,6 @@
 #pragma warning( push )
 #pragma warning( disable:4127 )
 
-extern POVS_SWITCH_CONTEXT gOvsSwitchContext;
 extern UINT64 ovsTimeIncrementPerTick;
 
 static NTSTATUS ReportFlowInfo(OvsFlow *flow, UINT32 getFlags,
@@ -83,7 +82,8 @@ static NTSTATUS _MapFlowArpKeyToNlKey(PNL_BUFFER nlBuf,
 static NTSTATUS _MapFlowMplsKeyToNlKey(PNL_BUFFER nlBuf,
                                        MplsKey *mplsFlowPutKey);
 
-static NTSTATUS OvsDoDumpFlows(OvsFlowDumpInput *dumpInput,
+static NTSTATUS OvsDoDumpFlows(POVS_SWITCH_CONTEXT switchContext,
+                               OvsFlowDumpInput *dumpInput,
                                OvsFlowDumpOutput *dumpOutput,
                                UINT32 *replyLen);
 static NTSTATUS OvsProbeSupportedFeature(POVS_MESSAGE msgIn,
@@ -303,7 +303,8 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     if ((genlMsgHdr->cmd == OVS_FLOW_CMD_DEL) &&
         (!NlMsgAttrsLen(nlMsgHdr))) {
 
-        rc = OvsFlushFlowIoctl(ovsHdr->dp_ifindex);
+        rc = OvsFlushFlowIoctl(usrParamsCtx->switchContext,
+                               ovsHdr->dp_ifindex);
 
        if (rc == STATUS_SUCCESS) {
             /* XXX: refactor this code. */
@@ -354,8 +355,8 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         goto done;
     }
 
-    rc = OvsPutFlowIoctl(&mappedFlow, sizeof (struct OvsFlowPut),
-                         &stats);
+    rc = OvsPutFlowIoctl(usrParamsCtx->switchContext, &mappedFlow,
+                         sizeof (struct OvsFlowPut), &stats);
     if (rc != STATUS_SUCCESS) {
         OVS_LOG_ERROR("OvsPutFlowIoctl failed.");
         /*
@@ -566,7 +567,7 @@ _FlowNlGetCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     /* 4th argument is a no op.
      * We are keeping this argument to be compatible
      * with our dpif-windows based interface. */
-    rc = OvsGetFlowIoctl(&getInput, &getOutput);
+    rc = OvsGetFlowIoctl(usrParamsCtx->switchContext, &getInput, &getOutput);
     if (rc != STATUS_SUCCESS) {
         OVS_LOG_ERROR("OvsGetFlowIoctl failed.");
         /*
@@ -670,7 +671,8 @@ _FlowNlDumpCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         dumpInput.position[0] = instance->dumpState.index[0];
         dumpInput.position[1] = instance->dumpState.index[1];
 
-        rc = OvsDoDumpFlows(&dumpInput, &dumpOutput, &temp);
+        rc = OvsDoDumpFlows(usrParamsCtx->switchContext, &dumpInput,
+                            &dumpOutput, &temp);
         if (rc != STATUS_SUCCESS) {
             OVS_LOG_ERROR("OvsDoDumpFlows failed with rc: %d", rc);
             /*
@@ -2848,7 +2850,8 @@ FreeFlow(OvsFlow *flow)
 }
 
 NTSTATUS
-OvsDoDumpFlows(OvsFlowDumpInput *dumpInput,
+OvsDoDumpFlows(POVS_SWITCH_CONTEXT switchContext,
+               OvsFlowDumpInput *dumpInput,
                OvsFlowDumpOutput *dumpOutput,
                UINT32 *replyLen)
 {
@@ -2863,7 +2866,7 @@ OvsDoDumpFlows(OvsFlowDumpInput *dumpInput,
     BOOLEAN findNextNonEmpty = FALSE;
 
     dpNo = dumpInput->dpNo;
-    if (gOvsSwitchContext->dpNo != dpNo) {
+    if (switchContext == NULL || switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
@@ -2877,7 +2880,7 @@ OvsDoDumpFlows(OvsFlowDumpInput *dumpInput,
 
     columnIndex = dumpInput->position[1];
 
-    datapath = &gOvsSwitchContext->datapath;
+    datapath = &switchContext->datapath;
     ASSERT(datapath);
     OvsAcquireDatapathRead(datapath, &dpLockState, FALSE);
 
@@ -2980,7 +2983,8 @@ ReportFlowInfo(OvsFlow *flow,
 }
 
 NTSTATUS
-OvsPutFlowIoctl(PVOID inputBuffer,
+OvsPutFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
+                PVOID inputBuffer,
                 UINT32 inputLength,
                 struct OvsFlowStats *stats)
 {
@@ -3003,12 +3007,12 @@ OvsPutFlowIoctl(PVOID inputBuffer,
     }
 
     dpNo = put->dpNo;
-    if (gOvsSwitchContext->dpNo != dpNo) {
+    if (switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
 
-    datapath = &gOvsSwitchContext->datapath;
+    datapath = &switchContext->datapath;
     ASSERT(datapath);
     OvsAcquireDatapathWrite(datapath, &dpLockState, FALSE);
     status = HandleFlowPut(put, datapath, stats);
@@ -3154,7 +3158,8 @@ OvsPrepareFlow(OvsFlow **flow,
 }
 
 NTSTATUS
-OvsGetFlowIoctl(PVOID inputBuffer,
+OvsGetFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
+                PVOID inputBuffer,
                 PVOID outputBuffer)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -3176,12 +3181,12 @@ OvsGetFlowIoctl(PVOID inputBuffer,
     }
 
     dpNo = getInput->dpNo;
-    if (gOvsSwitchContext->dpNo != dpNo) {
+    if (switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
 
-    datapath = &gOvsSwitchContext->datapath;
+    datapath = &switchContext->datapath;
     ASSERT(datapath);
     OvsAcquireDatapathRead(datapath, &dpLockState, FALSE);
     flow = OvsLookupFlow(datapath, &getInput->key, &hash, FALSE);
@@ -3200,18 +3205,19 @@ exit:
 }
 
 NTSTATUS
-OvsFlushFlowIoctl(UINT32 dpNo)
+OvsFlushFlowIoctl(POVS_SWITCH_CONTEXT switchContext,
+                  UINT32 dpNo)
 {
     NTSTATUS status = STATUS_SUCCESS;
     OVS_DATAPATH *datapath = NULL;
     LOCK_STATE_EX dpLockState;
 
-    if (gOvsSwitchContext->dpNo != dpNo) {
+    if (switchContext->dpNo != dpNo) {
         status = STATUS_INVALID_PARAMETER;
         goto exit;
     }
 
-    datapath = &gOvsSwitchContext->datapath;
+    datapath = &switchContext->datapath;
     ASSERT(datapath);
     OvsAcquireDatapathWrite(datapath, &dpLockState, FALSE);
     DeleteAllFlows(datapath);

--- a/datapath-windows/ovsext/Flow.h
+++ b/datapath-windows/ovsext/Flow.h
@@ -69,10 +69,11 @@ VOID OvsFlowUsed(OvsFlow *flow, const NET_BUFFER_LIST *pkt,
 NTSTATUS OvsDumpFlowIoctl(PVOID inputBuffer, UINT32 inputLength,
                           PVOID outputBuffer, UINT32 outputLength,
                           UINT32 *replyLen);
-NTSTATUS OvsPutFlowIoctl(PVOID inputBuffer, UINT32 inputLength,
-                         struct OvsFlowStats *stats);
-NTSTATUS OvsGetFlowIoctl(PVOID inputBuffer, PVOID outputBuffer);
-NTSTATUS OvsFlushFlowIoctl(UINT32 dpNo);
+NTSTATUS OvsPutFlowIoctl(POVS_SWITCH_CONTEXT switchContext, PVOID inputBuffer,
+                         UINT32 inputLength, struct OvsFlowStats *stats);
+NTSTATUS OvsGetFlowIoctl(POVS_SWITCH_CONTEXT switchContext, PVOID inputBuffer,
+                         PVOID outputBuffer);
+NTSTATUS OvsFlushFlowIoctl(POVS_SWITCH_CONTEXT switchContext, UINT32 dpNo);
 
 NTSTATUS OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                              UINT32 *replyLen);

--- a/datapath-windows/ovsext/Ip6Fragment.c
+++ b/datapath-windows/ovsext/Ip6Fragment.c
@@ -127,13 +127,13 @@ OvsIp6FragmentEntryCleaner(PVOID data)
     PsTerminateSystemThread(STATUS_SUCCESS);
 }
 
-NDIS_STATUS OvsInitIp6Fragment(POVS_SWITCH_CONTEXT context)
+NDIS_STATUS OvsInitIp6Fragment(NDIS_HANDLE ndisFilterHandle)
 {
     NDIS_STATUS status;
     HANDLE threadHandle = NULL;
 
     OVS_LOG_INFO("Init ipv6 fragment.");
-    ovsIp6FragmentHashLockObj = NdisAllocateRWLock(context->NdisFilterHandle);
+    ovsIp6FragmentHashLockObj = NdisAllocateRWLock(ndisFilterHandle);
     if (ovsIp6FragmentHashLockObj == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -206,6 +206,10 @@ VOID OvsCleanupIp6Fragment(VOID)
     PLIST_ENTRY link, next;
     POVS_IP6FRAG_ENTRY entry;
     LOCK_STATE_EX lockState;
+
+    if (ip6FragThreadCtx.threadObject == NULL) {
+        return;
+    }
 
     ip6FragThreadCtx.exit = 1;
     KeSetEvent(&ip6FragThreadCtx.event, 0, FALSE);

--- a/datapath-windows/ovsext/Ip6Fragment.c
+++ b/datapath-windows/ovsext/Ip6Fragment.c
@@ -160,7 +160,7 @@ NDIS_STATUS OvsInitIp6Fragment(NDIS_HANDLE ndisFilterHandle)
                                   &ip6FragThreadCtx);
 
     if (status != STATUS_SUCCESS) {
-        OvsFreeMemoryWithTag(OvsIp6FragTable, OVS_IPFRAG_POOL_TAG);
+        OvsFreeMemoryWithTag(OvsIp6FragTable, OVS_IP6FRAG_POOL_TAG);
         OvsIp6FragTable = NULL;
         NdisFreeRWLock(ovsIp6FragmentHashLockObj);
         ovsIp6FragmentHashLockObj = NULL;

--- a/datapath-windows/ovsext/Ip6Fragment.h
+++ b/datapath-windows/ovsext/Ip6Fragment.h
@@ -101,7 +101,7 @@ NDIS_STATUS OvsStorageIpv6ExtHeader(POVS_IP6FRAG_ENTRY entry,
                                     UINT16 priorFragEleOffset,
                                     CHAR *pktBuf,
                                     POVS_PACKET_HDR_INFO layers);
-NDIS_STATUS OvsInitIp6Fragment(POVS_SWITCH_CONTEXT context);
+NDIS_STATUS OvsInitIp6Fragment(NDIS_HANDLE ndisFilterHandle);
 VOID OvsCleanupIp6Fragment(VOID);
 NDIS_STATUS OvsGetPacketMeta(PIP6_PktExtHeader_Meta pktMeta, EthHdr *eth,
                              OvsFlowKey *key, POVS_PACKET_HDR_INFO layers);

--- a/datapath-windows/ovsext/IpFragment.c
+++ b/datapath-windows/ovsext/IpFragment.c
@@ -41,14 +41,14 @@ static UINT64 ipTotalEntries;
 static PLIST_ENTRY OvsIpFragTable;
 
 NDIS_STATUS
-OvsInitIpFragment(POVS_SWITCH_CONTEXT context)
+OvsInitIpFragment(NDIS_HANDLE ndisFilterHandle)
 {
 
     NDIS_STATUS status;
     HANDLE threadHandle = NULL;
 
     /* Init the sync-lock */
-    ovsIpFragmentHashLockObj = NdisAllocateRWLock(context->NdisFilterHandle);
+    ovsIpFragmentHashLockObj = NdisAllocateRWLock(ndisFilterHandle);
     if (ovsIpFragmentHashLockObj == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -503,6 +503,10 @@ OvsCleanupIpFragment(VOID)
     PLIST_ENTRY link, next;
     POVS_IPFRAG_ENTRY entry;
     LOCK_STATE_EX lockState;
+
+    if (ipFragThreadCtx.threadObject == NULL) {
+        return;
+    }
 
     ipFragThreadCtx.exit = 1;
     KeSetEvent(&ipFragThreadCtx.event, 0, FALSE);

--- a/datapath-windows/ovsext/IpFragment.h
+++ b/datapath-windows/ovsext/IpFragment.h
@@ -70,6 +70,6 @@ NDIS_STATUS OvsProcessIpv4Fragment(POVS_SWITCH_CONTEXT switchContext,
                                    NDIS_SWITCH_PORT_ID sourcePort,
                                    POVS_PACKET_HDR_INFO layers,
                                    ovs_be64 tunnelId);
-NDIS_STATUS OvsInitIpFragment(POVS_SWITCH_CONTEXT context);
+NDIS_STATUS OvsInitIpFragment(NDIS_HANDLE ndisFilterHandle);
 VOID OvsCleanupIpFragment(VOID);
 #endif /* __IPFRAGMENT_H_ */

--- a/datapath-windows/ovsext/IpHelper.c
+++ b/datapath-windows/ovsext/IpHelper.c
@@ -2146,6 +2146,9 @@ init_cleanup:
 VOID
 OvsCleanupIpHelper(VOID)
 {
+    if (ovsIpHelperThreadContext.threadObject == NULL) {
+        return;
+    }
     OvsCancelChangeNotification();
 
     NdisAcquireSpinLock(&ovsIpHelperLock);
@@ -2156,6 +2159,7 @@ OvsCleanupIpHelper(VOID)
     KeWaitForSingleObject(ovsIpHelperThreadContext.threadObject, Executive,
                           KernelMode, FALSE, NULL);
     ObDereferenceObject(ovsIpHelperThreadContext.threadObject);
+    ovsIpHelperThreadContext.threadObject = NULL;
 
     OvsFreeMemoryWithTag(ovsFwdHashTable, OVS_IPHELPER_POOL_TAG);
     OvsFreeMemoryWithTag(ovsRouteHashTable, OVS_IPHELPER_POOL_TAG);

--- a/datapath-windows/ovsext/Meter.c
+++ b/datapath-windows/ovsext/Meter.c
@@ -82,6 +82,17 @@ OvsCleanupMeter(VOID)
         return;
     }
     if (meterGlobalTable) {
+        /* Free any meters still installed before releasing the table. Runs at
+         * driver unload after the request paths are gone, so no lock needed. */
+        for (UINT32 index = 0; index < METER_HASH_BUCKET_MAX; index++) {
+            PLIST_ENTRY head = &meterGlobalTable[index];
+            PLIST_ENTRY link, next;
+            LIST_FORALL_SAFE(head, link, next) {
+                DpMeter *entry = CONTAINING_RECORD(link, DpMeter, link);
+                RemoveEntryList(&entry->link);
+                OvsFreeMemoryWithTag(entry, OVS_METER_TAG);
+            }
+        }
         OvsFreeMemoryWithTag(meterGlobalTable, OVS_METER_TAG);
         meterGlobalTable = NULL;
     }

--- a/datapath-windows/ovsext/Meter.c
+++ b/datapath-windows/ovsext/Meter.c
@@ -51,11 +51,11 @@ const NL_POLICY bandPolicy[OVS_BAND_ATTR_MAX + 1] = {
 };
 
 NTSTATUS
-OvsInitMeter(POVS_SWITCH_CONTEXT context)
+OvsInitMeter(NDIS_HANDLE ndisFilterHandle)
 {
     UINT32 maxEntry = METER_HASH_BUCKET_MAX;
 
-    meterGlobalTableLock = NdisAllocateRWLock(context->NdisFilterHandle);
+    meterGlobalTableLock = NdisAllocateRWLock(ndisFilterHandle);
     if (meterGlobalTableLock == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -64,6 +64,7 @@ OvsInitMeter(POVS_SWITCH_CONTEXT context)
                                                 OVS_METER_TAG);
     if (!meterGlobalTable) {
         NdisFreeRWLock(meterGlobalTableLock);
+        meterGlobalTableLock = NULL;
         return NDIS_STATUS_RESOURCES;
     }
 
@@ -72,6 +73,20 @@ OvsInitMeter(POVS_SWITCH_CONTEXT context)
     }
 
     return NDIS_STATUS_SUCCESS;
+}
+
+VOID
+OvsCleanupMeter(VOID)
+{
+    if (meterGlobalTableLock == NULL) {
+        return;
+    }
+    if (meterGlobalTable) {
+        OvsFreeMemoryWithTag(meterGlobalTable, OVS_METER_TAG);
+        meterGlobalTable = NULL;
+    }
+    NdisFreeRWLock(meterGlobalTableLock);
+    meterGlobalTableLock = NULL;
 }
 
 NDIS_STATUS

--- a/datapath-windows/ovsext/Meter.h
+++ b/datapath-windows/ovsext/Meter.h
@@ -50,7 +50,8 @@ typedef struct _DpMeter {
     DpMeterBand  bands[OVS_MAX_BANDS];
 } DpMeter;
 
-NTSTATUS OvsInitMeter(POVS_SWITCH_CONTEXT context);
+NTSTATUS OvsInitMeter(NDIS_HANDLE ndisFilterHandle);
+VOID OvsCleanupMeter(VOID);
 NDIS_STATUS OvsNewMeterCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                                   UINT32 *replyLen);
 NDIS_STATUS OvsMeterFeatureProbe(POVS_USER_PARAMS_CONTEXT usrParamsCtx,

--- a/datapath-windows/ovsext/Oid.c
+++ b/datapath-windows/ovsext/Oid.c
@@ -755,6 +755,69 @@ done:
 
 /*
  * --------------------------------------------------------------------------
+ * Captures the Hyper-V switch GUID into switchContext->dpGuidName, where it
+ * serves as the datapath's canonical name. On any failure the name is left
+ * empty and the datapath falls back to the default name; it is never fatal.
+ * --------------------------------------------------------------------------
+ */
+VOID
+OvsCaptureSwitchName(POVS_SWITCH_CONTEXT switchContext)
+{
+    NDIS_STATUS status;
+    PNDIS_SWITCH_PARAMETERS switchParams;
+    UINT32 outputSizeNeeded;
+    ANSI_STRING astr;
+    UNICODE_STRING ustr;
+
+    switchContext->dpGuidName[0] = '\0';
+
+    switchParams = OvsAllocateMemoryWithTag(sizeof *switchParams,
+                                            OVS_OID_POOL_TAG);
+    if (!switchParams) {
+        return;
+    }
+
+    RtlZeroMemory(switchParams, sizeof *switchParams);
+    switchParams->Header.Revision = NDIS_SWITCH_PARAMETERS_REVISION_1;
+    switchParams->Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+    switchParams->Header.Size = NDIS_SIZEOF_NDIS_SWITCH_PARAMETERS_REVISION_1;
+
+    status = OvsIssueOidRequest(switchContext, NdisRequestQueryInformation,
+                                OID_SWITCH_PARAMETERS, NULL, 0,
+                                (PVOID)switchParams, sizeof *switchParams,
+                                &outputSizeNeeded);
+    if (status != NDIS_STATUS_SUCCESS) {
+        OVS_LOG_WARN("Failed to query switch name, status: %x", status);
+        goto cleanup;
+    }
+
+    ustr.Buffer = switchParams->SwitchName.String;
+    ustr.Length = switchParams->SwitchName.Length;
+    ustr.MaximumLength = IF_MAX_STRING_SIZE;
+
+    astr.Buffer = switchContext->dpGuidName;
+    astr.MaximumLength = OVS_DP_GUID_NAME_LEN;
+    astr.Length = 0;
+
+    if (RtlUnicodeStringToAnsiSize(&ustr) > OVS_DP_GUID_NAME_LEN) {
+        OVS_LOG_WARN("Switch name too long for datapath name buffer");
+        goto cleanup;
+    }
+
+    status = RtlUnicodeStringToAnsiString(&astr, &ustr, FALSE);
+    if (status != STATUS_SUCCESS) {
+        switchContext->dpGuidName[0] = '\0';
+        goto cleanup;
+    }
+    switchContext->dpGuidName[astr.Length] = '\0';
+
+cleanup:
+    OvsFreeMemoryWithTag(switchParams, OVS_OID_POOL_TAG);
+}
+
+
+/*
+ * --------------------------------------------------------------------------
  * Utility function to get the array of ports on the extensible switch. Upon
  * success, the caller needs to free the returned array.
  * --------------------------------------------------------------------------

--- a/datapath-windows/ovsext/Oid.h
+++ b/datapath-windows/ovsext/Oid.h
@@ -19,6 +19,7 @@
 
 NDIS_STATUS OvsQuerySwitchActivationComplete(POVS_SWITCH_CONTEXT switchContext,
                                              BOOLEAN *switchActive);
+VOID OvsCaptureSwitchName(POVS_SWITCH_CONTEXT switchContext);
 NDIS_STATUS OvsGetPortsOnSwitch(POVS_SWITCH_CONTEXT switchContext,
                                 PNDIS_SWITCH_PORT_ARRAY *portArrayOut);
 NDIS_STATUS OvsGetNicsOnSwitch(POVS_SWITCH_CONTEXT switchContext,

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -38,7 +38,6 @@
 #include "Debug.h"
 
 POVS_SWITCH_CONTEXT gOvsSwitchContext;
-LONG volatile gOvsInAttach;
 UINT64 ovsTimeIncrementPerTick;
 
 extern NDIS_HANDLE gOvsExtDriverHandle;
@@ -97,22 +96,6 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
         goto cleanup;
     }
 
-    NdisAcquireSpinLock(&gOvsDatapathLock);
-    if (gOvsSwitchContext) {
-        NdisReleaseSpinLock(&gOvsDatapathLock);
-        OVS_LOG_TRACE("Exit: Failed to create OVS Switch, only one datapath is"
-                      "supported, %p.", gOvsSwitchContext);
-        goto cleanup;
-    }
-    NdisReleaseSpinLock(&gOvsDatapathLock);
-
-    if (InterlockedCompareExchange(&gOvsInAttach, 1, 0)) {
-        /* Just fail the request. */
-        OVS_LOG_TRACE("Exit: Failed to create OVS Switch, since another attach"
-                      "instance is in attach process.");
-        goto cleanup;
-    }
-
     status = OvsCreateSwitch(ndisFilterHandle, &switchContext);
     if (status != NDIS_STATUS_SUCCESS) {
         goto cleanup;
@@ -143,7 +126,6 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
     OvsRegisterDatapath(switchContext);
 
 cleanup:
-    InterlockedExchange(&gOvsInAttach, 0);
     if (status != NDIS_STATUS_SUCCESS) {
         if (switchContext != NULL) {
             OvsDeleteSwitch(switchContext);

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -664,6 +664,8 @@ OvsActivateSwitch(POVS_SWITCH_CONTEXT switchContext)
     OVS_LOG_TRACE("Enter: activate switch %p, dpNo: %ld",
                   switchContext, switchContext->dpNo);
 
+    OvsCaptureSwitchName(switchContext);
+
     status = OvsAddConfiguredSwitchPorts(switchContext);
 
     if (status != NDIS_STATUS_SUCCESS) {

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -215,12 +215,6 @@ OvsCreateSwitch(NDIS_HANDLE ndisFilterHandle,
         goto create_switch_done;
     }
 
-    status = OvsInitTunnelFilter(gOvsExtDriverObject, gOvsDeviceObject);
-    if (status != NDIS_STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        goto create_switch_done;
-    }
-
     status = OvsInitConntrack(switchContext);
     if (status != STATUS_SUCCESS) {
         OvsUninitSwitchContext(switchContext);
@@ -312,7 +306,6 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
     {
         dpNo = switchContext->dpNo;
         OvsClearAllSwitchVports(switchContext);
-        OvsUninitTunnelFilter(gOvsExtDriverObject);
         OvsUnregisterDatapath(switchContext);
         OvsUninitSwitchContext(switchContext);
     }

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -140,9 +140,7 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
     switchContext->controlFlowState = OvsSwitchAttached;
     switchContext->dataFlowState = OvsSwitchPaused;
 
-    gOvsSwitchContextRefCount = 1;
-    gOvsSwitchContext = switchContext;
-    KeMemoryBarrier();
+    OvsRegisterDatapath(switchContext);
 
 cleanup:
     InterlockedExchange(&gOvsInAttach, 0);
@@ -307,6 +305,7 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
         dpNo = switchContext->dpNo;
         OvsClearAllSwitchVports(switchContext);
         OvsUninitTunnelFilter(gOvsExtDriverObject);
+        OvsUnregisterDatapath(switchContext);
         OvsUninitSwitchContext(switchContext);
     }
     OVS_LOG_TRACE("Exit: deleted switch %p  dpNo: %d", switchContext, dpNo);
@@ -560,6 +559,57 @@ OvsAcquireSwitchContext(VOID)
     }
 
     return ret;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ *  Datapath registry: maps a datapath number (dpNo) to its switch context.
+ * --------------------------------------------------------------------------
+ */
+VOID
+OvsRegisterDatapath(POVS_SWITCH_CONTEXT switchContext)
+{
+    ASSERT(gOvsSwitchContext == NULL);
+
+    gOvsSwitchContextRefCount = 1;
+    gOvsSwitchContext = switchContext;
+    KeMemoryBarrier();
+}
+
+VOID
+OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext)
+{
+    /*
+     * The context's storage is released by OvsReleaseSwitchContext when its
+     * last reference drops, so removing it from the registry needs no separate
+     * unlink and must not touch gOvsSwitchContextRefCount (doing so would
+     * double-release the context).
+     */
+    UNREFERENCED_PARAMETER(switchContext);
+}
+
+/*
+ *  Returns the switch context for datapath number 'dpNo' with a reference held
+ *  (release it with OvsReleaseSwitchContext), or NULL if no such datapath
+ *  exists.
+ */
+POVS_SWITCH_CONTEXT
+OvsAcquireDatapathByNumber(UINT32 dpNo)
+{
+    POVS_SWITCH_CONTEXT switchContext;
+
+    if (!OvsAcquireSwitchContext()) {
+        return NULL;
+    }
+
+    /* The held reference keeps the context and gOvsSwitchContext alive. */
+    switchContext = gOvsSwitchContext;
+    if (switchContext != NULL && switchContext->dpNo == dpNo) {
+        return switchContext;
+    }
+
+    OvsReleaseSwitchContext(switchContext);
+    return NULL;
 }
 
 /*

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -113,15 +113,8 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
         goto cleanup;
     }
 
-    status = OvsInitIpHelper(ndisFilterHandle);
-    if (status != STATUS_SUCCESS) {
-        OVS_LOG_ERROR("Exit: Failed to initialize IP helper.");
-        goto cleanup;
-    }
-
     status = OvsCreateSwitch(ndisFilterHandle, &switchContext);
     if (status != NDIS_STATUS_SUCCESS) {
-        OvsCleanupIpHelper();
         goto cleanup;
     }
     ASSERT(switchContext);
@@ -140,7 +133,6 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
     status = NdisFSetAttributes(ndisFilterHandle, switchContext, &ovsExtAttributes);
     if (status != NDIS_STATUS_SUCCESS) {
         OVS_LOG_ERROR("Failed to set attributes.");
-        OvsCleanupIpHelper();
         goto cleanup;
     }
 
@@ -277,7 +269,6 @@ OvsExtDetach(NDIS_HANDLE filterModuleContext)
         NdisMSleep(1000);
     }
     OvsDeleteSwitch(switchContext);
-    OvsCleanupIpHelper();
     OvsCleanupConntrack();
     OvsCleanupCtRelated();
     OvsCleanupIpFragment();

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -55,6 +55,16 @@ extern PDEVICE_OBJECT gOvsDeviceObject;
 POVS_SWITCH_CONTEXT gOvsDatapaths[OVS_MAX_DATAPATHS];
 NDIS_SPIN_LOCK     gOvsDatapathLock;
 
+/*
+ * The upcall pid hash maps a globally-unique handle pid to its open instance.
+ * Pids are allocated from a single driver-wide counter, so the hash is a
+ * driver-global resource (lifetime = driver load), not per-switch: this keeps
+ * it intact when the default datapath detaches and 'gOvsSwitchContext' is
+ * promoted to another datapath. See User.c.
+ */
+PLIST_ENTRY        gOvsPidHashArray;
+NDIS_SPIN_LOCK     gOvsPidHashLock;
+
 static NDIS_STATUS OvsCreateSwitch(NDIS_HANDLE ndisFilterHandle,
                                    POVS_SWITCH_CONTEXT *switchContextOut);
 static NDIS_STATUS OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext);
@@ -340,8 +350,6 @@ OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
         sizeof(LIST_ENTRY) * OVS_MAX_VPORT_ARRAY_SIZE, OVS_SWITCH_POOL_TAG);
     switchContext->portIdHashArray= (PLIST_ENTRY)OvsAllocateMemoryWithTag(
         sizeof(LIST_ENTRY) * OVS_MAX_VPORT_ARRAY_SIZE, OVS_SWITCH_POOL_TAG);
-    switchContext->pidHashArray = (PLIST_ENTRY)OvsAllocateMemoryWithTag(
-        sizeof(LIST_ENTRY) * OVS_MAX_PID_ARRAY_SIZE, OVS_SWITCH_POOL_TAG);
     switchContext->tunnelVportsArray = (PLIST_ENTRY)OvsAllocateMemoryWithTag(
         sizeof(LIST_ENTRY) * OVS_MAX_VPORT_ARRAY_SIZE, OVS_SWITCH_POOL_TAG);
     status = OvsAllocateFlowTable(&switchContext->datapath, switchContext);
@@ -354,7 +362,6 @@ OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
         switchContext->portNoHashArray == NULL ||
         switchContext->ovsPortNameHashArray == NULL ||
         switchContext->portIdHashArray== NULL ||
-        switchContext->pidHashArray == NULL ||
         switchContext->tunnelVportsArray == NULL) {
         if (switchContext->dispatchLock) {
             NdisFreeRWLock(switchContext->dispatchLock);
@@ -369,10 +376,6 @@ OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
         }
         if (switchContext->portIdHashArray) {
             OvsFreeMemoryWithTag(switchContext->portIdHashArray,
-                                 OVS_SWITCH_POOL_TAG);
-        }
-        if (switchContext->pidHashArray) {
-            OvsFreeMemoryWithTag(switchContext->pidHashArray,
                                  OVS_SWITCH_POOL_TAG);
         }
 
@@ -394,11 +397,6 @@ OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
         InitializeListHead(&switchContext->tunnelVportsArray[i]);
     }
 
-    for (i = 0; i < OVS_MAX_PID_ARRAY_SIZE; i++) {
-        InitializeListHead(&switchContext->pidHashArray[i]);
-    }
-
-    NdisAllocateSpinLock(&(switchContext->pidHashLock));
     switchContext->isActivated = FALSE;
     switchContext->isActivateFailed = FALSE;
     switchContext->refCount = 1;
@@ -431,7 +429,6 @@ OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 
     NdisFreeRWLock(switchContext->dispatchLock);
     switchContext->dispatchLock = NULL;
-    NdisFreeSpinLock(&(switchContext->pidHashLock));
     OvsFreeMemoryWithTag(switchContext->ovsPortNameHashArray,
                          OVS_SWITCH_POOL_TAG);
     switchContext->ovsPortNameHashArray = NULL;
@@ -441,9 +438,6 @@ OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
     OvsFreeMemoryWithTag(switchContext->portNoHashArray,
                          OVS_SWITCH_POOL_TAG);
     switchContext->portNoHashArray = NULL;
-    OvsFreeMemoryWithTag(switchContext->pidHashArray,
-                         OVS_SWITCH_POOL_TAG);
-    switchContext->pidHashArray = NULL;
     OvsFreeMemory(switchContext->tunnelVportsArray);
     switchContext->tunnelVportsArray = NULL;
     OvsDeleteFlowTable(&switchContext->datapath);
@@ -490,16 +484,38 @@ OvsAcquireSwitchContext(VOID)
  *  Datapath registry: maps a datapath number (dpNo) to its switch context.
  * --------------------------------------------------------------------------
  */
-VOID
+NDIS_STATUS
 OvsInitDatapathRegistry(VOID)
 {
+    UINT32 i;
+
     NdisAllocateSpinLock(&gOvsDatapathLock);
     RtlZeroMemory(gOvsDatapaths, sizeof gOvsDatapaths);
+
+    /* The upcall pid hash is driver-global (see the declaration comment). */
+    gOvsPidHashArray = (PLIST_ENTRY)OvsAllocateMemoryWithTag(
+        sizeof(LIST_ENTRY) * OVS_MAX_PID_ARRAY_SIZE, OVS_SWITCH_POOL_TAG);
+    if (gOvsPidHashArray == NULL) {
+        /* gOvsDatapathLock is owned by OvsCleanupDatapathRegistry, which runs on
+         * the failed-OvsInit cleanup path; do not free it here (double-free). */
+        return NDIS_STATUS_RESOURCES;
+    }
+    for (i = 0; i < OVS_MAX_PID_ARRAY_SIZE; i++) {
+        InitializeListHead(&gOvsPidHashArray[i]);
+    }
+    NdisAllocateSpinLock(&gOvsPidHashLock);
+
+    return NDIS_STATUS_SUCCESS;
 }
 
 VOID
 OvsCleanupDatapathRegistry(VOID)
 {
+    if (gOvsPidHashArray != NULL) {
+        NdisFreeSpinLock(&gOvsPidHashLock);
+        OvsFreeMemoryWithTag(gOvsPidHashArray, OVS_SWITCH_POOL_TAG);
+        gOvsPidHashArray = NULL;
+    }
     NdisFreeSpinLock(&gOvsDatapathLock);
 }
 
@@ -539,7 +555,20 @@ OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext)
         }
     }
     if (gOvsSwitchContext == switchContext) {
+        /*
+         * The default datapath is detaching: promote the next live datapath so
+         * 'gOvsSwitchContext' never dangles while any datapath remains (the
+         * dp_ifindex-less request/packet paths anchor on it). The detaching slot
+         * was cleared above, so the scan never re-selects it. NULL only when no
+         * datapath is left. The pid hash is global, so promotion is safe.
+         */
         gOvsSwitchContext = NULL;
+        for (i = 0; i < OVS_MAX_DATAPATHS; i++) {
+            if (gOvsDatapaths[i] != NULL) {
+                gOvsSwitchContext = gOvsDatapaths[i];
+                break;
+            }
+        }
     }
     NdisReleaseSpinLock(&gOvsDatapathLock);
 

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -643,6 +643,26 @@ OvsAcquireDatapathByNumber(UINT32 dpNo)
     return switchContext;
 }
 
+POVS_SWITCH_CONTEXT
+OvsAcquireNextDatapath(UINT32 startSlot, UINT32 *nextSlot)
+{
+    POVS_SWITCH_CONTEXT switchContext = NULL;
+    UINT32 i;
+
+    NdisAcquireSpinLock(&gOvsDatapathLock);
+    for (i = startSlot; i < OVS_MAX_DATAPATHS; i++) {
+        if (gOvsDatapaths[i] != NULL) {
+            switchContext = gOvsDatapaths[i];
+            InterlockedIncrement(&switchContext->refCount);
+            *nextSlot = i + 1;
+            break;
+        }
+    }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
+
+    return switchContext;
+}
+
 /*
  * --------------------------------------------------------------------------
  *  This function activates the switch by initializing it with all the runtime

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -207,40 +207,6 @@ OvsCreateSwitch(NDIS_HANDLE ndisFilterHandle,
         goto create_switch_done;
     }
 
-    status = OvsInitConntrack(switchContext);
-    if (status != STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        OVS_LOG_ERROR("Exit: Failed to initialize Connection tracking");
-        goto create_switch_done;
-    }
-
-    status = OvsInitCtRelated(switchContext);
-    if (status != STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        OVS_LOG_ERROR("Exit: Failed to initialize Connection tracking");
-    }
-
-    status = OvsInitIpFragment(switchContext);
-    if (status != STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        OVS_LOG_ERROR("Exit: Failed to initialize Ip Fragment");
-        goto create_switch_done;
-    }
-
-    status = OvsInitIp6Fragment(switchContext);
-    if (status != STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        OVS_LOG_ERROR("Exit: Failed to initialize Ip6 Fragment");
-        goto create_switch_done;
-    }
-    
-    status = OvsInitMeter(switchContext);
-    if (status != STATUS_SUCCESS) {
-        OvsUninitSwitchContext(switchContext);
-        OVS_LOG_ERROR("Exit: Failed to initialize Ovs meter.");
-        goto create_switch_done;
-    }
-
     *switchContextOut = switchContext;
 
 create_switch_done:
@@ -269,10 +235,6 @@ OvsExtDetach(NDIS_HANDLE filterModuleContext)
         NdisMSleep(1000);
     }
     OvsDeleteSwitch(switchContext);
-    OvsCleanupConntrack();
-    OvsCleanupCtRelated();
-    OvsCleanupIpFragment();
-    OvsCleanupIp6Fragment();
 
     /* This completes the cleanup, and a new attach can be handled now. */
 

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -46,10 +46,15 @@ extern NDIS_HANDLE gOvsExtDriverObject;
 extern PDEVICE_OBJECT gOvsDeviceObject;
 
 /*
- * Reference count used to prevent premature deallocation of the global switch
- * context structure, gOvsSwitchContext.
+ * Datapath registry: each attached Hyper-V switch is a datapath, addressed by
+ * its datapath number (dpNo), which is the slot index in 'gOvsDatapaths'.
+ * 'gOvsDatapathLock' serializes registration, lookup and the reference taken
+ * during lookup. 'gOvsSwitchContext' points at the default (first) datapath,
+ * which still backs the paths that have no dp_ifindex of their own.
  */
-volatile LONG      gOvsSwitchContextRefCount = 0;
+#define OVS_MAX_DATAPATHS 16
+POVS_SWITCH_CONTEXT gOvsDatapaths[OVS_MAX_DATAPATHS];
+NDIS_SPIN_LOCK     gOvsDatapathLock;
 
 static NDIS_STATUS OvsCreateSwitch(NDIS_HANDLE ndisFilterHandle,
                                    POVS_SWITCH_CONTEXT *switchContextOut);
@@ -92,11 +97,14 @@ OvsExtAttach(NDIS_HANDLE ndisFilterHandle,
         goto cleanup;
     }
 
+    NdisAcquireSpinLock(&gOvsDatapathLock);
     if (gOvsSwitchContext) {
+        NdisReleaseSpinLock(&gOvsDatapathLock);
         OVS_LOG_TRACE("Exit: Failed to create OVS Switch, only one datapath is"
                       "supported, %p.", gOvsSwitchContext);
         goto cleanup;
     }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
 
     if (InterlockedCompareExchange(&gOvsInAttach, 1, 0)) {
         /* Just fail the request. */
@@ -465,7 +473,7 @@ OvsInitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
     NdisAllocateSpinLock(&(switchContext->pidHashLock));
     switchContext->isActivated = FALSE;
     switchContext->isActivateFailed = FALSE;
-    switchContext->dpNo = OVS_DP_NUMBER;
+    switchContext->refCount = 1;
     ovsTimeIncrementPerTick = KeQueryTimeIncrement() / 10000;
 
     OVS_LOG_TRACE("Exit: Succesfully initialized switchContext: %p",
@@ -520,45 +528,33 @@ OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 {
-    LONG ref = 0;
-    LONG newRef = 0;
-    LONG icxRef = 0;
+    if (switchContext == NULL) {
+        return;
+    }
 
-    do {
-        ref = InterlockedAdd(&gOvsSwitchContextRefCount, 0);
-        newRef = (0 == ref) ? 0 : ref - 1;
-        icxRef = InterlockedCompareExchange(&gOvsSwitchContextRefCount,
-                                            newRef,
-                                            ref);
-    } while (icxRef != ref);
-
-    if (ref == 1) {
+    if (InterlockedDecrement(&switchContext->refCount) == 0) {
         OvsDeleteSwitchContext(switchContext);
-        gOvsSwitchContext = NULL;
     }
 }
 
-BOOLEAN
+/*
+ *  Returns the default datapath's switch context with a reference held (release
+ *  it with OvsReleaseSwitchContext), or NULL if no datapath is registered. Used
+ *  by request paths that carry no dp_ifindex of their own.
+ */
+POVS_SWITCH_CONTEXT
 OvsAcquireSwitchContext(VOID)
 {
-    LONG ref = 0;
-    LONG newRef = 0;
-    LONG icxRef = 0;
-    BOOLEAN ret = FALSE;
+    POVS_SWITCH_CONTEXT switchContext;
 
-    do {
-        ref = InterlockedAdd(&gOvsSwitchContextRefCount, 0);
-        newRef = (0 == ref) ? 0 : ref + 1;
-        icxRef = InterlockedCompareExchange(&gOvsSwitchContextRefCount,
-                                            newRef,
-                                            ref);
-    } while (icxRef != ref);
-
-    if (ref != 0) {
-        ret = TRUE;
+    NdisAcquireSpinLock(&gOvsDatapathLock);
+    switchContext = gOvsSwitchContext;
+    if (switchContext != NULL) {
+        InterlockedIncrement(&switchContext->refCount);
     }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
 
-    return ret;
+    return switchContext;
 }
 
 /*
@@ -567,25 +563,64 @@ OvsAcquireSwitchContext(VOID)
  * --------------------------------------------------------------------------
  */
 VOID
+OvsInitDatapathRegistry(VOID)
+{
+    NdisAllocateSpinLock(&gOvsDatapathLock);
+    RtlZeroMemory(gOvsDatapaths, sizeof gOvsDatapaths);
+}
+
+VOID
+OvsCleanupDatapathRegistry(VOID)
+{
+    NdisFreeSpinLock(&gOvsDatapathLock);
+}
+
+VOID
 OvsRegisterDatapath(POVS_SWITCH_CONTEXT switchContext)
 {
-    ASSERT(gOvsSwitchContext == NULL);
+    UINT32 i;
 
-    gOvsSwitchContextRefCount = 1;
-    gOvsSwitchContext = switchContext;
-    KeMemoryBarrier();
+    NdisAcquireSpinLock(&gOvsDatapathLock);
+    for (i = 0; i < OVS_MAX_DATAPATHS; i++) {
+        if (gOvsDatapaths[i] == NULL) {
+            gOvsDatapaths[i] = switchContext;
+            switchContext->dpNo = i;
+            break;
+        }
+    }
+    if (i == OVS_MAX_DATAPATHS) {
+        OVS_LOG_ERROR("Datapath registry full, cannot register %p",
+                      switchContext);
+        ASSERT(FALSE);
+    } else if (gOvsSwitchContext == NULL) {
+        gOvsSwitchContext = switchContext;
+    }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
 }
 
 VOID
 OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext)
 {
+    UINT32 i;
+
+    NdisAcquireSpinLock(&gOvsDatapathLock);
+    for (i = 0; i < OVS_MAX_DATAPATHS; i++) {
+        if (gOvsDatapaths[i] == switchContext) {
+            gOvsDatapaths[i] = NULL;
+            break;
+        }
+    }
+    if (gOvsSwitchContext == switchContext) {
+        gOvsSwitchContext = NULL;
+    }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
+
     /*
-     * The context's storage is released by OvsReleaseSwitchContext when its
-     * last reference drops, so removing it from the registry needs no separate
-     * unlink and must not touch gOvsSwitchContextRefCount (doing so would
-     * double-release the context).
+     * Removing the context from the registry stops new lookups from finding it.
+     * The owning reference is dropped by the OvsUninitSwitchContext that follows
+     * in OvsDeleteSwitch; in-flight lookups that already hold a reference keep
+     * the context alive until they release it.
      */
-    UNREFERENCED_PARAMETER(switchContext);
 }
 
 /*
@@ -596,20 +631,16 @@ OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext)
 POVS_SWITCH_CONTEXT
 OvsAcquireDatapathByNumber(UINT32 dpNo)
 {
-    POVS_SWITCH_CONTEXT switchContext;
+    POVS_SWITCH_CONTEXT switchContext = NULL;
 
-    if (!OvsAcquireSwitchContext()) {
-        return NULL;
+    NdisAcquireSpinLock(&gOvsDatapathLock);
+    if (dpNo < OVS_MAX_DATAPATHS && gOvsDatapaths[dpNo] != NULL) {
+        switchContext = gOvsDatapaths[dpNo];
+        InterlockedIncrement(&switchContext->refCount);
     }
+    NdisReleaseSpinLock(&gOvsDatapathLock);
 
-    /* The held reference keeps the context and gOvsSwitchContext alive. */
-    switchContext = gOvsSwitchContext;
-    if (switchContext != NULL && switchContext->dpNo == dpNo) {
-        return switchContext;
-    }
-
-    OvsReleaseSwitchContext(switchContext);
-    return NULL;
+    return switchContext;
 }
 
 /*

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -264,4 +264,13 @@ OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext);
 POVS_SWITCH_CONTEXT
 OvsAcquireDatapathByNumber(UINT32 dpNo);
 
+/*
+ * Returns the first registered datapath at or after registry slot 'startSlot'
+ * with a reference held (release it with OvsReleaseSwitchContext), or NULL if
+ * none. On success '*nextSlot' is set to the slot after the one returned, so a
+ * dump can resume the scan from there.
+ */
+POVS_SWITCH_CONTEXT
+OvsAcquireNextDatapath(UINT32 startSlot, UINT32 *nextSlot);
+
 #endif /* __SWITCH_H_ */

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -171,8 +171,6 @@ typedef struct _OVS_SWITCH_CONTEXT
     PLIST_ENTRY             portNoHashArray;        // based on ovs port number
     PLIST_ENTRY             tunnelVportsArray;      // based on ovs dst port number
     PLIST_ENTRY             ovsPortNameHashArray;   // based on ovsName
-    PLIST_ENTRY             pidHashArray;           // based on packet pids
-    NDIS_SPIN_LOCK          pidHashLock;            // Lock for pidHash table
 
     UINT32                  numPhysicalNics;        // the number of physical
                                                     // external NICs.
@@ -249,7 +247,7 @@ VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext);
 
 /* Datapath registry: maps a datapath number (dpNo) to its switch context. */
-VOID
+NDIS_STATUS
 OvsInitDatapathRegistry(VOID);
 
 VOID

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -32,6 +32,10 @@
 
 #define OVS_INTERNAL_VPORT_DEFAULT_INDEX 0
 
+/* Holds a Hyper-V switch GUID string "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+ * (38 chars + NUL); sized with headroom against an unexpectedly longer name. */
+#define OVS_DP_GUID_NAME_LEN     64
+
 //Tunnel port indicies
 #define RESERVED_START_INDEX1    1
 #define OVS_TUNNEL_INDEX_START RESERVED_START_INDEX1
@@ -99,6 +103,10 @@ typedef struct _OVS_SWITCH_CONTEXT
      * drops to zero. The owning reference is taken at creation and released on
      * detach. */
     volatile LONG           refCount;
+
+    /* The Hyper-V switch GUID, captured at activation, used as the datapath's
+     * canonical name. Empty until activation completes or if the query failed. */
+    CHAR                    dpGuidName[OVS_DP_GUID_NAME_LEN];
 
     /*
      * 'virtualExternalVport' represents default external interface. This is

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -230,4 +230,14 @@ OvsAcquireSwitchContext(VOID);
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext);
 
+/* Datapath registry: maps a datapath number (dpNo) to its switch context. */
+VOID
+OvsRegisterDatapath(POVS_SWITCH_CONTEXT switchContext);
+
+VOID
+OvsUnregisterDatapath(POVS_SWITCH_CONTEXT switchContext);
+
+POVS_SWITCH_CONTEXT
+OvsAcquireDatapathByNumber(UINT32 dpNo);
+
 #endif /* __SWITCH_H_ */

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -95,6 +95,11 @@ typedef struct _OVS_SWITCH_CONTEXT
 
     UINT32                  dpNo;
 
+    /* Outstanding references to this context; the context is freed when this
+     * drops to zero. The owning reference is taken at creation and released on
+     * detach. */
+    volatile LONG           refCount;
+
     /*
      * 'virtualExternalVport' represents default external interface. This is
      * a virtual interface. The friendly name of such an interface has
@@ -224,13 +229,24 @@ OvsReleaseDatapath(OVS_DATAPATH *datapath,
     NdisReleaseRWLock(datapath->lock, lockState);
 }
 
-BOOLEAN
+POVS_SWITCH_CONTEXT
 OvsAcquireSwitchContext(VOID);
 
+/*
+ * Must run at PASSIVE_LEVEL: when the last reference drops, the context is
+ * freed, which releases NDIS RW and spin locks that require PASSIVE_LEVEL.
+ */
+_IRQL_requires_(PASSIVE_LEVEL)
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext);
 
 /* Datapath registry: maps a datapath number (dpNo) to its switch context. */
+VOID
+OvsInitDatapathRegistry(VOID);
+
+VOID
+OvsCleanupDatapathRegistry(VOID);
+
 VOID
 OvsRegisterDatapath(POVS_SWITCH_CONTEXT switchContext);
 

--- a/datapath-windows/ovsext/Tunnel.c
+++ b/datapath-windows/ovsext/Tunnel.c
@@ -309,7 +309,7 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
             datapath->misses++;
             elem = OvsCreateQueueNlPacket(NULL, 0, OVS_PACKET_CMD_MISS,
                                           vport, &key, NULL, pNbl, curNb,
-                                          TRUE, &layers);
+                                          TRUE, &layers, gOvsSwitchContext->dpNo);
             if (elem) {
                 /* Complete the packet since it was copied to user buffer. */
                 InsertTailList(&missedPackets, &elem->link);

--- a/datapath-windows/ovsext/Tunnel.c
+++ b/datapath-windows/ovsext/Tunnel.c
@@ -215,6 +215,15 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
     OvsCompletionList completionList;
     KIRQL irql;
     ULONG SendFlags = NDIS_SEND_FLAGS_SWITCH_DESTINATION_GROUP;
+    /*
+     * VXLAN decap runs from a host-global WFP datagram callout that has no
+     * Hyper-V switch association, so tunnel termination is bound to the default
+     * datapath (gOvsSwitchContext): the tunnel-vport lookup, flow table and the
+     * miss upcall's dp_ifindex all use it. Overlay traffic across multiple
+     * datapaths is out of scope for the L2-only multi-datapath model -- it would
+     * need a cross-datapath tunnel-vport registry keyed by the outer tunnel
+     * identity (e.g. VNI), since the callout can only see the outer key.
+     */
     OVS_DATAPATH *datapath = &gOvsSwitchContext->datapath;
 
     ASSERT(gOvsSwitchContext);

--- a/datapath-windows/ovsext/TunnelFilter.c
+++ b/datapath-windows/ovsext/TunnelFilter.c
@@ -804,9 +804,8 @@ OvsUnsubscribeTunnelInitBfeStateChanges()
  * to be called whenever the state of the filter engine changes.
  *
  * Initialize OVS tunnel filter call hierarchy:
- * <OvsExtAttach>
- *     <OvsCreateSwitch>
- *         <OvsInitTunnelFilter>
+ * <DriverEntry>
+ *     <OvsInitTunnelFilter>
  *             <OvsSubscribeTunnelInitBfeStateChanges>
  *                 --> registers OvsTunnelInitBfeCallback callback
  *                     <OvsTunnelInitBfeCallback>
@@ -859,9 +858,8 @@ OvsInitTunnelFilter(PDRIVER_OBJECT driverObject, PVOID deviceObject)
  * OvsTunnelInitBfeCallback callback from BFE.
  *
  * Uninitialize OVS tunnel filter call hierarchy:
- * <OvsExtDetach>
- *     <OvsDeleteSwitch>
- *         <OvsUninitTunnelFilter>
+ * <OvsExtUnload>
+ *     <OvsUninitTunnelFilter>
  *             <OvsTunnelFilterUninitialize>
  *                 <OvsTunnelFilterStopThreads>
  *                 <OvsTunnelUnregisterCallouts>

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -344,7 +344,7 @@ OvsNlExecuteCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     _MapNlAttrToOvsPktExec(nlMsgHdr, nlAttrs, keyAttrs, &execute);
 
-    status = OvsExecuteDpIoctl(&execute);
+    status = OvsExecuteDpIoctl(&execute, usrParamsCtx->switchContext);
 
     /* Default reply that we want to send */
     if (status == STATUS_SUCCESS) {
@@ -418,7 +418,7 @@ _MapNlAttrToOvsPktExec(PNL_MSG_HDR nlMsgHdr, PNL_ATTR *nlAttrs,
 }
 
 NTSTATUS
-OvsExecuteDpIoctl(OvsPacketExecute *execute)
+OvsExecuteDpIoctl(OvsPacketExecute *execute, POVS_SWITCH_CONTEXT switchContext)
 {
     NTSTATUS                    status = STATUS_SUCCESS;
     NTSTATUS                    ndisStatus = STATUS_SUCCESS;
@@ -446,7 +446,7 @@ OvsExecuteDpIoctl(OvsPacketExecute *execute)
      * Allocate the NBL, copy the data from the userspace buffer. Allocate
      * also, the forwarding context for the packet.
      */
-    pNbl = OvsAllocateNBLFromBuffer(gOvsSwitchContext, execute->packetBuf,
+    pNbl = OvsAllocateNBLFromBuffer(switchContext, execute->packetBuf,
                                     execute->packetLen);
     if (pNbl == NULL) {
         status = STATUS_NO_MEMORY;
@@ -496,8 +496,8 @@ OvsExecuteDpIoctl(OvsPacketExecute *execute)
     ctx->mru = execute->mru;
 
     if (ndisStatus == NDIS_STATUS_SUCCESS) {
-        NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, 0);
-        vport = OvsFindVportByPortNo(gOvsSwitchContext, execute->inPort);
+        NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, 0);
+        vport = OvsFindVportByPortNo(switchContext, execute->inPort);
         if (vport) {
             fwdDetail->SourcePortId = vport->portId;
             fwdDetail->SourceNicIndex = vport->nicIndex;
@@ -505,14 +505,14 @@ OvsExecuteDpIoctl(OvsPacketExecute *execute)
             fwdDetail->SourcePortId = NDIS_SWITCH_DEFAULT_PORT_ID;
             fwdDetail->SourceNicIndex = 0;
         }
-        ndisStatus = OvsActionsExecute(gOvsSwitchContext, NULL, pNbl,
+        ndisStatus = OvsActionsExecute(switchContext, NULL, pNbl,
                                        vport ? vport->portNo :
                                                OVS_DPPORT_NUMBER_INVALID,
                                        NDIS_SEND_FLAGS_SWITCH_DESTINATION_GROUP,
                                        &key, NULL, &layers, actions,
                                        execute->actionsLen);
         pNbl = NULL;
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
     }
     if (ndisStatus != NDIS_STATUS_SUCCESS) {
         if (ndisStatus == NDIS_STATUS_NOT_SUPPORTED) {
@@ -524,7 +524,7 @@ OvsExecuteDpIoctl(OvsPacketExecute *execute)
 
 dropit:
     if (pNbl) {
-        OvsCompleteNBL(gOvsSwitchContext, pNbl, TRUE);
+        OvsCompleteNBL(switchContext, pNbl, TRUE);
     }
 exit:
     return status;

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -44,6 +44,8 @@
 POVS_PACKET_QUEUE_ELEM OvsGetNextPacket(POVS_OPEN_INSTANCE instance);
 extern PNDIS_SPIN_LOCK gOvsCtrlLock;
 extern POVS_SWITCH_CONTEXT gOvsSwitchContext;
+extern PLIST_ENTRY gOvsPidHashArray;
+extern NDIS_SPIN_LOCK gOvsPidHashLock;
 OVS_USER_STATS ovsUserStats;
 
 static VOID _MapNlAttrToOvsPktExec(PNL_MSG_HDR nlMsgHdr, PNL_ATTR *nlAttrs,
@@ -56,22 +58,22 @@ extern UINT32 nlFlowTunnelKeyPolicyLen;
 DRIVER_CANCEL OvsCancelIrpDatapath;
 
 _IRQL_raises_(DISPATCH_LEVEL)
-_IRQL_saves_global_(OldIrql, gOvsSwitchContext->pidHashLock)
-_Acquires_lock_(gOvsSwitchContext->pidHashLock)
+_IRQL_saves_global_(OldIrql, gOvsPidHashLock)
+_Acquires_lock_(gOvsPidHashLock)
 static __inline VOID
 OvsAcquirePidHashLock()
 {
-    NdisAcquireSpinLock(&(gOvsSwitchContext->pidHashLock));
+    NdisAcquireSpinLock(&gOvsPidHashLock);
 }
 
 _IRQL_requires_(DISPATCH_LEVEL)
-_IRQL_restores_global_(OldIrql, gOvsSwitchContext->pidHashLock)
-_Requires_lock_held_(gOvsSwitchContext->pidHashLock)
-_Releases_lock_(gOvsSwitchContext->pidHashLock)
+_IRQL_restores_global_(OldIrql, gOvsPidHashLock)
+_Requires_lock_held_(gOvsPidHashLock)
+_Releases_lock_(gOvsPidHashLock)
 static __inline VOID
 OvsReleasePidHashLock()
 {
-    NdisReleaseSpinLock(&(gOvsSwitchContext->pidHashLock));
+    NdisReleaseSpinLock(&gOvsPidHashLock);
 }
 
 
@@ -154,13 +156,10 @@ OvsCleanupPacketQueue(POVS_OPEN_INSTANCE instance)
         OvsFreeMemoryWithTag(queue, OVS_USER_POOL_TAG);
     }
 
-    /* Verify if gOvsSwitchContext exists. */
-    if (gOvsSwitchContext) {
-        /* Remove the instance from pidHashArray */
-        OvsAcquirePidHashLock();
-        OvsDelPidInstance(gOvsSwitchContext, instance->pid);
-        OvsReleasePidHashLock();
-    }
+    /* Remove the instance from the (driver-global) pid hash. */
+    OvsAcquirePidHashLock();
+    OvsDelPidInstance(instance->pid);
+    OvsReleasePidHashLock();
 }
 
 NTSTATUS
@@ -192,8 +191,8 @@ OvsSubscribeDpIoctl(PVOID instanceP,
         NdisReleaseSpinLock(&queue->queueLock);
 
         OvsAcquirePidHashLock();
-        /* Insert the instance to pidHashArray */
-        OvsAddPidInstance(gOvsSwitchContext, pid, instance);
+        /* Insert the instance into the (driver-global) pid hash. */
+        OvsAddPidInstance(pid, instance);
         OvsReleasePidHashLock();
 
     } else {
@@ -657,7 +656,7 @@ OvsGetQueue(UINT32 pid)
     POVS_OPEN_INSTANCE instance;
     POVS_USER_PACKET_QUEUE ret = NULL;
 
-    instance = OvsGetPidInstance(gOvsSwitchContext, pid);
+    instance = OvsGetPidInstance(pid);
 
     if (instance) {
         ret = instance->packetQueue;
@@ -673,13 +672,13 @@ OvsGetQueue(UINT32 pid)
  * ---------------------------------------------------------------------------
  */
 POVS_OPEN_INSTANCE
-OvsGetPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid)
+OvsGetPidInstance(UINT32 pid)
 {
     POVS_OPEN_INSTANCE instance;
     PLIST_ENTRY head, link;
     UINT32 hash = OvsJhashBytes((const VOID *)&pid, sizeof(pid),
                                 OVS_HASH_BASIS);
-    head = &(switchContext->pidHashArray[hash & OVS_PID_MASK]);
+    head = &(gOvsPidHashArray[hash & OVS_PID_MASK]);
     LIST_FORALL(head, link) {
         instance = CONTAINING_RECORD(link, OVS_OPEN_INSTANCE, pidLink);
         if (instance->pid == pid) {
@@ -696,13 +695,12 @@ OvsGetPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid)
  * ---------------------------------------------------------------------------
  */
 VOID
-OvsAddPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid,
-                  POVS_OPEN_INSTANCE instance)
+OvsAddPidInstance(UINT32 pid, POVS_OPEN_INSTANCE instance)
 {
     PLIST_ENTRY head;
     UINT32 hash = OvsJhashBytes((const VOID *)&pid, sizeof(pid),
                                 OVS_HASH_BASIS);
-    head = &(switchContext->pidHashArray[hash & OVS_PID_MASK]);
+    head = &(gOvsPidHashArray[hash & OVS_PID_MASK]);
     InsertHeadList(head, &(instance->pidLink));
 }
 
@@ -713,9 +711,9 @@ OvsAddPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid,
  * ---------------------------------------------------------------------------
  */
 VOID
-OvsDelPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid)
+OvsDelPidInstance(UINT32 pid)
 {
-    POVS_OPEN_INSTANCE instance = OvsGetPidInstance(switchContext, pid);
+    POVS_OPEN_INSTANCE instance = OvsGetPidInstance(pid);
 
     if (instance) {
         RemoveEntryList(&(instance->pidLink));

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -834,7 +834,7 @@ OvsCreateAndAddPackets(PVOID userData,
     while (nb) {
         elem = OvsCreateQueueNlPacket(userData, userDataLen,
                                     cmd, vport, key, NULL, nbl, nb,
-                                    isRecv, hdrInfo);
+                                    isRecv, hdrInfo, switchContext->dpNo);
         if (elem) {
             InsertTailList(list, &elem->link);
             (*num)++;
@@ -1020,7 +1020,8 @@ OvsCreateQueueNlPacket(PVOID userData,
                        PNET_BUFFER_LIST nbl,
                        PNET_BUFFER nb,
                        BOOLEAN isRecv,
-                       POVS_PACKET_HDR_INFO hdrInfo)
+                       POVS_PACKET_HDR_INFO hdrInfo,
+                       UINT32 dpNo)
 {
 #define VLAN_TAG_SIZE 4
     UINT32 allocLen, dataLen, extraLen = 0;
@@ -1113,7 +1114,7 @@ OvsCreateQueueNlPacket(PVOID userData,
      */
     if (!NlFillOvsMsg(&nlBuf, OVS_WIN_NL_PACKET_FAMILY_ID, 0,
                       0, pid, (UINT8)cmd, OVS_PACKET_VERSION,
-                      gOvsSwitchContext->dpNo)) {
+                      dpNo)) {
         goto fail;
     }
 

--- a/datapath-windows/ovsext/User.h
+++ b/datapath-windows/ovsext/User.h
@@ -102,7 +102,8 @@ NTSTATUS OvsReadDpIoctl(PFILE_OBJECT fileObject,
                         PVOID outputBuffer,
                         UINT32 outputLength,
                         UINT32 *replyLen);
-NTSTATUS OvsExecuteDpIoctl(OvsPacketExecute *execute);
+NTSTATUS OvsExecuteDpIoctl(OvsPacketExecute *execute,
+                           POVS_SWITCH_CONTEXT switchContext);
 NTSTATUS OvsPurgeDpIoctl(PFILE_OBJECT fileObject);
 
 NTSTATUS OvsWaitDpIoctl(PIRP irp, PFILE_OBJECT fileObject);

--- a/datapath-windows/ovsext/User.h
+++ b/datapath-windows/ovsext/User.h
@@ -113,14 +113,13 @@ NTSTATUS OvsNlExecuteCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                                 UINT32 *replyLen);
 
 POVS_OPEN_INSTANCE
-OvsGetPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid);
+OvsGetPidInstance(UINT32 pid);
 
 VOID
-OvsAddPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid,
-                  POVS_OPEN_INSTANCE instance);
+OvsAddPidInstance(UINT32 pid, POVS_OPEN_INSTANCE instance);
 
 VOID
-OvsDelPidInstance(POVS_SWITCH_CONTEXT switchContext, UINT32 pid);
+OvsDelPidInstance(UINT32 pid);
 
 NTSTATUS OvsReadPacketCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                                  UINT32 *replyLen);

--- a/datapath-windows/ovsext/User.h
+++ b/datapath-windows/ovsext/User.h
@@ -79,7 +79,8 @@ POVS_PACKET_QUEUE_ELEM OvsCreateQueueNlPacket(PVOID userData,
                                               PNET_BUFFER_LIST nbl,
                                               PNET_BUFFER nb,
                                               BOOLEAN isRecv,
-                                              POVS_PACKET_HDR_INFO hdrInfo);
+                                              POVS_PACKET_HDR_INFO hdrInfo,
+                                              UINT32 dpNo);
 
 VOID OvsQueuePackets(PLIST_ENTRY packetList, UINT32 numElems);
 NTSTATUS OvsCreateAndAddPackets(PVOID userData,

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1637,7 +1637,7 @@ OvsGetExtInfoIoctl(POVS_VPORT_GET vportGet,
     NTSTATUS status = STATUS_SUCCESS;
     BOOLEAN doConvert = FALSE;
 
-    RtlZeroMemory(extInfo, sizeof (POVS_VPORT_EXT_INFO));
+    RtlZeroMemory(extInfo, sizeof (*extInfo));
     NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, 0);
     if (vportGet->portNo == 0) {
         vport = OvsFindVportByHvNameA(switchContext, vportGet->name);

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1958,6 +1958,7 @@ static NTSTATUS
 OvsGetVportDumpNext(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                     UINT32 *replyLen)
 {
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     POVS_MESSAGE msgIn;
     POVS_OPEN_INSTANCE instance =
         (POVS_OPEN_INSTANCE)usrParamsCtx->ovsInstance;
@@ -1987,10 +1988,17 @@ OvsGetVportDumpNext(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
      * it means we have an array of pids, instead of a single pid.
      * ATM we assume we have one pid only.
     */
-    NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    if (switchContext == NULL) {
+        /* The datapath was torn down between dump start and this read. */
+        *replyLen = 0;
+        FreeUserDumpState(instance);
+        return STATUS_SUCCESS;
+    }
 
-    if (gOvsSwitchContext->numHvVports > 0 ||
-            gOvsSwitchContext->numNonHvVports > 0) {
+    NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, 0);
+
+    if (switchContext->numHvVports > 0 ||
+            switchContext->numNonHvVports > 0) {
         /* inBucket: the bucket, used for lookup */
         UINT32 inBucket = instance->dumpState.index[0];
         /* inIndex: index within the given bucket, used for lookup */
@@ -2002,7 +2010,7 @@ OvsGetVportDumpNext(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
         for (i = inBucket; i < OVS_MAX_VPORT_ARRAY_SIZE; i++) {
             PLIST_ENTRY head, link;
-            head = &(gOvsSwitchContext->portNoHashArray[i]);
+            head = &(switchContext->portNoHashArray[i]);
             POVS_VPORT_ENTRY vport = NULL;
 
             outIndex = 0;
@@ -2020,7 +2028,7 @@ OvsGetVportDumpNext(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                     OvsCreateMsgFromVport(vport, msgIn,
                                           usrParamsCtx->outputBuffer,
                                           usrParamsCtx->outputLength,
-                                          gOvsSwitchContext->dpNo);
+                                          switchContext->dpNo);
                     ++outIndex;
                     break;
                 }
@@ -2046,7 +2054,7 @@ OvsGetVportDumpNext(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         instance->dumpState.index[1] = outIndex;
     }
 
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     /* if i < OVS_MAX_VPORT_ARRAY_SIZE => vport was found */
     if (i < OVS_MAX_VPORT_ARRAY_SIZE) {
@@ -2069,6 +2077,7 @@ static NTSTATUS
 OvsGetVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
             UINT32 *replyLen)
 {
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     NTSTATUS status = STATUS_SUCCESS;
     LOCK_STATE_EX lockState;
 
@@ -2103,7 +2112,7 @@ OvsGetVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     /* Output buffer has been validated while validating transact dev op. */
     ASSERT(msgOut != NULL && usrParamsCtx->outputLength >= sizeof *msgOut);
 
-    NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, 0);
     if (vportAttrs[OVS_VPORT_ATTR_NAME] != NULL) {
         portName = NlAttrGet(vportAttrs[OVS_VPORT_ATTR_NAME]);
         portNameLen = NlAttrGetSize(vportAttrs[OVS_VPORT_ATTR_NAME]);
@@ -2111,27 +2120,27 @@ OvsGetVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         /* the port name is expected to be null-terminated */
         ASSERT(portName[portNameLen - 1] == '\0');
 
-        vport = OvsFindVportByOvsName(gOvsSwitchContext, portName);
+        vport = OvsFindVportByOvsName(switchContext, portName);
     } else if (vportAttrs[OVS_VPORT_ATTR_PORT_NO] != NULL) {
         portNumber = NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_PORT_NO]);
 
-        vport = OvsFindVportByPortNo(gOvsSwitchContext, portNumber);
+        vport = OvsFindVportByPortNo(switchContext, portNumber);
     } else {
         nlError = NL_ERROR_INVAL;
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
         goto Cleanup;
     }
 
     if (!vport) {
         nlError = NL_ERROR_NODEV;
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
         goto Cleanup;
     }
 
     status = OvsCreateMsgFromVport(vport, msgIn, usrParamsCtx->outputBuffer,
                                    usrParamsCtx->outputLength,
-                                   gOvsSwitchContext->dpNo);
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+                                   switchContext->dpNo);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     *replyLen = msgOut->nlMsg.nlmsgLen;
 
@@ -2203,6 +2212,7 @@ NTSTATUS
 OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                       UINT32 *replyLen)
 {
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     NDIS_STATUS status = STATUS_SUCCESS;
     LOCK_STATE_EX lockState;
 
@@ -2248,9 +2258,9 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     /* we are expecting null terminated strings to be passed */
     ASSERT(portName[portNameLen - 1] == '\0');
 
-    NdisAcquireRWLockWrite(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    NdisAcquireRWLockWrite(switchContext->dispatchLock, &lockState, 0);
 
-    vport = OvsFindVportByOvsName(gOvsSwitchContext, portName);
+    vport = OvsFindVportByOvsName(switchContext, portName);
     if (vport) {
         nlError = NL_ERROR_EXIST;
         goto Cleanup;
@@ -2259,7 +2269,7 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     if (portType == OVS_VPORT_TYPE_NETDEV ||
         portType == OVS_VPORT_TYPE_INTERNAL) {
         /* External and internal ports can also be looked up like VIF ports. */
-        vport = OvsFindVportByHvNameA(gOvsSwitchContext, portName);
+        vport = OvsFindVportByHvNameA(switchContext, portName);
     } else {
         ASSERT(OvsIsTunnelVportType(portType));
 
@@ -2305,7 +2315,7 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
              * different tunneling types.
              */
             dupVport =
-                OvsFindTunnelVportByDstPortAndNWProto(gOvsSwitchContext,
+                OvsFindTunnelVportByDstPortAndNWProto(switchContext,
                                                       transportPortDest,
                                                       nwProto);
             if (dupVport) {
@@ -2356,7 +2366,7 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
          */
         vport->portNo = NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_PORT_NO]);
     } else {
-        vport->portNo = OvsComputeVportNo(gOvsSwitchContext);
+        vport->portNo = OvsComputeVportNo(switchContext);
         if (vport->portNo == OVS_DPPORT_NUMBER_INVALID) {
             nlError = NL_ERROR_NOMEM;
             goto Cleanup;
@@ -2379,19 +2389,19 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
      */
     vport->upcallPid = NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_UPCALL_PID]);
 
-    status = InitOvsVportCommon(gOvsSwitchContext, vport);
+    status = InitOvsVportCommon(switchContext, vport);
     ASSERT(status == STATUS_SUCCESS);
 
     status = OvsCreateMsgFromVport(vport, msgIn, usrParamsCtx->outputBuffer,
                                    usrParamsCtx->outputLength,
-                                   gOvsSwitchContext->dpNo);
+                                   switchContext->dpNo);
 
     *replyLen = msgOut->nlMsg.nlmsgLen;
     OVS_LOG_INFO("Created new vport, name: %s, type: %u", vport->ovsName,
                  vport->ovsType);
 
 Cleanup:
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     if ((nlError != NL_ERROR_SUCCESS) && (nlError != NL_ERROR_PENDING)) {
         POVS_MESSAGE_ERROR msgError = (POVS_MESSAGE_ERROR)
@@ -2433,6 +2443,7 @@ NTSTATUS
 OvsSetVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                       UINT32 *replyLen)
 {
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     NDIS_STATUS status = STATUS_SUCCESS;
     LOCK_STATE_EX lockState;
 
@@ -2469,7 +2480,7 @@ OvsSetVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     /* Output buffer has been validated while validating transact dev op. */
     ASSERT(msgOut != NULL && usrParamsCtx->outputLength >= sizeof *msgOut);
 
-    NdisAcquireRWLockWrite(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    NdisAcquireRWLockWrite(switchContext->dispatchLock, &lockState, 0);
     if (vportAttrs[OVS_VPORT_ATTR_NAME] != NULL) {
         PSTR portName = NlAttrGet(vportAttrs[OVS_VPORT_ATTR_NAME]);
 #ifdef DBG
@@ -2478,9 +2489,9 @@ OvsSetVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         /* the port name is expected to be null-terminated */
         ASSERT(portName[portNameLen - 1] == '\0');
 
-        vport = OvsFindVportByOvsName(gOvsSwitchContext, portName);
+        vport = OvsFindVportByOvsName(switchContext, portName);
     } else if (vportAttrs[OVS_VPORT_ATTR_PORT_NO] != NULL) {
-        vport = OvsFindVportByPortNo(gOvsSwitchContext,
+        vport = OvsFindVportByPortNo(switchContext,
                     NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_PORT_NO]));
     }
 
@@ -2515,12 +2526,12 @@ OvsSetVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     status = OvsCreateMsgFromVport(vport, msgIn, usrParamsCtx->outputBuffer,
                                    usrParamsCtx->outputLength,
-                                   gOvsSwitchContext->dpNo);
+                                   switchContext->dpNo);
 
     *replyLen = msgOut->nlMsg.nlmsgLen;
 
 Cleanup:
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     if (nlError != NL_ERROR_SUCCESS) {
         POVS_MESSAGE_ERROR msgError = (POVS_MESSAGE_ERROR)
@@ -2543,6 +2554,7 @@ NTSTATUS
 OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                          UINT32 *replyLen)
 {
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
     NDIS_STATUS status = STATUS_SUCCESS;
     LOCK_STATE_EX lockState;
 
@@ -2573,7 +2585,7 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     /* Output buffer has been validated while validating transact dev op. */
     ASSERT(msgOut != NULL && usrParamsCtx->outputLength >= sizeof *msgOut);
 
-    NdisAcquireRWLockWrite(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    NdisAcquireRWLockWrite(switchContext->dispatchLock, &lockState, 0);
     if (vportAttrs[OVS_VPORT_ATTR_NAME] != NULL) {
         portName = NlAttrGet(vportAttrs[OVS_VPORT_ATTR_NAME]);
         portNameLen = NlAttrGetSize(vportAttrs[OVS_VPORT_ATTR_NAME]);
@@ -2581,10 +2593,10 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         /* the port name is expected to be null-terminated */
         ASSERT(portName[portNameLen - 1] == '\0');
 
-        vport = OvsFindVportByOvsName(gOvsSwitchContext, portName);
+        vport = OvsFindVportByOvsName(switchContext, portName);
     }
     else if (vportAttrs[OVS_VPORT_ATTR_PORT_NO] != NULL) {
-        vport = OvsFindVportByPortNo(gOvsSwitchContext,
+        vport = OvsFindVportByPortNo(switchContext,
             NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_PORT_NO]));
     }
 
@@ -2595,7 +2607,7 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     status = OvsCreateMsgFromVport(vport, msgIn, usrParamsCtx->outputBuffer,
                                    usrParamsCtx->outputLength,
-                                   gOvsSwitchContext->dpNo);
+                                   switchContext->dpNo);
 
     *replyLen = msgOut->nlMsg.nlmsgLen;
 
@@ -2604,7 +2616,7 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
      * on the Hyper-V switch, it gets deallocated. Otherwise, it stays.
      */
     status = OvsRemoveAndDeleteVport(usrParamsCtx,
-                                     gOvsSwitchContext,
+                                     switchContext,
                                      vport,
                                      FALSE,
                                      TRUE);
@@ -2613,7 +2625,7 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     }
 
 Cleanup:
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     if ((nlError != NL_ERROR_SUCCESS) && (nlError != NL_ERROR_PENDING)) {
         POVS_MESSAGE_ERROR msgError = (POVS_MESSAGE_ERROR)

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -301,11 +301,13 @@ HvDeletePort(POVS_SWITCH_CONTEXT switchContext,
     if (vport) {
         OVS_VPORT_EVENT_ENTRY event;
 
+        RtlZeroMemory(&event, sizeof event);
         event.portNo = vport->portNo;
         event.ovsType = vport->ovsType;
         event.upcallPid = vport->upcallPid;
         RtlCopyMemory(&event.ovsName, &vport->ovsName, sizeof event.ovsName);
         event.type = OVS_EVENT_LINK_DOWN;
+        event.dpNo = switchContext->dpNo;
         OvsRemoveAndDeleteVport(NULL, switchContext, vport, TRUE, FALSE);
         OvsPostVportEvent(&event);
     } else {
@@ -558,11 +560,13 @@ HvUpdateNic(POVS_SWITCH_CONTEXT switchContext,
 
     if (nameChanged) {
         OVS_VPORT_EVENT_ENTRY evt;
+        RtlZeroMemory(&evt, sizeof evt);
         evt.portNo = vport->portNo;
         evt.ovsType = vport->ovsType;
         evt.upcallPid = vport->upcallPid;
         RtlCopyMemory(&evt.ovsName, &vport->ovsName, sizeof evt.ovsName);
         evt.type = OVS_EVENT_LINK_DOWN;
+        evt.dpNo = switchContext->dpNo;
         OvsRemoveAndDeleteVport(NULL, switchContext, vport, FALSE, TRUE);
         OvsPostVportEvent(&evt);
     }
@@ -623,11 +627,13 @@ HvDisconnectNic(POVS_SWITCH_CONTEXT switchContext,
         isInternalPort = TRUE;
     }
 
+    RtlZeroMemory(&event, sizeof event);
     event.portNo = vport->portNo;
     event.ovsType = vport->ovsType;
     event.upcallPid = vport->upcallPid;
     RtlCopyMemory(&event.ovsName, &vport->ovsName, sizeof event.ovsName);
     event.type = OVS_EVENT_LINK_DOWN;
+    event.dpNo = switchContext->dpNo;
     OvsPostVportEvent(&event);
 
     /*

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1252,7 +1252,7 @@ InitOvsVportCommon(POVS_SWITCH_CONTEXT switchContext,
                              sizeof(dstPort),
                              OVS_HASH_BASIS);
         InsertHeadList(
-            &gOvsSwitchContext->tunnelVportsArray[hash & OVS_VPORT_MASK],
+            &switchContext->tunnelVportsArray[hash & OVS_VPORT_MASK],
             &vport->tunnelVportLink);
         switchContext->numNonHvVports++;
         break;
@@ -1268,13 +1268,13 @@ InitOvsVportCommon(POVS_SWITCH_CONTEXT switchContext,
      * portNo is stored in 2 bytes only (max port number = MAXUINT16).
      */
     hash = OvsJhashWords(&vport->portNo, 1, OVS_HASH_BASIS);
-    InsertHeadList(&gOvsSwitchContext->portNoHashArray[hash & OVS_VPORT_MASK],
+    InsertHeadList(&switchContext->portNoHashArray[hash & OVS_VPORT_MASK],
                    &vport->portNoLink);
 
     hash = OvsJhashBytes(vport->ovsName, strlen(vport->ovsName) + 1,
                          OVS_HASH_BASIS);
     InsertHeadList(
-        &gOvsSwitchContext->ovsPortNameHashArray[hash & OVS_VPORT_MASK],
+        &switchContext->ovsPortNameHashArray[hash & OVS_VPORT_MASK],
         &vport->ovsNameLink);
 
     return STATUS_SUCCESS;

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -75,7 +75,8 @@ static VOID OvsCopyPortParamsFromVport(POVS_VPORT_ENTRY vport,
 static __inline VOID OvsWaitActivate(POVS_SWITCH_CONTEXT switchContext,
                                      ULONG sleepMicroSec);
 static NTSTATUS OvsGetExtInfoIoctl(POVS_VPORT_GET vportGet,
-                                   POVS_VPORT_EXT_INFO extInfo);
+                                   POVS_VPORT_EXT_INFO extInfo,
+                                   POVS_SWITCH_CONTEXT switchContext);
 static NTSTATUS CreateNetlinkMesgForNetdev(POVS_VPORT_EXT_INFO info,
                                            POVS_MESSAGE msgIn,
                                            PVOID outBuffer,
@@ -1622,7 +1623,8 @@ OvsConvertIfCountedStrToAnsiStr(PIF_COUNTED_STRING wStr,
  */
 NTSTATUS
 OvsGetExtInfoIoctl(POVS_VPORT_GET vportGet,
-                   POVS_VPORT_EXT_INFO extInfo)
+                   POVS_VPORT_EXT_INFO extInfo,
+                   POVS_SWITCH_CONTEXT switchContext)
 {
     POVS_VPORT_ENTRY vport;
     LOCK_STATE_EX lockState;
@@ -1630,20 +1632,20 @@ OvsGetExtInfoIoctl(POVS_VPORT_GET vportGet,
     BOOLEAN doConvert = FALSE;
 
     RtlZeroMemory(extInfo, sizeof (POVS_VPORT_EXT_INFO));
-    NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, 0);
+    NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, 0);
     if (vportGet->portNo == 0) {
-        vport = OvsFindVportByHvNameA(gOvsSwitchContext, vportGet->name);
+        vport = OvsFindVportByHvNameA(switchContext, vportGet->name);
         if (vport == NULL) {
             /* If the port is not a Hyper-V port and it has been added earlier,
              * we'll find it in 'ovsPortNameHashArray'. */
-            vport = OvsFindVportByOvsName(gOvsSwitchContext, vportGet->name);
+            vport = OvsFindVportByOvsName(switchContext, vportGet->name);
         }
     } else {
-        vport = OvsFindVportByPortNo(gOvsSwitchContext, vportGet->portNo);
+        vport = OvsFindVportByPortNo(switchContext, vportGet->portNo);
     }
     if (vport == NULL || (vport->ovsState != OVS_STATE_CONNECTED &&
                           vport->ovsState != OVS_STATE_NIC_CREATED)) {
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
         if (vportGet->portNo) {
             OVS_LOG_WARN("vport %u does not exist any more", vportGet->portNo);
         } else {
@@ -1684,7 +1686,7 @@ OvsGetExtInfoIoctl(POVS_VPORT_GET vportGet,
         extInfo->vmUUID[0] = 0;
         extInfo->vifUUID[0] = 0;
     }
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
     if (doConvert) {
         status = OvsConvertIfCountedStrToAnsiStr(&vport->portFriendlyName,
                                                  extInfo->name,
@@ -1734,6 +1736,8 @@ OvsGetNetdevCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     NL_ERROR nlError = NL_ERROR_SUCCESS;
     OVS_VPORT_GET vportGet;
     OVS_VPORT_EXT_INFO info;
+    POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
+    BOOLEAN releaseCtx = FALSE;
 
     static const NL_POLICY ovsNetdevPolicy[] = {
         [OVS_WIN_NETDEV_ATTR_NAME] = { .type = NL_A_STRING,
@@ -1758,11 +1762,26 @@ OvsGetNetdevCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         return STATUS_INVALID_PARAMETER;
     }
 
+    /*
+     * This command does not validate the dp_ifindex, so the resolved context
+     * may be NULL; fall back to the default datapath to match the historical
+     * unconditional use of the global switch context.
+     */
+    if (switchContext == NULL) {
+        switchContext = OvsAcquireSwitchContext();
+        releaseCtx = TRUE;
+        if (switchContext == NULL) {
+            nlError = NL_ERROR_NODEV;
+            goto cleanup;
+        }
+    }
+
     vportGet.portNo = 0;
+    vportGet.dpNo = switchContext->dpNo;
     RtlCopyMemory(&vportGet.name, NlAttrGet(netdevAttrs[OVS_VPORT_ATTR_NAME]),
                   NlAttrGetSize(netdevAttrs[OVS_VPORT_ATTR_NAME]));
 
-    status = OvsGetExtInfoIoctl(&vportGet, &info);
+    status = OvsGetExtInfoIoctl(&vportGet, &info, switchContext);
     if (status == STATUS_DEVICE_DOES_NOT_EXIST) {
         nlError = NL_ERROR_NODEV;
         goto cleanup;
@@ -1770,12 +1789,15 @@ OvsGetNetdevCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     status = CreateNetlinkMesgForNetdev(&info, msgIn,
                  usrParamsCtx->outputBuffer, usrParamsCtx->outputLength,
-                 gOvsSwitchContext->dpNo);
+                 switchContext->dpNo);
     if (status == STATUS_SUCCESS) {
         *replyLen = msgOut->nlMsg.nlmsgLen;
     }
 
 cleanup:
+    if (releaseCtx) {
+        OvsReleaseSwitchContext(switchContext);
+    }
     if (nlError != NL_ERROR_SUCCESS) {
         POVS_MESSAGE_ERROR msgError = (POVS_MESSAGE_ERROR)
             usrParamsCtx->outputBuffer;

--- a/datapath-windows/test-catlet/README.md
+++ b/datapath-windows/test-catlet/README.md
@@ -35,7 +35,7 @@ SFTP subsystem.
 - **`run-full-mgmt-dp-test.ps1`** — the main test. Exercises the management plane
   (db-init, schema upgrade, `--detach`, logs, `ovs-vsctl` db interaction,
   `ovs-appctl`) and the kernel datapath (`add-br datapath_type=windows`,
-  `ovs-dpctl show`, flow put/dump/del against `windows@ovs-system`).
+  `ovs-dpctl show`, flow put/dump/del against `system@ovs-system`).
 - **`test-vsctl.ps1`** — cross-version check: eryph's packaged `ovs-vsctl` against
   our `ovsdb-server`.
 - **`wait-ips.ps1` / `ping-ubuntu.ps1`** — nested-VM forwarding test: wait for

--- a/datapath-windows/test-catlet/README.md
+++ b/datapath-windows/test-catlet/README.md
@@ -34,7 +34,7 @@ SFTP subsystem.
 
 - **`run-full-mgmt-dp-test.ps1`** — the main test. Exercises the management plane
   (db-init, schema upgrade, `--detach`, logs, `ovs-vsctl` db interaction,
-  `ovs-appctl`) and the kernel datapath (`add-br datapath_type=windows`,
+  `ovs-appctl`) and the kernel datapath (`add-br datapath_type=system`,
   `ovs-dpctl show`, flow put/dump/del against `system@ovs-system`).
 - **`test-vsctl.ps1`** — cross-version check: eryph's packaged `ovs-vsctl` against
   our `ovsdb-server`.

--- a/datapath-windows/test-catlet/detach-promote-test.ps1
+++ b/datapath-windows/test-catlet/detach-promote-test.ps1
@@ -1,0 +1,90 @@
+# SAFE detach/promotion test (run INSIDE ovs-kerneldev, NEW DBO_OVSE.sys loaded).
+#
+# Proves: when the DEFAULT datapath (gOvsSwitchContext) detaches while another
+# datapath is live, the driver promotes the survivor (no BSOD) and the global
+# upcall pid-hash survives, so forwarding + flow-miss upcalls keep working.
+#
+# Topology trick: enable ovs-test2's ext FIRST so it becomes the default (dp0),
+# and host ub1/ub2 on eryph_overlay (dp1). Detaching ovs-test2 then exercises
+# the promotion path while ub1/ub2 (on the survivor) remain pingable.
+$ErrorActionPreference = 'Continue'
+$native='C:\ovs-test\native'; $run='C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl="$native\ovs-vsctl.exe"; $dpctl="$native\ovs-dpctl.exe"; $tool="$native\ovsdb-tool.exe"
+$ext='dbosoft Open vSwitch Extension'
+$OVERLAY = (Get-VMSwitch -Name eryph_overlay).Id.ToString().ToUpper()
+
+function DrvState { (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State }
+function PingVMs($idx) {
+    foreach ($vm in 'ub1','ub2') {
+        $ll = (Get-VMNetworkAdapter -VMName $vm -EA SilentlyContinue).IPAddresses | Where-Object { $_ -match '^fe80' } | Select-Object -First 1
+        if ($ll) { ping -6 -n 3 "$ll%$idx" | Out-Null; "$vm ($ll): exit=$LASTEXITCODE" }
+    }
+}
+
+"=== 1. clean slate: stop daemons, disable both exts ==="
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Disable-VMSwitchExtension -VMSwitchName ovs-test2 -Name $ext -EA Continue | Out-Null
+Disable-VMSwitchExtension -VMSwitchName eryph_overlay -Name $ext -EA Continue | Out-Null
+Start-Sleep 3
+"driver = $(DrvState)"
+
+"=== 2. enable ovs-test2 FIRST (-> default dp0) ==="
+Enable-VMSwitchExtension -VMSwitchName ovs-test2 -Name $ext -EA Continue | Out-Null
+Start-Sleep 3
+"=== 3. enable eryph_overlay (-> dp1, hosts ub1/ub2) ==="
+Enable-VMSwitchExtension -VMSwitchName eryph_overlay -Name $ext -EA Continue | Out-Null
+Start-Sleep 3
+"driver = $(DrvState)"
+"--- datapaths (expect ovs-test2 GUID + eryph_overlay GUID) ---"
+& $dpctl show 2>&1
+
+"=== 4. bring up OVS, br-int on eryph_overlay (the survivor) ==="
+Remove-Item "$run\conf.db","$run\*.log","$run\*.pid" -EA SilentlyContinue
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+& $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$OVERLAY
+Start-Sleep 3
+foreach ($p in 'ovs_ub1','ovs_ub2') {
+    & $vsctl --timeout=25 add-port br-int $p; Start-Sleep 1
+    if ((& $vsctl --timeout=10 get interface $p ofport) -match '-1') {
+        & $vsctl --timeout=25 del-port br-int $p; Start-Sleep 1; & $vsctl --timeout=25 add-port br-int $p; Start-Sleep 1
+    }
+}
+Enable-NetAdapter -Name br-int -EA Continue | Out-Null
+Start-Sleep 3
+$idx = (Get-NetAdapter -Name br-int -EA SilentlyContinue).ifIndex
+"=== 5. BASELINE forwarding (default=ovs-test2 anchor, traffic on eryph_overlay dp1) ==="
+PingVMs $idx
+
+"=== 6. DETACH THE DEFAULT: disable ovs-test2 ext (dp0) -> promotion ==="
+Disable-VMSwitchExtension -VMSwitchName ovs-test2 -Name $ext -EA Continue | Out-Null
+Start-Sleep 4
+"driver = $(DrvState)   (MUST be Running -> no BSOD)"
+"--- datapaths now (expect only eryph_overlay) ---"
+& $dpctl show 2>&1
+
+"=== 7. POST-PROMOTION: forwarding must continue + fresh upcall must work ==="
+& $dpctl del-flows "windows@$OVERLAY" 2>&1 | Out-Null   # force flow misses -> upcalls
+Start-Sleep 1
+PingVMs $idx
+"--- flows re-installed by upcalls (forwarding evidence) ---"
+& $dpctl dump-flows "windows@$OVERLAY" 2>&1 | Select-Object -First 4
+
+"=== 8. vswitchd RESTART after promotion (re-stamp pids on global hash) ==="
+Get-Process ovs-vswitchd -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep 2
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 4
+PingVMs $idx
+
+"=== cleanup: stop daemons, restore baseline (overlay ext on, test2 off) ==="
+& $vsctl --timeout=20 del-br br-int 2>&1 | Out-Null
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+"driver = $(DrvState)"
+"DETACH-TEST-DONE"

--- a/datapath-windows/test-catlet/detach-promote-test.ps1
+++ b/datapath-windows/test-catlet/detach-promote-test.ps1
@@ -70,11 +70,11 @@ Start-Sleep 4
 & $dpctl show 2>&1
 
 "=== 7. POST-PROMOTION: forwarding must continue + fresh upcall must work ==="
-& $dpctl del-flows "windows@$OVERLAY" 2>&1 | Out-Null   # force flow misses -> upcalls
+& $dpctl del-flows "${OVERLAY}@ovs-system" 2>&1 | Out-Null   # force flow misses -> upcalls
 Start-Sleep 1
 PingVMs $idx
 "--- flows re-installed by upcalls (forwarding evidence) ---"
-& $dpctl dump-flows "windows@$OVERLAY" 2>&1 | Select-Object -First 4
+& $dpctl dump-flows "${OVERLAY}@ovs-system" 2>&1 | Select-Object -First 4
 
 "=== 8. vswitchd RESTART after promotion (re-stamp pids on global hash) ==="
 Get-Process ovs-vswitchd -EA SilentlyContinue | Stop-Process -Force

--- a/datapath-windows/test-catlet/ms-dp.ps1
+++ b/datapath-windows/test-catlet/ms-dp.ps1
@@ -12,7 +12,7 @@
 #   ms-dp.ps1 info               switches + GUIDs + ext state + datapaths (copy the GUIDs from here)
 #   ms-dp.ps1 dpctl show         run ovs-dpctl with the env already set
 #   ms-dp.ps1 vsctl show         run ovs-vsctl  with the env already set
-#   ms-dp.ps1 dpctl dump-flows windows@<GUID>
+#   ms-dp.ps1 dpctl dump-flows <GUID>@ovs-system
 #   ms-dp.ps1 ping               ping ub1/ub2 link-local through br-int (switch 1)
 #   ms-dp.ps1 down               del bridges, stop daemons, disable the ovs-test2 ext
 #
@@ -144,7 +144,7 @@ Examples:
   ms-dp.ps1 info
   ms-dp.ps1 dpctl show
   ms-dp.ps1 vsctl show
-  ms-dp.ps1 dpctl dump-flows windows@<GUID-from-info>
+  ms-dp.ps1 dpctl dump-flows <GUID-from-info>@ovs-system
   ms-dp.ps1 vsctl -- add-br br3 -- set bridge br3 datapath_type=<GUID-from-info>
   ms-dp.ps1 ping
   ms-dp.ps1 down

--- a/datapath-windows/test-catlet/ms-dp.ps1
+++ b/datapath-windows/test-catlet/ms-dp.ps1
@@ -1,0 +1,156 @@
+# Multi-switch datapath test console, run INSIDE the ovs-kerneldev catlet.
+#
+# Wraps the OVS run-dir env + binary paths so you can fire ovs-vsctl / ovs-dpctl
+# commands by hand, and gives up/down/info/ping helpers for a two-switch
+# topology (a bridge per Hyper-V switch, each selected by datapath_type=<switch
+# GUID>).  The kernel names each datapath by its switch GUID in UPPERCASE and
+# datapath_type resolution is case-sensitive, so this script always uses the
+# uppercased Get-VMSwitch Id.
+#
+# USAGE (from the catlet, or: ssh ovs-kerneldev powershell -File C:\ovs-test\ms-dp.ps1 <action>)
+#   ms-dp.ps1 up                 enable both exts, start OVS, build br-int (sw1) + br-test2 (sw2)
+#   ms-dp.ps1 info               switches + GUIDs + ext state + datapaths (copy the GUIDs from here)
+#   ms-dp.ps1 dpctl show         run ovs-dpctl with the env already set
+#   ms-dp.ps1 vsctl show         run ovs-vsctl  with the env already set
+#   ms-dp.ps1 dpctl dump-flows windows@<GUID>
+#   ms-dp.ps1 ping               ping ub1/ub2 link-local through br-int (switch 1)
+#   ms-dp.ps1 down               del bridges, stop daemons, disable the ovs-test2 ext
+#
+# Any unknown first word is treated as help.  vsctl/dpctl/ofctl/appctl pass all
+# remaining arguments straight through.
+
+param(
+    [string]$Action = 'help',
+    [Parameter(ValueFromRemainingArguments = $true)] [string[]]$Rest
+)
+
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"
+$ofctl = "$native\ovs-ofctl.exe"; $appctl = "$native\ovs-appctl.exe"; $tool = "$native\ovsdb-tool.exe"
+$ext = 'dbosoft Open vSwitch Extension'
+
+# Switches to wire up (edit these two names if your switches differ).
+$SW1 = 'eryph_overlay'   # bridge br-int; ub1/ub2 live here
+$SW2 = 'ovs-test2'       # bridge br-test2
+
+function DpType($switchName) {
+    $s = Get-VMSwitch -Name $switchName -EA SilentlyContinue
+    if ($s) { return $s.Id.ToString().ToUpper() }
+    return $null
+}
+function EnableExt($switchName) {
+    Enable-VMSwitchExtension -VMSwitchName $switchName -Name $ext -EA Continue | Out-Null
+}
+function StartDaemons {
+    Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+    Start-Sleep -Milliseconds 700
+    Remove-Item "$run\conf.db","$run\*.log","$run\*.pid" -EA SilentlyContinue
+    & $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+    & "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+    Start-Sleep 1
+    & $vsctl --no-wait init
+    & "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+    Start-Sleep 2
+}
+function AddPort($br, $port) {
+    & $vsctl --timeout=25 add-port $br $port
+    Start-Sleep 1
+    if ((& $vsctl --timeout=10 get interface $port ofport) -match '-1') {
+        & $vsctl --timeout=25 del-port $br $port; Start-Sleep 1
+        & $vsctl --timeout=25 add-port $br $port; Start-Sleep 1
+    }
+}
+
+switch ($Action) {
+
+  'up' {
+    $dp1 = DpType $SW1; $dp2 = DpType $SW2
+    if (-not $dp1 -or -not $dp2) { "ERROR: could not resolve switch GUIDs ($SW1=$dp1, $SW2=$dp2)"; break }
+    "switch 1 '$SW1' datapath_type = $dp1"
+    "switch 2 '$SW2' datapath_type = $dp2"
+    EnableExt $SW1; EnableExt $SW2; Start-Sleep 2
+    StartDaemons
+    "=== br-int on $SW1 ==="
+    & $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$dp1
+    Start-Sleep 3
+    AddPort 'br-int' 'ovs_ub1'; AddPort 'br-int' 'ovs_ub2'
+    "=== br-test2 on $SW2 ==="
+    & $vsctl --timeout=25 add-br br-test2 -- set bridge br-test2 datapath_type=$dp2
+    Start-Sleep 3
+    Enable-NetAdapter -Name br-int -EA Continue
+    Enable-NetAdapter -Name br-test2 -EA Continue
+    Start-Sleep 2
+    "=== ovs-vsctl show ==="; & $vsctl show
+    "=== ovs-dpctl show ==="; & $dpctl show
+    "UP-DONE"
+  }
+
+  'down' {
+    & $vsctl --timeout=10 del-br br-test2 2>&1 | Out-Null
+    & $vsctl --timeout=10 del-br br-int 2>&1 | Out-Null
+    Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+    Start-Sleep 1
+    Disable-VMSwitchExtension -VMSwitchName $SW2 -Name $ext -EA Continue | Out-Null
+    "stopped daemons; deleted bridges; disabled '$SW2' ext (left '$SW1' ext as-is)"
+    "driver = " + (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+    "DOWN-DONE"
+  }
+
+  'info' {
+    "=== switches (use the UPPERCASE Id as datapath_type) ==="
+    Get-VMSwitch | Select-Object Name,@{n='datapath_type';e={$_.Id.ToString().ToUpper()}},SwitchType | Format-Table -Auto | Out-String
+    "=== extension state ==="
+    Get-VMSwitch | ForEach-Object { $s=$_; Get-VMSwitchExtension -VMSwitchName $s.Name | Where-Object Name -match 'Open vSwitch' | Select-Object @{n='Switch';e={$s.Name}},Enabled,Running } | Format-Table -Auto | Out-String
+    "=== VM NIC connections ==="
+    Get-VMNetworkAdapter -VMName ub1,ub2 -EA SilentlyContinue | Select-Object VMName,SwitchName,MacAddress | Format-Table -Auto | Out-String
+    "=== driver ==="; (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+    "=== ovs-dpctl show (one block per datapath; ports listed under each) ==="
+    & $dpctl show 2>&1
+  }
+
+  'ping' {
+    $idx = (Get-NetAdapter -Name br-int -EA SilentlyContinue).ifIndex
+    if (-not $idx) { "br-int adapter not found - run 'up' first"; break }
+    foreach ($vm in 'ub1','ub2') {
+      $ll = (Get-VMNetworkAdapter -VMName $vm -EA SilentlyContinue).IPAddresses | Where-Object { $_ -match '^fe80' } | Select-Object -First 1
+      if ($ll) { "=== ping $vm ($ll) via br-int ==="; ping -6 -n 4 "$ll%$idx"; "exit=$LASTEXITCODE" }
+      else { "no link-local found for $vm (is it running?)" }
+    }
+  }
+
+  'vsctl'  { & $vsctl  @Rest }
+  'dpctl'  { & $dpctl  @Rest }
+  'ofctl'  { & $ofctl  @Rest }
+  'appctl' { & $appctl @Rest }
+
+  default {
+    @"
+ms-dp.ps1 - multi-switch datapath test console (run inside ovs-kerneldev)
+
+  up            enable both exts, start OVS, build br-int ($SW1) + br-test2 ($SW2)
+  down          del bridges, stop daemons, disable the '$SW2' ext
+  info          switches + GUIDs (datapath_type values) + ext state + datapaths
+  ping          ping ub1/ub2 link-local through br-int (switch 1)
+  vsctl  <...>  run ovs-vsctl  with the OVS env already set
+  dpctl  <...>  run ovs-dpctl  with the OVS env already set
+  ofctl  <...>  run ovs-ofctl
+  appctl <...>  run ovs-appctl
+
+Examples:
+  ms-dp.ps1 up
+  ms-dp.ps1 info
+  ms-dp.ps1 dpctl show
+  ms-dp.ps1 vsctl show
+  ms-dp.ps1 dpctl dump-flows windows@<GUID-from-info>
+  ms-dp.ps1 vsctl -- add-br br3 -- set bridge br3 datapath_type=<GUID-from-info>
+  ms-dp.ps1 ping
+  ms-dp.ps1 down
+
+Note: datapath_type must be the switch Id in UPPERCASE (the kernel names each
+datapath by that GUID and resolution is case-sensitive). 'info' prints them.
+"@
+  }
+}

--- a/datapath-windows/test-catlet/run-full-mgmt-dp-test.ps1
+++ b/datapath-windows/test-catlet/run-full-mgmt-dp-test.ps1
@@ -65,11 +65,11 @@ Step "APPCTL: live daemon interaction"
 & $appctl --timeout=10 -t ovs-vswitchd vlog/list 2>&1 | Select-Object -First 2
 
 Step "DATAPATH (DRIVER): ovs-dpctl show + flow put/dump/del"
-& $dpctl show windows@ovs-system 2>&1
-& $dpctl add-flow windows@ovs-system "in_port(2),eth(),eth_type(0x0800),ipv4()" "1"; Write-Output "dp add-flow exit=$LASTEXITCODE"
-Write-Output "dump-flows (expect 1):"; & $dpctl dump-flows windows@ovs-system 2>&1
-& $dpctl del-flow windows@ovs-system "in_port(2),eth(),eth_type(0x0800),ipv4()"; Write-Output "dp del-flow exit=$LASTEXITCODE"
-Write-Output "dump-flows (expect empty):"; & $dpctl dump-flows windows@ovs-system 2>&1
+& $dpctl show system@ovs-system 2>&1
+& $dpctl add-flow system@ovs-system "in_port(2),eth(),eth_type(0x0800),ipv4()" "1"; Write-Output "dp add-flow exit=$LASTEXITCODE"
+Write-Output "dump-flows (expect 1):"; & $dpctl dump-flows system@ovs-system 2>&1
+& $dpctl del-flow system@ovs-system "in_port(2),eth(),eth_type(0x0800),ipv4()"; Write-Output "dp del-flow exit=$LASTEXITCODE"
+Write-Output "dump-flows (expect empty):"; & $dpctl dump-flows system@ovs-system 2>&1
 
 Step "LOGS: tails"
 Write-Output "--- ovsdb-server.log ---"; Get-Content "$run\ovsdb-server.log" -Tail 6 -EA SilentlyContinue

--- a/datapath-windows/test-catlet/run-full-mgmt-dp-test.ps1
+++ b/datapath-windows/test-catlet/run-full-mgmt-dp-test.ps1
@@ -1,6 +1,6 @@
 # Comprehensive Windows OVS validation, run INSIDE the ovs-kerneldev catlet.
 # Covers management-plane (db-init, detach, logs, db interaction, schema upgrade)
-# AND the kernel datapath (driver) via add-br datapath_type=windows + ovs-dpctl.
+# AND the kernel datapath (driver) via add-br datapath_type=system + ovs-dpctl.
 $ErrorActionPreference = 'Continue'
 $native = 'C:\ovs-test\native'
 $run    = 'C:\ovs-test\run'
@@ -50,8 +50,8 @@ Write-Output ("ovsdb-server.pid = " + (Get-Content "$run\ovsdb-server.pid" -EA S
 Write-Output ("ovs-vswitchd.pid = " + (Get-Content "$run\ovs-vswitchd.pid" -EA SilentlyContinue))
 Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Select-Object Name,Id | Format-Table -Auto | Out-String
 
-Step "DB INTERACTION: add-br/add-port/set/get/list (datapath_type=windows -> driver)"
-& $vsctl --timeout=25 add-br br-test -- set bridge br-test datapath_type=windows; Write-Output "add-br exit=$LASTEXITCODE"
+Step "DB INTERACTION: add-br/add-port/set/get/list (datapath_type=system -> driver)"
+& $vsctl --timeout=25 add-br br-test -- set bridge br-test datapath_type=system; Write-Output "add-br exit=$LASTEXITCODE"
 Start-Sleep -Seconds 2
 & $vsctl --timeout=25 add-port br-test p1 -- set interface p1 type=internal; Write-Output "add-port exit=$LASTEXITCODE"
 & $vsctl --timeout=25 set bridge br-test other-config:probe=hello; Write-Output "set exit=$LASTEXITCODE"

--- a/datapath-windows/test-catlet/run-fwd-ping.ps1
+++ b/datapath-windows/test-catlet/run-fwd-ping.ps1
@@ -1,6 +1,6 @@
 # Host<->nested-VM forwarding test through the live Windows OVS datapath, run
 # INSIDE the ovs-kerneldev catlet. Brings up our ovsdb+vswitchd, builds a
-# datapath_type=windows bridge, adds the nested guests' OVS ports (already named
+# datapath_type=system bridge, adds the nested guests' OVS ports (already named
 # ovs_ub1/ovs_ub2), enables the bridge host adapter, then pings each guest's
 # IPv6 link-local through the datapath. Stops the daemons at the end so the
 # invoking SSH session (whose pipe the --detach'd daemons inherit) returns.
@@ -21,7 +21,7 @@ Start-Sleep 1
 & "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
 Start-Sleep 2
 
-& $vsctl --timeout=25 add-br $br -- set bridge $br datapath_type=windows
+& $vsctl --timeout=25 add-br $br -- set bridge $br datapath_type=system
 Start-Sleep 3
 foreach ($p in 'ovs_ub1','ovs_ub2') {
     & $vsctl --timeout=25 add-port $br $p
@@ -40,7 +40,7 @@ Enable-NetAdapter -Name $br -EA Continue
 Start-Sleep 3
 $ifIdx = (Get-NetAdapter -Name $br -EA SilentlyContinue).ifIndex
 "=== dpctl show ==="
-& $dpctl show windows@ovs-system 2>&1
+& $dpctl show system@ovs-system 2>&1
 "$br host ifIndex = $ifIdx"
 
 $targets = @{ ub1 = 'fe80::d0ab:bfff:fef2:a0bd'; ub2 = 'fe80::d0ab:6fff:fe99:3fd' }
@@ -51,7 +51,7 @@ foreach ($name in $targets.Keys) {
 }
 
 "=== flows on datapath (forwarding evidence) ==="
-& $dpctl dump-flows windows@ovs-system 2>&1 | Select-Object -First 8
+& $dpctl dump-flows system@ovs-system 2>&1 | Select-Object -First 8
 
 "=== cleanup ==="
 & $vsctl --timeout=25 del-br $br 2>&1 | Out-Null

--- a/datapath-windows/test-catlet/run-fwd-ping.ps1
+++ b/datapath-windows/test-catlet/run-fwd-ping.ps1
@@ -1,0 +1,60 @@
+# Host<->nested-VM forwarding test through the live Windows OVS datapath, run
+# INSIDE the ovs-kerneldev catlet. Brings up our ovsdb+vswitchd, builds a
+# datapath_type=windows bridge, adds the nested guests' OVS ports (already named
+# ovs_ub1/ovs_ub2), enables the bridge host adapter, then pings each guest's
+# IPv6 link-local through the datapath. Stops the daemons at the end so the
+# invoking SSH session (whose pipe the --detach'd daemons inherit) returns.
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"; $tool = "$native\ovsdb-tool.exe"
+$br = 'br-int'
+
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep -Milliseconds 700
+Remove-Item "$run\conf.db","$run\ovsdb-server.log","$run\ovs-vswitchd.log","$run\*.pid" -EA SilentlyContinue
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+
+& $vsctl --timeout=25 add-br $br -- set bridge $br datapath_type=windows
+Start-Sleep 3
+foreach ($p in 'ovs_ub1','ovs_ub2') {
+    & $vsctl --timeout=25 add-port $br $p
+    Start-Sleep 1
+    $ofport = (& $vsctl --timeout=10 get interface $p ofport) 2>&1
+    if ($ofport -match '-1') {
+        # ofport=-1 "No such device": one clean del+re-add, never churn reconnect.
+        & $vsctl --timeout=25 del-port $br $p
+        Start-Sleep 1
+        & $vsctl --timeout=25 add-port $br $p
+        Start-Sleep 1
+    }
+}
+
+Enable-NetAdapter -Name $br -EA Continue
+Start-Sleep 3
+$ifIdx = (Get-NetAdapter -Name $br -EA SilentlyContinue).ifIndex
+"=== dpctl show ==="
+& $dpctl show windows@ovs-system 2>&1
+"$br host ifIndex = $ifIdx"
+
+$targets = @{ ub1 = 'fe80::d0ab:bfff:fef2:a0bd'; ub2 = 'fe80::d0ab:6fff:fe99:3fd' }
+foreach ($name in $targets.Keys) {
+    "=== ping $name ($($targets[$name])) through datapath ==="
+    ping -6 -n 4 "$($targets[$name])%$ifIdx"
+    "ping exit=$LASTEXITCODE"
+}
+
+"=== flows on datapath (forwarding evidence) ==="
+& $dpctl dump-flows windows@ovs-system 2>&1 | Select-Object -First 8
+
+"=== cleanup ==="
+& $vsctl --timeout=25 del-br $br 2>&1 | Out-Null
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+"driver state = " + (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+"DONE"

--- a/datapath-windows/test-catlet/run-twoswitch-demo.ps1
+++ b/datapath-windows/test-catlet/run-twoswitch-demo.ps1
@@ -69,7 +69,7 @@ foreach ($name in $targets.Keys) {
 }
 
 "=== flows on switch-1 datapath (forwarding evidence) ==="
-& $dpctl dump-flows "windows@$DP1" 2>&1 | Select-Object -First 6
+& $dpctl dump-flows "${DP1}@ovs-system" 2>&1 | Select-Object -First 6
 
 "=== driver state ==="
 (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State

--- a/datapath-windows/test-catlet/run-twoswitch-demo.ps1
+++ b/datapath-windows/test-catlet/run-twoswitch-demo.ps1
@@ -1,0 +1,76 @@
+# Two-switch forwarding demo, run INSIDE the ovs-kerneldev catlet.
+# Proves the ovsext multi-datapath stack end to end: one bridge per Hyper-V
+# switch, each selected by datapath_type=<switch-guid>, opening that switch's
+# own kernel datapath and forwarding independently.
+#
+#   br-int   datapath_type=<eryph_overlay GUID>  ports ovs_ub1, ovs_ub2
+#   br-test2 datapath_type=<ovs-test2 GUID>      internal port on ovs-test2
+#
+# The kernel reports datapath names as the switch GUID in UPPERCASE; the bridge
+# datapath_type must match that spelling (resolve is case-sensitive).
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"; $tool = "$native\ovsdb-tool.exe"
+
+$DP1 = '3D2A3FE1-1C10-4067-9067-BFCA27F869FB'   # eryph_overlay (ub1/ub2 live here)
+$DP2 = '9B6AA6B7-2242-43FF-8764-EA6FA9C6FEAF'   # ovs-test2 (internal)
+
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep -Milliseconds 700
+Remove-Item "$run\conf.db","$run\ovsdb-server.log","$run\ovs-vswitchd.log","$run\*.pid" -EA SilentlyContinue
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+
+"=== create br-int on switch 1 ($DP1) ==="
+& $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$DP1
+Start-Sleep 3
+foreach ($p in 'ovs_ub1','ovs_ub2') {
+    & $vsctl --timeout=25 add-port br-int $p
+    Start-Sleep 1
+    $ofport = (& $vsctl --timeout=10 get interface $p ofport) 2>&1
+    if ($ofport -match '-1') {
+        & $vsctl --timeout=25 del-port br-int $p; Start-Sleep 1
+        & $vsctl --timeout=25 add-port br-int $p; Start-Sleep 1
+    }
+}
+
+"=== create br-test2 on switch 2 ($DP2) ==="
+& $vsctl --timeout=25 add-br br-test2 -- set bridge br-test2 datapath_type=$DP2
+Start-Sleep 3
+
+Enable-NetAdapter -Name br-int -EA Continue
+Enable-NetAdapter -Name br-test2 -EA Continue
+Start-Sleep 3
+
+"=== ovs-vsctl show ==="
+& $vsctl show 2>&1
+
+"=== dpctl show (each datapath lists only its own ports) ==="
+& $dpctl show 2>&1
+
+"=== br-test2 internal adapter must be bound to ovs-test2 ==="
+Get-VMNetworkAdapter -ManagementOS -EA SilentlyContinue |
+    Where-Object Name -match 'br-test2|br-int' |
+    Select-Object Name,SwitchName | Format-Table -Auto | Out-String
+
+$ifIdx = (Get-NetAdapter -Name br-int -EA SilentlyContinue).ifIndex
+"br-int host ifIndex = $ifIdx"
+$targets = @{ ub1 = 'fe80::d0ab:bfff:fef2:a0bd'; ub2 = 'fe80::d0ab:6fff:fe99:3fd' }
+foreach ($name in $targets.Keys) {
+    "=== ping $name through switch-1 datapath ==="
+    ping -6 -n 4 "$($targets[$name])%$ifIdx"
+    "ping exit=$LASTEXITCODE"
+}
+
+"=== flows on switch-1 datapath (forwarding evidence) ==="
+& $dpctl dump-flows "windows@$DP1" 2>&1 | Select-Object -First 6
+
+"=== driver state ==="
+(Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+"DEMO-DONE"

--- a/datapath-windows/test-catlet/sw2-forward.ps1
+++ b/datapath-windows/test-catlet/sw2-forward.ps1
@@ -28,7 +28,7 @@ try {
     Enable-NetAdapter -Name br-test2 -EA Continue
     Start-Sleep 3
     "=== dpctl show switch-2 datapath (must list br-test2 + ovs_ub2) ==="
-    & $dpctl show "windows@$DP2" 2>&1
+    & $dpctl show "${DP2}@ovs-system" 2>&1
 
     $ifIdx = (Get-NetAdapter -Name br-test2 -EA SilentlyContinue).ifIndex
     "br-test2 host ifIndex = $ifIdx"
@@ -37,7 +37,7 @@ try {
     "ping exit=$LASTEXITCODE"
 
     "=== flows on switch-2 datapath ==="
-    & $dpctl dump-flows "windows@$DP2" 2>&1 | Select-Object -First 6
+    & $dpctl dump-flows "${DP2}@ovs-system" 2>&1 | Select-Object -First 6
 }
 finally {
     "=== RESTORE: ub2 -> eryph_overlay ==="

--- a/datapath-windows/test-catlet/sw2-forward.ps1
+++ b/datapath-windows/test-catlet/sw2-forward.ps1
@@ -1,0 +1,50 @@
+# Bilateral proof: move ub2 onto switch 2 (ovs-test2), bind it to br-test2, and
+# ping it through switch-2's INDEPENDENT datapath while ub1 still forwards on
+# switch 1. Restores ub2 to eryph_overlay at the end no matter what.
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"
+$DP2 = '9B6AA6B7-2242-43FF-8764-EA6FA9C6FEAF'
+$ub2ll = 'fe80::d0ab:6fff:fe99:3fd'
+
+try {
+    "=== move ub2 -> ovs-test2 ==="
+    Connect-VMNetworkAdapter -VMName ub2 -SwitchName ovs-test2 -EA Continue
+    Start-Sleep 4
+    Get-VMNetworkAdapter -VMName ub2 | Select-Object VMName,SwitchName | Format-Table -Auto | Out-String
+
+    "=== add ub2 port to br-test2 ==="
+    & $vsctl --timeout=25 add-port br-test2 ovs_ub2
+    Start-Sleep 2
+    $ofport = (& $vsctl --timeout=10 get interface ovs_ub2 ofport) 2>&1
+    "ovs_ub2 ofport = $ofport"
+    if ($ofport -match '-1') {
+        & $vsctl --timeout=25 del-port br-test2 ovs_ub2; Start-Sleep 1
+        & $vsctl --timeout=25 add-port br-test2 ovs_ub2; Start-Sleep 2
+    }
+
+    Enable-NetAdapter -Name br-test2 -EA Continue
+    Start-Sleep 3
+    "=== dpctl show switch-2 datapath (must list br-test2 + ovs_ub2) ==="
+    & $dpctl show "windows@$DP2" 2>&1
+
+    $ifIdx = (Get-NetAdapter -Name br-test2 -EA SilentlyContinue).ifIndex
+    "br-test2 host ifIndex = $ifIdx"
+    "=== ping ub2 through SWITCH-2 datapath ==="
+    ping -6 -n 4 "$ub2ll%$ifIdx"
+    "ping exit=$LASTEXITCODE"
+
+    "=== flows on switch-2 datapath ==="
+    & $dpctl dump-flows "windows@$DP2" 2>&1 | Select-Object -First 6
+}
+finally {
+    "=== RESTORE: ub2 -> eryph_overlay ==="
+    & $vsctl --timeout=25 del-port br-test2 ovs_ub2 2>&1 | Out-Null
+    Connect-VMNetworkAdapter -VMName ub2 -SwitchName eryph_overlay -EA Continue
+    Start-Sleep 2
+    Get-VMNetworkAdapter -VMName ub2 | Select-Object VMName,SwitchName | Format-Table -Auto | Out-String
+    "driver state = " + (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+}
+"SW2-DONE"

--- a/datapath-windows/test-catlet/test-vsctl.ps1
+++ b/datapath-windows/test-catlet/test-vsctl.ps1
@@ -13,6 +13,6 @@ Start-Sleep 2
 $ev = "$erun\bin\ovs-vsctl.exe"
 Write-Output '=== eryph vsctl (3.3) show against our ovsdb (3.5) ==='
 & $ev --timeout=10 show 2>&1; Write-Output "show exit=$LASTEXITCODE"
-Write-Output '=== eryph vsctl add-br br-test datapath_type=windows ==='
-& $ev --timeout=10 add-br br-test -- set bridge br-test datapath_type=windows 2>&1; Write-Output "add-br exit=$LASTEXITCODE"
+Write-Output '=== eryph vsctl add-br br-test datapath_type=system ==='
+& $ev --timeout=10 add-br br-test -- set bridge br-test datapath_type=system 2>&1; Write-Output "add-br exit=$LASTEXITCODE"
 & $ev --timeout=10 show 2>&1

--- a/datapath-windows/test-catlet/verify-system-type.ps1
+++ b/datapath-windows/test-catlet/verify-system-type.ps1
@@ -1,0 +1,30 @@
+# Verify the "system" datapath-type rename end to end.
+$ErrorActionPreference = 'Continue'
+$native='C:\ovs-test\native'; $run='C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl="$native\ovs-vsctl.exe"; $dpctl="$native\ovs-dpctl.exe"
+
+& C:\ovs-test\ms-dp.ps1 down | Out-Null
+Start-Sleep 2
+& C:\ovs-test\ms-dp.ps1 up | Out-Null
+Start-Sleep 2
+
+"=== (1) dpctl show: expect system@ovs-system + <GUID>@ovs-system, NO windows@ ==="
+& $dpctl show 2>&1
+
+"=== (2) switch-1 forwarding ==="
+& C:\ovs-test\ms-dp.ps1 ping
+
+"=== (3) DEFAULT bridge bug fix: add-br with NO datapath_type ==="
+& $vsctl --timeout=25 add-br br-default
+Start-Sleep 3
+"br-default datapath_type = '" + (& $vsctl --timeout=10 get bridge br-default datapath_type) + "'"
+"br-default local ofport   = " + (& $vsctl --timeout=10 get interface br-default ofport 2>&1)
+"unknown-datapath-type errors in log (expect NONE):"
+Select-String -Path "$run\ovs-vswitchd.log" -Pattern 'unknown datapath type|could not create datapath br-default' -EA SilentlyContinue | ForEach-Object { $_.Line }
+"=== dpctl show after default bridge ==="
+& $dpctl show 2>&1
+
+& $vsctl --timeout=10 del-br br-default 2>&1 | Out-Null
+"VERIFY-DONE"

--- a/lib/dpif-netlink.c
+++ b/lib/dpif-netlink.c
@@ -1081,7 +1081,7 @@ dpif_netlink_port_add_compat(struct dpif_netlink *dpif, struct netdev *netdev,
 
 #ifdef _WIN32
     if (ovs_type == OVS_VPORT_TYPE_INTERNAL) {
-        if (!create_wmi_port(name)){
+        if (!create_wmi_port(name, NULL)){
             VLOG_ERR("Could not create wmi internal port with name:%s", name);
             return EINVAL;
         };

--- a/lib/dpif-provider.h
+++ b/lib/dpif-provider.h
@@ -708,6 +708,10 @@ struct dpif_class {
 extern const struct dpif_class dpif_netlink_class;
 #ifdef _WIN32
 extern const struct dpif_class dpif_windows_class;
+/* Registers a per-Hyper-V-switch alias of 'dpif_windows_class' under the type
+ * 'type' (a switch GUID) so ofproto can open a datapath_type=<switch-guid>
+ * backer.  See lib/dpif-windows.c. */
+int dpif_windows_register_switch_type(const char *type);
 #endif
 extern const struct dpif_class dpif_netdev_class;
 

--- a/lib/dpif-provider.h
+++ b/lib/dpif-provider.h
@@ -712,6 +712,9 @@ extern const struct dpif_class dpif_windows_class;
  * 'type' (a switch GUID) so ofproto can open a datapath_type=<switch-guid>
  * backer.  See lib/dpif-windows.c. */
 int dpif_windows_register_switch_type(const char *type);
+/* Registers such an alias for every switch the kernel currently exposes a
+ * datapath for; called during datapath-type enumeration. */
+void dpif_windows_register_all_switch_types(void);
 #endif
 extern const struct dpif_class dpif_netdev_class;
 

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -65,24 +65,28 @@ static struct vlog_rate_limit error_rl = VLOG_RATE_LIMIT_INIT(9999, 5);
 #define FLOW_DUMP_MAX_BATCH 50
 #define OPERATE_MAX_OPS 50
 
-/* The ovsext kernel exposes a single, global datapath whose name is fixed to
- * "ovs-system" (OVS_SYSTEM_DP_NAME in the driver): OVS_DP_CMD_GET/NEW/SET reject
- * any other OVS_DP_ATTR_NAME with NL_ERROR_NODEV.  ofproto-dpif, however, opens
- * its backer under the name "ovs-<datapath_type>" (i.e. "ovs-windows"), and
- * dpctl callers may pass an arbitrary name.  We therefore ignore the
- * userspace-facing dpif name when addressing the kernel and always use this
- * fixed name; the single global datapath makes that unambiguous. */
-#define OVS_WINDOWS_KERNEL_DP_NAME "ovs-system"
+/* The ovsext kernel backs one datapath per Hyper-V switch, each addressed on
+ * the wire by its dp_ifindex and named by its switch identity. ofproto-dpif
+ * opens its backer under the name "ovs-<datapath_type>" (e.g. "ovs-windows")
+ * and dpctl callers may pass an arbitrary name. dpif_windows_open resolves that
+ * name to a dp_ifindex by dumping the datapaths and matching: the default
+ * suffix ("windows"/"system") selects the lowest-numbered datapath, otherwise
+ * the suffix must match a datapath's reported name. The resolved name and
+ * dp_ifindex are then used to address the kernel for the lifetime of the dpif.
+ *
+ * Names can be a switch GUID, longer than IFNAMSIZ; the datapath-name parse and
+ * the resolver buffers are sized accordingly. */
+#define OVS_DP_NAME_MAX 64
 
-/* On Windows the kernel datapath uses a single, global datapath whose
- * dp_ifindex the userspace side does not allocate; dpif-netlink threads a
- * dp_ifindex through every message.  We keep the same field, initialized from
- * the OVS_DP_CMD_GET/NEW reply, and default to 0 (the driver accepts 0 for the
- * single datapath). */
+/* Upper bound on datapaths to enumerate when resolving a name; matches the
+ * driver's OVS_MAX_DATAPATHS. */
+#define DPIF_WINDOWS_MAX_DPS 16
+
 struct dpif_windows {
     struct dpif dpif;
     struct ovsext_channel channel;
     int dp_ifindex;
+    char *dp_name;              /* Kernel-reported datapath name. */
     uint32_t user_features;
     bool upcalls_enabled;       /* recv_set() state. */
 };
@@ -154,7 +158,7 @@ dpif_windows_dp_from_ofpbuf(struct dpif_windows_dp *dp,
                             const struct ofpbuf *buf)
 {
     static const struct nl_policy ovs_datapath_policy[] = {
-        [OVS_DP_ATTR_NAME] = { .type = NL_A_STRING, .max_len = IFNAMSIZ },
+        [OVS_DP_ATTR_NAME] = { .type = NL_A_STRING, .max_len = OVS_DP_NAME_MAX },
         [OVS_DP_ATTR_STATS] = { NL_POLICY_FOR(struct ovs_dp_stats),
                                 .optional = true },
         [OVS_DP_ATTR_MEGAFLOW_STATS] = {
@@ -238,7 +242,7 @@ dpif_windows_dp_get(struct dpif_windows *dpif, struct dpif_windows_dp *reply,
     dpif_windows_dp_init(&request);
     request.cmd = OVS_DP_CMD_GET;
     request.dp_ifindex = dpif->dp_ifindex;
-    request.name = OVS_WINDOWS_KERNEL_DP_NAME;
+    request.name = dpif->dp_name;
 
     return dpif_windows_dp_transact(dpif, &request, reply, bufp);
 }
@@ -844,6 +848,97 @@ dpif_windows_enumerate(struct sset *all_dps,
     return error;
 }
 
+/* One datapath as reported by an OVS_DP_CMD_GET dump. */
+struct dpif_windows_dp_entry {
+    int dp_ifindex;
+    char name[OVS_DP_NAME_MAX];
+};
+
+/* Dumps all datapaths on 'channel' into 'entries' (capacity 'max').  Returns
+ * the number collected, or a negative errno on dump failure. */
+static int
+dpif_windows_dump_dps(struct ovsext_channel *channel,
+                      struct dpif_windows_dp_entry *entries, int max)
+{
+    struct ovsext_dump dump;
+    struct dpif_windows_dp request;
+    struct ofpbuf *buf;
+    struct ofpbuf msg;
+    int n = 0;
+    int error;
+
+    dpif_windows_dp_init(&request);
+    request.cmd = OVS_DP_CMD_GET;
+
+    buf = ofpbuf_new(1024);
+    dpif_windows_dp_to_ofpbuf(&request, buf);
+    nl_msg_nlmsghdr(buf)->nlmsg_flags |= NLM_F_DUMP;
+    ovsext_dump_start(&dump, channel, buf);
+    ofpbuf_delete(buf);
+
+    while (ovsext_dump_next(&dump, &msg)) {
+        struct dpif_windows_dp dp;
+
+        if (!dpif_windows_dp_from_ofpbuf(&dp, &msg) && n < max) {
+            entries[n].dp_ifindex = dp.dp_ifindex;
+            ovs_strlcpy(entries[n].name, dp.name ? dp.name : "",
+                        sizeof entries[n].name);
+            n++;
+        }
+    }
+
+    error = ovsext_dump_done(&dump);
+    return error ? -error : n;
+}
+
+/* Resolves the userspace dpif 'name' to a kernel datapath by dumping all
+ * datapaths and matching.  The backer name is "ovs-<datapath_type>"; the
+ * default suffix ("windows"/"system") selects the lowest-numbered datapath,
+ * otherwise the suffix must exactly match a datapath's reported name.  On
+ * success sets '*dp_ifindex' and '*dp_name' (the caller frees '*dp_name'). */
+static int
+dpif_windows_resolve_dp(struct ovsext_channel *channel, const char *name,
+                        int *dp_ifindex, char **dp_name)
+{
+    struct dpif_windows_dp_entry entries[DPIF_WINDOWS_MAX_DPS];
+    const char *suffix;
+    bool is_default;
+    int n, i, best = -1;
+
+    n = dpif_windows_dump_dps(channel, entries, ARRAY_SIZE(entries));
+    if (n < 0) {
+        return -n;
+    }
+    if (n == 0) {
+        return ENODEV;
+    }
+
+    suffix = name;
+    if (!strncmp(suffix, "ovs-", 4)) {
+        suffix += 4;
+    }
+    is_default = !strcmp(suffix, "windows") || !strcmp(suffix, "system");
+
+    for (i = 0; i < n; i++) {
+        if (is_default) {
+            if (best < 0 || entries[i].dp_ifindex < entries[best].dp_ifindex) {
+                best = i;
+            }
+        } else if (!strcmp(entries[i].name, suffix)) {
+            best = i;
+            break;
+        }
+    }
+
+    if (best < 0) {
+        return ENODEV;
+    }
+
+    *dp_ifindex = entries[best].dp_ifindex;
+    *dp_name = xstrdup(entries[best].name);
+    return 0;
+}
+
 static int
 dpif_windows_open(const struct dpif_class *class, const char *name,
                   bool create, struct dpif **dpifp)
@@ -852,6 +947,8 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     struct dpif_windows_dp dp_request, dp;
     struct ofpbuf *buf = NULL;
     uint32_t upcall_pid;
+    char *dp_name = NULL;
+    int dp_ifindex = 0;
     int error;
 
     dpif = xzalloc(sizeof *dpif);
@@ -867,17 +964,12 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     dpif_init(&dpif->dpif, class, name, 0, 0);
     dpif->dp_ifindex = 0;
 
-    /* Create or look up the datapath, mirroring dpif_netlink_open() but
-     * without the Linux per-cpu/per-vport feature negotiation (the ovsext
-     * driver implements neither; it always dispatches to the subscribed
-     * userspace pid). */
-    dpif_windows_dp_init(&dp_request);
-    upcall_pid = dpif->channel.pid;
-    dp_request.upcall_pid = &upcall_pid;
-    dp_request.name = OVS_WINDOWS_KERNEL_DP_NAME;
-    dp_request.cmd = create ? OVS_DP_CMD_NEW : OVS_DP_CMD_GET;
-
-    error = dpif_windows_dp_transact(dpif, &dp_request, &dp, &buf);
+    /* Resolve 'name' to a concrete kernel datapath. The driver owns datapath
+     * lifetime (one per Hyper-V switch), so we never create one here; an
+     * OVS_DP_CMD_NEW for an existing datapath returns EEXIST, which lets
+     * dpif_create_and_open() fall back to the open path unchanged. */
+    error = dpif_windows_resolve_dp(&dpif->channel, name, &dp_ifindex,
+                                    &dp_name);
     if (error) {
         ovsext_channel_close(&dpif->channel);
         dpif_uninit(&dpif->dpif, false);
@@ -885,7 +977,24 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
         return error;
     }
 
+    dpif_windows_dp_init(&dp_request);
+    upcall_pid = dpif->channel.pid;
+    dp_request.upcall_pid = &upcall_pid;
+    dp_request.name = dp_name;
+    dp_request.dp_ifindex = dp_ifindex;
+    dp_request.cmd = create ? OVS_DP_CMD_NEW : OVS_DP_CMD_GET;
+
+    error = dpif_windows_dp_transact(dpif, &dp_request, &dp, &buf);
+    if (error) {
+        free(dp_name);
+        ovsext_channel_close(&dpif->channel);
+        dpif_uninit(&dpif->dpif, false);
+        free(dpif);
+        return error;
+    }
+
     dpif->dp_ifindex = dp.dp_ifindex;
+    dpif->dp_name = dp_name;
     dpif->user_features = dp.user_features;
     ofpbuf_delete(buf);
 
@@ -903,6 +1012,7 @@ dpif_windows_close(struct dpif *dpif_)
      * resources and the containing struct (mirrors dpif_netlink_close).
      * Calling dpif_uninit() here double-frees base_name. */
     ovsext_channel_close(&dpif->channel);
+    free(dpif->dp_name);
     free(dpif);
 }
 

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -100,10 +100,17 @@ struct dpif_windows {
 /* 'dpif_windows_class' is declared in dpif-provider.h and defined at the
  * bottom of this file. */
 
+static int dpif_windows_open(const struct dpif_class *class, const char *name,
+                             bool create, struct dpif **dpifp);
+
 static struct dpif_windows *
 dpif_windows_cast(const struct dpif *dpif)
 {
-    dpif_assert_class(dpif, &dpif_windows_class);
+    /* Besides 'dpif_windows_class' itself, the provider is also registered under
+     * per-switch alias classes (one per Hyper-V switch GUID, see
+     * dpif_windows_register_switch_type), which share these same methods. Accept
+     * any class backed by this provider rather than the base class alone. */
+    ovs_assert(dpif->dpif_class->open == dpif_windows_open);
     return CONTAINER_OF(dpif, struct dpif_windows, dpif);
 }
 
@@ -818,7 +825,7 @@ dpif_windows_init_flow_del(struct dpif_windows *dpif,
  * still dump it from the kernel rather than hard-coding the name. */
 static int
 dpif_windows_enumerate(struct sset *all_dps,
-                       const struct dpif_class *dpif_class OVS_UNUSED)
+                       const struct dpif_class *dpif_class)
 {
     struct ovsext_channel channel;
     struct ovsext_dump dump;
@@ -826,6 +833,12 @@ dpif_windows_enumerate(struct sset *all_dps,
     struct ofpbuf *buf;
     struct ofpbuf msg;
     int error;
+
+    /* The base "windows" class enumerates every datapath plus the default
+     * aliases; a per-switch alias class (type == a switch GUID) enumerates only
+     * its own datapath, so ofproto's stale-backer cleanup stays scoped to that
+     * switch. */
+    bool specific = strcmp(dpif_class->type, "windows") != 0;
 
     error = ovsext_channel_open(&channel);
     if (error) {
@@ -845,16 +858,22 @@ dpif_windows_enumerate(struct sset *all_dps,
     while (ovsext_dump_next(&dump, &msg)) {
         struct dpif_windows_dp dp;
 
-        if (!dpif_windows_dp_from_ofpbuf(&dp, &msg)) {
-            sset_add(all_dps, dp.name);
-            any = true;
+        if (!dpif_windows_dp_from_ofpbuf(&dp, &msg) && dp.name) {
+            if (specific) {
+                if (!strcmp(dp.name, dpif_class->type)) {
+                    sset_add(all_dps, dp.name);
+                }
+            } else {
+                sset_add(all_dps, dp.name);
+                any = true;
+            }
         }
     }
 
-    /* The kernel now names each datapath by its switch GUID, but ofproto opens
-     * its backer as "ovs-<datapath_type>" and dp_exists() checks this set for
-     * "ovs-system"/"ovs-windows".  Keep those default aliases resolvable as long
-     * as at least one datapath exists; dpif_windows_open maps them to the
+    /* The kernel names each datapath by its switch GUID, but ofproto opens the
+     * default backer as "ovs-<datapath_type>" and dp_exists() checks this set
+     * for "ovs-system"/"ovs-windows".  Keep those default aliases resolvable as
+     * long as at least one datapath exists; dpif_windows_open maps them to the
      * lowest-numbered datapath. */
     if (any) {
         sset_add(all_dps, "ovs-windows");
@@ -954,6 +973,55 @@ dpif_windows_resolve_dp(struct ovsext_channel *channel, const char *name,
 
     *dp_ifindex = entries[best].dp_ifindex;
     *dp_name = xstrdup(entries[best].name);
+    return 0;
+}
+
+/* The ovsext kernel backs one datapath per Hyper-V switch, named by the switch
+ * GUID.  ofproto-dpif shares one dpif backer per datapath_type and looks the
+ * type up as a registered dpif class, so a bridge that selects a specific
+ * switch with datapath_type=<switch-guid> needs a dpif provider registered
+ * under that GUID.  This registers an alias of 'dpif_windows_class' whose type
+ * is 'type', provided a kernel datapath currently carries that GUID name.
+ * Returns 0 if an alias is (or already was) registered, EAFNOSUPPORT if no
+ * datapath has that name, or another positive errno on failure. */
+int
+dpif_windows_register_switch_type(const char *type)
+{
+    struct dpif_windows_dp_entry entries[DPIF_WINDOWS_MAX_DPS];
+    struct ovsext_channel channel;
+    struct dpif_class *alias;
+    bool found = false;
+    int n, i, error;
+
+    error = ovsext_channel_open(&channel);
+    if (error) {
+        return error;
+    }
+    n = dpif_windows_dump_dps(&channel, entries, ARRAY_SIZE(entries));
+    ovsext_channel_close(&channel);
+    if (n < 0) {
+        return -n;
+    }
+
+    for (i = 0; i < n; i++) {
+        if (!strcmp(entries[i].name, type)) {
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        return EAFNOSUPPORT;
+    }
+
+    alias = xmemdup(&dpif_windows_class, sizeof dpif_windows_class);
+    alias->type = xstrdup(type);
+    error = dp_register_provider(alias);
+    if (error) {
+        /* EEXIST means a concurrent open already registered it; treat as OK. */
+        free(CONST_CAST(char *, alias->type));
+        free(alias);
+        return error == EEXIST ? 0 : error;
+    }
     return 0;
 }
 
@@ -1159,7 +1227,9 @@ dpif_windows_port_add(struct dpif *dpif_, struct netdev *netdev,
     /* Internal ports are backed by a Hyper-V WMI interface created here, as in
      * dpif-netlink's _WIN32 path. */
     if (ovs_type == OVS_VPORT_TYPE_INTERNAL) {
-        if (!create_wmi_port(CONST_CAST(char *, name))) {
+        /* dpif->dp_name is the bridge datapath's switch identity (the Hyper-V
+         * switch GUID), so the internal port is created on that exact switch. */
+        if (!create_wmi_port(CONST_CAST(char *, name), dpif->dp_name)) {
             VLOG_ERR("Could not create wmi internal port with name: %s", name);
             return EINVAL;
         }

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -33,6 +33,7 @@
 
 #ifdef _WIN32
 
+#include <errno.h>
 #include <stdio.h>              /* EOF */
 #include <net/if.h>             /* IFNAMSIZ */
 
@@ -1654,6 +1655,85 @@ parse_odp_packet(struct dpif_windows *dpif, struct ofpbuf *buf,
     return 0;
 }
 
+/*
+ * Re-stamps the upcall pid on every existing vport to this dpif's channel pid.
+ *
+ * ovs-vswitchd does not re-create the kernel-owned vports (VM NICs, the
+ * external/internal Hyper-V ports) when it (re)starts, so without this they
+ * keep the previous, now-dead vswitchd's upcall pid and every packet miss is
+ * dropped -- the datapath wedges until a reboot.  This mirrors dpif-netlink's
+ * dpif_netlink_refresh_handlers_vport_dispatch, which Linux runs from
+ * recv_set() for the same reason.
+ *
+ * The ovsext channel has a single stateful dump cursor, so the port numbers are
+ * collected first and the SETs issued only after the dump completes; a transact
+ * issued mid-dump would re-arm and destroy the cursor.  recv_set() runs on the
+ * main thread before the upcall handler threads are started, so the channel is
+ * not used concurrently here.
+ */
+static void
+dpif_windows_refresh_port_upcall_pids(struct dpif_windows *dpif)
+{
+    struct ovsext_dump dump;
+    struct dpif_windows_vport request;
+    struct ofpbuf *buf;
+    odp_port_t *ports = NULL;
+    size_t n = 0, allocated = 0;
+    uint32_t pid = dpif->channel.pid;
+    size_t i;
+
+    dpif_windows_vport_init(&request);
+    request.cmd = OVS_VPORT_CMD_GET;
+    request.dp_ifindex = dpif->dp_ifindex;
+    buf = ofpbuf_new(1024);
+    dpif_windows_vport_to_ofpbuf(&request, buf);
+    /* NLM_F_DUMP requests every vport. */
+    nl_msg_nlmsghdr(buf)->nlmsg_flags |= NLM_F_DUMP;
+    ovsext_dump_start(&dump, &dpif->channel, buf);
+    ofpbuf_delete(buf);
+
+    for (;;) {
+        struct dpif_windows_vport vport;
+        struct ofpbuf rec;
+
+        if (!ovsext_dump_next(&dump, &rec)) {
+            break;
+        }
+        if (dpif_windows_vport_from_ofpbuf(&vport, &rec)) {
+            continue;
+        }
+        if (vport.n_upcall_pids == 1 && vport.upcall_pids
+            && vport.upcall_pids[0] == pid) {
+            continue;       /* Already points at this vswitchd. */
+        }
+        if (n >= allocated) {
+            allocated = allocated ? allocated * 2 : 16;
+            ports = xrealloc(ports, allocated * sizeof *ports);
+        }
+        ports[n++] = vport.port_no;
+    }
+    ovsext_dump_done(&dump);
+
+    for (i = 0; i < n; i++) {
+        struct dpif_windows_vport set;
+        int error;
+
+        dpif_windows_vport_init(&set);
+        set.cmd = OVS_VPORT_CMD_SET;
+        set.dp_ifindex = dpif->dp_ifindex;
+        set.port_no = ports[i];
+        set.n_upcall_pids = 1;
+        set.upcall_pids = &pid;
+        error = dpif_windows_vport_transact(dpif, &set, NULL, NULL);
+        if (error && error != ENODEV && error != ENOENT) {
+            VLOG_WARN_RL(&error_rl,
+                         "failed to refresh upcall pid for port %"PRIu32" (%s)",
+                         odp_to_u32(ports[i]), ovs_strerror(error));
+        }
+    }
+    free(ports);
+}
+
 static int
 dpif_windows_recv_set(struct dpif *dpif_, bool enable)
 {
@@ -1663,6 +1743,9 @@ dpif_windows_recv_set(struct dpif *dpif_, bool enable)
     error = ovsext_subscribe_packets(&dpif->channel, enable);
     if (!error) {
         dpif->upcalls_enabled = enable;
+        if (enable) {
+            dpif_windows_refresh_port_upcall_pids(dpif);
+        }
     }
     return error;
 }

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -67,10 +67,10 @@ static struct vlog_rate_limit error_rl = VLOG_RATE_LIMIT_INIT(9999, 5);
 
 /* The ovsext kernel backs one datapath per Hyper-V switch, each addressed on
  * the wire by its dp_ifindex and named by its switch identity. ofproto-dpif
- * opens its backer under the name "ovs-<datapath_type>" (e.g. "ovs-windows")
+ * opens its backer under the name "ovs-<datapath_type>" (e.g. "ovs-system")
  * and dpctl callers may pass an arbitrary name. dpif_windows_open resolves that
  * name to a dp_ifindex by dumping the datapaths and matching: the default
- * suffix ("windows"/"system") selects the lowest-numbered datapath, otherwise
+ * suffix ("system") selects the lowest-numbered datapath, otherwise
  * the suffix must match a datapath's reported name. The resolved name and
  * dp_ifindex are then used to address the kernel for the lifetime of the dpif.
  *
@@ -83,6 +83,14 @@ static struct vlog_rate_limit error_rl = VLOG_RATE_LIMIT_INIT(9999, 5);
  * resolve the caller's name to a dp_ifindex via DP_DUMP, then target that
  * dp_ifindex while sending this fixed name. */
 #define OVS_WINDOWS_KERNEL_DP_NAME "ovs-system"
+
+/* The base datapath type for the native Windows provider.  Matches Linux's
+ * "system" type so a bridge with no datapath_type (normalized to "system")
+ * resolves here and "ovs-dpctl show" reads "system@ovs-system", as on Linux.
+ * Per-switch datapaths register additional alias types named by the switch
+ * GUID; this base type is the default, resolving to the lowest-numbered
+ * datapath. */
+#define OVS_WINDOWS_DEFAULT_DP_TYPE "system"
 
 /* Upper bound on datapaths to enumerate when resolving a name; matches the
  * driver's OVS_MAX_DATAPATHS. */
@@ -820,9 +828,9 @@ dpif_windows_init_flow_del(struct dpif_windows *dpif,
 /* Lists the names of all datapaths the kernel exposes, mirroring
  * dpif_netlink_enumerate().  dpctl commands that take an optional datapath
  * argument gate on dp_exists()/dp_enumerate_names(): without this method the
- * set comes back empty and even a valid "windows@ovs-system" is rejected with
- * "datapath not found".  On Windows there is a single global datapath, but we
- * still dump it from the kernel rather than hard-coding the name. */
+ * set comes back empty and even a valid "system@ovs-system" is rejected with
+ * "datapath not found".  We dump the datapaths from the kernel rather than
+ * hard-coding the name. */
 static int
 dpif_windows_enumerate(struct sset *all_dps,
                        const struct dpif_class *dpif_class)
@@ -834,11 +842,14 @@ dpif_windows_enumerate(struct sset *all_dps,
     struct ofpbuf msg;
     int error;
 
-    /* The base "windows" class enumerates every datapath plus the default
-     * aliases; a per-switch alias class (type == a switch GUID) enumerates only
-     * its own datapath, so ofproto's stale-backer cleanup stays scoped to that
-     * switch. */
-    bool specific = strcmp(dpif_class->type, "windows") != 0;
+    /* Every datapath is reported with the conventional name "ovs-system" (as on
+     * Linux); the switch identity lives in the dpif type.  A per-switch alias
+     * class (type == a switch GUID) reports "ovs-system" iff its switch's
+     * datapath exists, so it shows as "<switch-guid>@ovs-system".  The base
+     * "system" class reports "ovs-system" for the default (lowest) datapath
+     * ("system@ovs-system").  Thus "ovs-dpctl show" lists each switch once plus
+     * the default. */
+    bool specific = strcmp(dpif_class->type, OVS_WINDOWS_DEFAULT_DP_TYPE) != 0;
 
     error = ovsext_channel_open(&channel);
     if (error) {
@@ -861,22 +872,20 @@ dpif_windows_enumerate(struct sset *all_dps,
         if (!dpif_windows_dp_from_ofpbuf(&dp, &msg) && dp.name) {
             if (specific) {
                 if (!strcmp(dp.name, dpif_class->type)) {
-                    sset_add(all_dps, dp.name);
+                    any = true;
                 }
             } else {
-                sset_add(all_dps, dp.name);
                 any = true;
             }
         }
     }
 
-    /* The kernel names each datapath by its switch GUID, but ofproto opens the
-     * default backer as "ovs-<datapath_type>" and dp_exists() checks this set
-     * for "ovs-system"/"ovs-windows".  Keep those default aliases resolvable as
-     * long as at least one datapath exists; dpif_windows_open maps them to the
-     * lowest-numbered datapath. */
+    /* Report the conventional datapath name when this class' datapath exists:
+     * for a per-switch class that is its own switch ("<guid>@ovs-system"); for
+     * the base "system" class the default (lowest) datapath ("system@ovs-
+     * system").  dpif_windows_open resolves a per-switch class by its type and
+     * the base class by the "ovs-system" name. */
     if (any) {
-        sset_add(all_dps, "ovs-windows");
         sset_add(all_dps, "ovs-system");
     }
 
@@ -930,7 +939,7 @@ dpif_windows_dump_dps(struct ovsext_channel *channel,
 
 /* Resolves the userspace dpif 'name' to a kernel datapath by dumping all
  * datapaths and matching.  The backer name is "ovs-<datapath_type>"; the
- * default suffix ("windows"/"system") selects the lowest-numbered datapath,
+ * default suffix ("system") selects the lowest-numbered datapath,
  * otherwise the suffix must exactly match a datapath's reported name.  On
  * success sets '*dp_ifindex' and '*dp_name' (the caller frees '*dp_name'). */
 static int
@@ -954,7 +963,7 @@ dpif_windows_resolve_dp(struct ovsext_channel *channel, const char *name,
     if (!strncmp(suffix, "ovs-", 4)) {
         suffix += 4;
     }
-    is_default = !strcmp(suffix, "windows") || !strcmp(suffix, "system");
+    is_default = !strcmp(suffix, "system");
 
     for (i = 0; i < n; i++) {
         if (is_default) {
@@ -1085,11 +1094,19 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     dpif_init(&dpif->dpif, class, name, 0, 0);
     dpif->dp_ifindex = 0;
 
-    /* Resolve 'name' to a concrete kernel datapath. The driver owns datapath
-     * lifetime (one per Hyper-V switch), so we never create one here; an
-     * OVS_DP_CMD_NEW for an existing datapath returns EEXIST, which lets
-     * dpif_create_and_open() fall back to the open path unchanged. */
-    error = dpif_windows_resolve_dp(&dpif->channel, name, &dp_ifindex,
+    /* Resolve to a concrete kernel datapath. The driver owns datapath lifetime
+     * (one per Hyper-V switch), so we never create one here; an OVS_DP_CMD_NEW
+     * for an existing datapath returns EEXIST, which lets dpif_create_and_open()
+     * fall back to the open path unchanged.
+     *
+     * A per-switch alias class carries the switch identity (its GUID) in the
+     * class type, while its datapaths are named with the conventional
+     * "ovs-system"; resolve by the type so the right switch is selected
+     * regardless of the (cosmetic) name.  The base "system" class resolves by
+     * name, mapping the "system" suffix to the lowest datapath. */
+    const char *resolve_key =
+        strcmp(class->type, OVS_WINDOWS_DEFAULT_DP_TYPE) ? class->type : name;
+    error = dpif_windows_resolve_dp(&dpif->channel, resolve_key, &dp_ifindex,
                                     &dp_name);
     if (error) {
         ovsext_channel_close(&dpif->channel);
@@ -2077,7 +2094,7 @@ dpif_windows_recv_purge(struct dpif *dpif_)
  * ==================================================================== */
 
 const struct dpif_class dpif_windows_class = {
-    .type = "windows",
+    .type = OVS_WINDOWS_DEFAULT_DP_TYPE,
     .cleanup_required = false,
     .enumerate = dpif_windows_enumerate,
     .open = dpif_windows_open,

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1025,6 +1025,41 @@ dpif_windows_register_switch_type(const char *type)
     return 0;
 }
 
+/* Registers a per-switch alias of 'dpif_windows_class' for every Hyper-V switch
+ * the kernel currently exposes a datapath for.  ofproto resolves a bridge's
+ * datapath_type by enumerating registered dpif types before opening a backer,
+ * so the switch-GUID types must be registered up front (lazy registration at
+ * open time would be rejected earlier as an "unknown datapath type").  Already
+ * registered types are skipped; failures are non-fatal. */
+void
+dpif_windows_register_all_switch_types(void)
+{
+    struct dpif_windows_dp_entry entries[DPIF_WINDOWS_MAX_DPS];
+    struct ovsext_channel channel;
+    int n, i;
+
+    if (ovsext_channel_open(&channel)) {
+        return;
+    }
+    n = dpif_windows_dump_dps(&channel, entries, ARRAY_SIZE(entries));
+    ovsext_channel_close(&channel);
+
+    for (i = 0; i < n; i++) {
+        struct dpif_class *alias;
+
+        if (!entries[i].name[0] || dp_class_is_registered(entries[i].name)) {
+            continue;
+        }
+        /* Any registration failure just means we free the unused alias. */
+        alias = xmemdup(&dpif_windows_class, sizeof dpif_windows_class);
+        alias->type = xstrdup(entries[i].name);
+        if (dp_register_provider(alias)) {
+            free(CONST_CAST(char *, alias->type));
+            free(alias);
+        }
+    }
+}
+
 static int
 dpif_windows_open(const struct dpif_class *class, const char *name,
                   bool create, struct dpif **dpifp)

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -78,6 +78,12 @@ static struct vlog_rate_limit error_rl = VLOG_RATE_LIMIT_INIT(9999, 5);
  * the resolver buffers are sized accordingly. */
 #define OVS_DP_NAME_MAX 64
 
+/* The kernel addresses datapaths by dp_ifindex; for the OVS_DP_ATTR_NAME on the
+ * wire it accepts only this fixed name (any other is rejected with NODEV). We
+ * resolve the caller's name to a dp_ifindex via DP_DUMP, then target that
+ * dp_ifindex while sending this fixed name. */
+#define OVS_WINDOWS_KERNEL_DP_NAME "ovs-system"
+
 /* Upper bound on datapaths to enumerate when resolving a name; matches the
  * driver's OVS_MAX_DATAPATHS. */
 #define DPIF_WINDOWS_MAX_DPS 16
@@ -242,7 +248,7 @@ dpif_windows_dp_get(struct dpif_windows *dpif, struct dpif_windows_dp *reply,
     dpif_windows_dp_init(&request);
     request.cmd = OVS_DP_CMD_GET;
     request.dp_ifindex = dpif->dp_ifindex;
-    request.name = dpif->dp_name;
+    request.name = OVS_WINDOWS_KERNEL_DP_NAME;
 
     return dpif_windows_dp_transact(dpif, &request, reply, bufp);
 }
@@ -835,12 +841,24 @@ dpif_windows_enumerate(struct sset *all_dps,
     ovsext_dump_start(&dump, &channel, buf);
     ofpbuf_delete(buf);
 
+    bool any = false;
     while (ovsext_dump_next(&dump, &msg)) {
         struct dpif_windows_dp dp;
 
         if (!dpif_windows_dp_from_ofpbuf(&dp, &msg)) {
             sset_add(all_dps, dp.name);
+            any = true;
         }
+    }
+
+    /* The kernel now names each datapath by its switch GUID, but ofproto opens
+     * its backer as "ovs-<datapath_type>" and dp_exists() checks this set for
+     * "ovs-system"/"ovs-windows".  Keep those default aliases resolvable as long
+     * as at least one datapath exists; dpif_windows_open maps them to the
+     * lowest-numbered datapath. */
+    if (any) {
+        sset_add(all_dps, "ovs-windows");
+        sset_add(all_dps, "ovs-system");
     }
 
     error = ovsext_dump_done(&dump);
@@ -980,7 +998,7 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     dpif_windows_dp_init(&dp_request);
     upcall_pid = dpif->channel.pid;
     dp_request.upcall_pid = &upcall_pid;
-    dp_request.name = dp_name;
+    dp_request.name = OVS_WINDOWS_KERNEL_DP_NAME;
     dp_request.dp_ifindex = dp_ifindex;
     dp_request.cmd = create ? OVS_DP_CMD_NEW : OVS_DP_CMD_GET;
 

--- a/lib/dpif.c
+++ b/lib/dpif.c
@@ -250,6 +250,14 @@ dp_enumerate_types(struct sset *types)
 
     dp_initialize();
 
+#ifdef _WIN32
+    /* The ovsext kernel backs one datapath per Hyper-V switch (named by the
+     * switch GUID).  Register a windows dpif provider alias for each so that a
+     * bridge's datapath_type=<switch-guid> is a known type here, before ofproto
+     * resolves it.  Done outside dpif_mutex (registration takes it itself). */
+    dpif_windows_register_all_switch_types();
+#endif
+
     ovs_mutex_lock(&dpif_mutex);
     SHASH_FOR_EACH(node, &dpif_classes) {
         const struct registered_dpif_class *registered_class = node->data;
@@ -280,6 +288,20 @@ dp_class_lookup(const char *type)
     ovs_mutex_unlock(&dpif_mutex);
 
     return rc;
+}
+
+/* Returns true if a datapath provider of the given 'type' is registered.  Does
+ * not take a reference. */
+bool
+dp_class_is_registered(const char *type)
+{
+    bool registered;
+
+    ovs_mutex_lock(&dpif_mutex);
+    registered = shash_find(&dpif_classes, type) != NULL;
+    ovs_mutex_unlock(&dpif_mutex);
+
+    return registered;
 }
 
 /* Clears 'names' and enumerates the names of all known created datapaths with

--- a/lib/dpif.c
+++ b/lib/dpif.c
@@ -349,6 +349,17 @@ do_open(const char *name, const char *type, bool create, struct dpif **dpifp)
 
     type = dpif_normalize_type(type);
     registered_class = dp_class_lookup(type);
+#ifdef _WIN32
+    if (!registered_class) {
+        /* On Windows the ovsext kernel backs one datapath per Hyper-V switch,
+         * named by the switch GUID.  A bridge may select a specific switch with
+         * datapath_type=<switch-guid>; register a windows dpif provider alias
+         * for that GUID on demand so the backer can be opened. */
+        if (!dpif_windows_register_switch_type(type)) {
+            registered_class = dp_class_lookup(type);
+        }
+    }
+#endif
     if (!registered_class) {
         VLOG_WARN("could not create datapath %s of unknown type %s", name,
                   type);

--- a/lib/dpif.h
+++ b/lib/dpif.h
@@ -401,6 +401,7 @@ struct nlattr;
 struct sset;
 
 int dp_register_provider(const struct dpif_class *);
+bool dp_class_is_registered(const char *type);
 int dp_unregister_provider(const char *type);
 void dp_disallow_provider(const char *type);
 void dp_enumerate_types(struct sset *types);

--- a/lib/wmi.c
+++ b/lib/wmi.c
@@ -328,7 +328,7 @@ get_first_element(IEnumWbemClassObject *penumerate,
 
 /* This function is a wrapper that transforms a char * into a wchar_t * */
 static boolean
-tranform_wide(char *name, wchar_t *wide_name)
+tranform_wide(const char *name, wchar_t *wide_name)
 {
     unsigned long size = strlen(name) + 1;
     long long ret = 0;
@@ -739,7 +739,7 @@ create_wmi_port(char *name, const char *switch_id) {
     if (target_switch) {
         /* Target the bridge's specific Hyper-V switch by its GUID. */
         wide_switch = xmalloc((strlen(target_switch) + 1) * sizeof(wchar_t));
-        if (!tranform_wide(CONST_CAST(char *, target_switch), wide_switch)) {
+        if (!tranform_wide(target_switch, wide_switch)) {
             retval = false;
             goto error;
         }
@@ -818,8 +818,7 @@ create_wmi_port(char *name, const char *switch_id) {
     }
 
     if (!get_first_element(penumerate, &pcls_obj)) {
-        VLOG_WARN("Could not get the switch object on which the extension is"
-                  "activated");
+        VLOG_WARN("Could not find the target Hyper-V switch object");
         retval = false;
         goto error;
     }

--- a/lib/wmi.c
+++ b/lib/wmi.c
@@ -629,12 +629,17 @@ error:
  * executing the method AddResourceSettings as per documentation:
  * https://msdn.microsoft.com/en-us/library/hh850019%28v=vs.85%29.aspx.
  * It will verify if the port is already defined, in which case it will use
- * the specific port, and if the forwarding extension "Open vSwitch Extension"
- * is enabled and running only on a single switch.
+ * the specific port.
+ * 'switch_id' selects the target virtual switch by its GUID
+ * (Msvm_VirtualEthernetSwitch.Name): the ovsext kernel backs one datapath per
+ * Hyper-V switch and the bridge's datapath carries its switch identity, so the
+ * internal port must be created on that exact switch.  When 'switch_id' is NULL
+ * (or a default alias) the legacy behaviour is used: the single switch on which
+ * the forwarding extension is enabled and running, aborting if more than one.
  * After the port is created and bound to the switch we will disable the
  * created net adapter and rename it to match the OVS bridge name .*/
 boolean
-create_wmi_port(char *name) {
+create_wmi_port(char *name, const char *switch_id) {
     HRESULT hres = 0;
     boolean retval = true;
 
@@ -654,6 +659,8 @@ create_wmi_port(char *name) {
     IWbemClassObject *pout_params = NULL;
 
     wchar_t *wide_name = NULL;
+    wchar_t *wide_switch = NULL;
+    const char *target_switch = NULL;
     VARIANT vt_prop;
     VARIANT switch_setting_path;
     VARIANT new_name;
@@ -664,6 +671,14 @@ create_wmi_port(char *name) {
     VariantInit(&vt_prop);
     VariantInit(&switch_setting_path);
     sanitize_port_name(name);
+
+    /* A concrete switch GUID selects that switch directly; a default alias
+     * ("ovs-system"/"ovs-windows") or NULL falls back to extension discovery. */
+    if (switch_id && switch_id[0]
+        && strcmp(switch_id, "ovs-system")
+        && strcmp(switch_id, "ovs-windows")) {
+        target_switch = switch_id;
+    }
 
     if (psa == NULL) {
         VLOG_WARN("Could not allocate memory for a SAFEARRAY");
@@ -718,63 +733,76 @@ create_wmi_port(char *name) {
     penumerate->lpVtbl->Release(penumerate);
     penumerate = NULL;
 
-    /* Check if the extension is enabled and running.  Also check if the
-     * the extension is enabled on more than one switch. */
-    hres = psvc->lpVtbl->ExecQuery(psvc,
-                                   L"WQL",
-                                   L"SELECT * "
-                                   L"FROM Msvm_EthernetSwitchExtension "
-                                   L"WHERE "
-                                   L"ElementName=\"dbosoft Open vSwitch Extension\" "
-                                   L"AND EnabledState=2 "
-                                   L"AND HealthState=5",
-                                   WBEM_FLAG_FORWARD_ONLY |
-                                   WBEM_FLAG_RETURN_IMMEDIATELY,
-                                   NULL,
-                                   &penumerate);
-
-    if (FAILED(hres)) {
-        retval = false;
-        goto error;
-    }
-
-    if (!get_first_element(penumerate, &pcls_obj)) {
-        VLOG_WARN("dbosoft Open vSwitch Extension is not enabled on any switch");
-        retval = false;
-        goto error;
-    }
     wcscpy_s(internal_port_query, WMI_QUERY_COUNT,
              L"SELECT * FROM Msvm_VirtualEthernetSwitch WHERE Name = \"");
 
-    hres = pcls_obj->lpVtbl->Get(pcls_obj, L"SystemName", 0,
-                                 &vt_prop, 0, 0);
-    if (FAILED(hres)) {
-        retval = false;
-        goto error;
-    }
+    if (target_switch) {
+        /* Target the bridge's specific Hyper-V switch by its GUID. */
+        wide_switch = xmalloc((strlen(target_switch) + 1) * sizeof(wchar_t));
+        if (!tranform_wide(CONST_CAST(char *, target_switch), wide_switch)) {
+            retval = false;
+            goto error;
+        }
+        wcscat_s(internal_port_query, WMI_QUERY_COUNT, wide_switch);
+    } else {
+        /* No specific switch requested: fall back to the single switch on which
+         * the forwarding extension is enabled and running, aborting if it is
+         * enabled on more than one. */
+        hres = psvc->lpVtbl->ExecQuery(psvc,
+                                       L"WQL",
+                                       L"SELECT * "
+                                       L"FROM Msvm_EthernetSwitchExtension "
+                                       L"WHERE "
+                                       L"ElementName=\"dbosoft Open vSwitch Extension\" "
+                                       L"AND EnabledState=2 "
+                                       L"AND HealthState=5",
+                                       WBEM_FLAG_FORWARD_ONLY |
+                                       WBEM_FLAG_RETURN_IMMEDIATELY,
+                                       NULL,
+                                       &penumerate);
 
-    wcscat_s(internal_port_query, WMI_QUERY_COUNT,
-             vt_prop.bstrVal);
+        if (FAILED(hres)) {
+            retval = false;
+            goto error;
+        }
 
-    VariantClear(&vt_prop);
-    pcls_obj->lpVtbl->Release(pcls_obj);
-    pcls_obj = NULL;
+        if (!get_first_element(penumerate, &pcls_obj)) {
+            VLOG_WARN("dbosoft Open vSwitch Extension is not enabled on any "
+                      "switch");
+            retval = false;
+            goto error;
+        }
 
-    if (get_first_element(penumerate, &pcls_obj)) {
-        VLOG_WARN("The extension is activated on more than one switch, "
-                  "aborting operation. Please activate the extension on a "
-                  "single switch");
-        retval = false;
-        goto error;
-    }
-    penumerate->lpVtbl->Release(penumerate);
-    penumerate = NULL;
-    if (pcls_obj != NULL) {
+        hres = pcls_obj->lpVtbl->Get(pcls_obj, L"SystemName", 0,
+                                     &vt_prop, 0, 0);
+        if (FAILED(hres)) {
+            retval = false;
+            goto error;
+        }
+
+        wcscat_s(internal_port_query, WMI_QUERY_COUNT,
+                 vt_prop.bstrVal);
+
+        VariantClear(&vt_prop);
         pcls_obj->lpVtbl->Release(pcls_obj);
         pcls_obj = NULL;
+
+        if (get_first_element(penumerate, &pcls_obj)) {
+            VLOG_WARN("The extension is activated on more than one switch, "
+                      "aborting operation. Please activate the extension on a "
+                      "single switch");
+            retval = false;
+            goto error;
+        }
+        penumerate->lpVtbl->Release(penumerate);
+        penumerate = NULL;
+        if (pcls_obj != NULL) {
+            pcls_obj->lpVtbl->Release(pcls_obj);
+            pcls_obj = NULL;
+        }
     }
 
-    /* Get the switch object on which the extension is activated. */
+    /* Get the switch object selected above. */
     wcscat_s(internal_port_query, WMI_QUERY_COUNT, L"\"");
     hres = psvc->lpVtbl->ExecQuery(psvc,
                                    L"WQL",
@@ -1260,6 +1288,10 @@ error:
     if (wide_name != NULL) {
         free(wide_name);
         wide_name = NULL;
+    }
+    if (wide_switch != NULL) {
+        free(wide_switch);
+        wide_switch = NULL;
     }
     VariantClear(&vt_prop);
     VariantClear(&switch_setting_path);

--- a/lib/wmi.h
+++ b/lib/wmi.h
@@ -45,7 +45,11 @@ static inline void fill_context(IWbemContext *pContext)
     VariantClear(&var);
 }
 
-boolean create_wmi_port(char *name);
+/* Creates a Hyper-V internal port named 'name'. 'switch_id' selects the target
+ * virtual switch by its GUID (Msvm_VirtualEthernetSwitch.Name); pass NULL (or a
+ * default alias like "ovs-system") to fall back to the single switch that has
+ * the forwarding extension enabled. */
+boolean create_wmi_port(char *name, const char *switch_id);
 boolean delete_wmi_port(char *name);
 
 #endif /* wmi.h */

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -275,9 +275,9 @@ main(int argc, char *argv[])
     memset(&mock, 0, sizeof mock);
     ovsext_set_transport(&mock_transport);
 
-    error = dpif_open("ovs-system", "windows", &dpif);
+    error = dpif_open("ovs-system", "system", &dpif);
     if (error) {
-        fprintf(stderr, "dpif_open(windows) failed: %s\n", ovs_strerror(error));
+        fprintf(stderr, "dpif_open(system) failed: %s\n", ovs_strerror(error));
         return 1;
     }
     printf("dpif_open ok (%s)\n", dpif_name(dpif));


### PR DESCRIPTION
Modernizes the Windows `ovsext` forwarding extension so it can back **multiple Hyper-V switches** (one datapath per switch, L2) instead of a single hardcoded datapath, and replaces the faked netlink transport with a native Windows dpif provider.

### Kernel (datapath-windows/ovsext)
- Datapath registry with per-context refcounts; every IOCTL/netlink request resolves its datapath from `dp_ifindex` into the switch context and threads it through the flow/vport/packet handlers (previously a `gOvsSwitchContext` singleton with `dpNo` hardcoded to 0).
- Each datapath is named by its Hyper-V switch GUID; `DP_GET` dumps all datapaths; the single-attach reject is removed so the extension attaches to N switches.
- Host-global singletons (tunnel WFP filter, IP helper, conntrack, fragment reassembly, meters) are lifted from per-attach to driver load, so a second attach can't double-init them.
- On detach of the default datapath the next live datapath is **promoted** instead of leaving the anchor dangling; the upcall pid-hash is made driver-global so promotion can't orphan subscribed queues.

### Userspace (lib)
- Native `dpif-windows` provider talks to the kernel over the IOCTL/netlink transport; resolves a bridge's `datapath_type` to a kernel datapath. A bridge selects a specific switch with `datapath_type=<switch-guid>` (per-switch dpif class registered on demand); the base type is `"system"` (matching Linux, and fixing a default-bridge resolution bug). `ovs-dpctl show` reads `<type>@ovs-system`.
- `create_wmi_port` targets the bridge's own Hyper-V switch by GUID.
- Fixes the "vswitchd restart wedges until reboot" bug by re-stamping upcall pids on existing vports in `recv_set`, like dpif-netlink.
