### PR TITLE
datapath-windows: NDIS 6.60/6.85 dual-binary modernization

### DIFF
--- a/datapath-windows/build-driver.ps1
+++ b/datapath-windows/build-driver.ps1
@@ -27,6 +27,10 @@ param(
     # Dev DriverVer must outrank the eryph-shipped 3.3.90 in the test VM so
     # pnputil/PnP prefers our build when superseding the installed extension.
     [string]$Version = '3.99.0.0',
+    # NDIS contract for the Win10 configs. Empty = the vcxproj default (660, the
+    # floor binary). Set to 685 for the modern Server-2022/Win11 feature binary.
+    [ValidateSet('', '660', '670', '680', '681', '682', '683', '684', '685')]
+    [string]$NdisLevel = '',
     [switch]$Rebuild
 )
 
@@ -54,6 +58,7 @@ $msbuildArgs = @(
     '-m'
     '-nologo'
 )
+if ($NdisLevel) { $msbuildArgs += "-p:OvsNdisLevel=$NdisLevel" }
 
 & $msbuild @msbuildArgs
 

--- a/datapath-windows/build-driver.ps1
+++ b/datapath-windows/build-driver.ps1
@@ -3,15 +3,16 @@
   Dev build for the dbosoft OVS Hyper-V forwarding extension (DBO_OVSE.sys).
 
 .DESCRIPTION
-  Wraps the MSBuild invocation with the two settings the WDK 10.0.26100 build
-  on this machine needs:
-    -p:Version=...                a concrete DriverVer version, because the
-                                  vcxproj's <Inf><TimeStamp>$(Version)</TimeStamp>
-                                  is empty and stampinf.exe rejects an empty -v.
+  Wraps the MSBuild invocation with the setting the WDK 10.0.26100 build on this
+  machine needs:
     -p:SkipPackageVerification    skips the DPVerifier/InfVerif step, whose x86
                                   InfVerif.dll is not present in this WDK install.
                                   (Verification is a packaging lint, not a build
                                   or signing requirement.)
+
+  The DriverVer version is no longer injected here: the vcxproj derives it from
+  the OVS source version in configure.ac (AC_INIT). Pass -Version only to
+  override (e.g. a dev build that must outrank an already-installed driver).
 
   Produces a test-signed package under:
     ovsext\x64\<Config>\package\   and   x64\<Config>\package\
@@ -24,9 +25,10 @@
 param(
     [ValidateSet('Win10Debug', 'Win10Release')]
     [string]$Config = 'Win10Debug',
-    # Dev DriverVer must outrank the eryph-shipped 3.3.90 in the test VM so
-    # pnputil/PnP prefers our build when superseding the installed extension.
-    [string]$Version = '3.99.0.0',
+    # DriverVer version. Empty => the vcxproj derives it from the OVS source
+    # version in configure.ac (AC_INIT). Override only for a dev build that must
+    # outrank an already-installed driver via pnputil/PnP ranking.
+    [string]$Version = '',
     # NDIS contract for the Win10 configs. Empty = the vcxproj default (660, the
     # floor binary). Set to 685 for the modern Server-2022/Win11 feature binary.
     [ValidateSet('', '660', '670', '680', '681', '682', '683', '684', '685')]
@@ -53,11 +55,11 @@ $msbuildArgs = @(
     "-t:$target"
     "-p:Configuration=$Config"
     '-p:Platform=x64'
-    "-p:Version=$Version"
     '-p:SkipPackageVerification=true'
     '-m'
     '-nologo'
 )
+if ($Version)   { $msbuildArgs += "-p:Version=$Version" }
 if ($NdisLevel) { $msbuildArgs += "-p:OvsNdisLevel=$NdisLevel" }
 
 & $msbuild @msbuildArgs

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -113,8 +113,22 @@ DriverEntry(PDRIVER_OBJECT driverObject,
 
     RtlZeroMemory(&driverChars, sizeof driverChars);
     driverChars.Header.Type = NDIS_OBJECT_TYPE_FILTER_DRIVER_CHARACTERISTICS;
-    driverChars.Header.Size = sizeof driverChars;
+    /*
+     * The characteristics revision must match the declared NDIS version. NDIS
+     * requires filters declaring MinorNdisVersion >= 80 to present REVISION_3
+     * (which carries the synchronous-OID handler slots); registering a lower
+     * revision at that contract is rejected (surfaces as "Access is denied").
+     * Older contracts use REVISION_2. The synchronous-OID handlers are left
+     * NULL above by RtlZeroMemory, which is valid - this filter has no
+     * synchronous-OID path. Size must always match the declared revision.
+     */
+#if (NDIS_SUPPORT_NDIS680)
+    driverChars.Header.Revision = NDIS_FILTER_CHARACTERISTICS_REVISION_3;
+    driverChars.Header.Size = NDIS_SIZEOF_FILTER_DRIVER_CHARACTERISTICS_REVISION_3;
+#else
     driverChars.Header.Revision = NDIS_FILTER_CHARACTERISTICS_REVISION_2;
+    driverChars.Header.Size = NDIS_SIZEOF_FILTER_DRIVER_CHARACTERISTICS_REVISION_2;
+#endif
     driverChars.MajorNdisVersion = NDIS_FILTER_MAJOR_VERSION;
     driverChars.MinorNdisVersion = NDIS_FILTER_MINOR_VERSION;
     driverChars.MajorDriverVersion = 1;

--- a/datapath-windows/ovsext/ovsext.vcxproj
+++ b/datapath-windows/ovsext/ovsext.vcxproj
@@ -121,7 +121,7 @@
     <!-- NDIS contract level for the Win10 configs. Overridable on the command
          line (-p:OvsNdisLevel=685) to produce a higher-contract binary; the
          declared NDIS version is a hard load-floor, so we ship one binary per
-         supported floor (660 = Server 2016+, 685 = Server 2019+/Win10 21H2). -->
+         supported floor (660 = Server 2016 and up, 685 = Server 2022 / Win11). -->
     <OvsNdisLevel Condition="'$(OvsNdisLevel)'==''">660</OvsNdisLevel>
     <!-- DriverVer / FILEVERSION version. When not supplied on the command line
          (-p:Version=x.y.z.w), derive it from the OVS source version in
@@ -132,7 +132,7 @@
          driver can still override with -p:Version. -->
     <OvsConfigureAc>$(MSBuildThisFileDirectory)..\..\configure.ac</OvsConfigureAc>
     <OvsAcText Condition="Exists('$(OvsConfigureAc)')">$([System.IO.File]::ReadAllText($(OvsConfigureAc)))</OvsAcText>
-    <OvsSourceVersion Condition="'$(OvsAcText)' != ''">$([System.Text.RegularExpressions.Regex]::Match($(OvsAcText), `(?&lt;=AC_INIT\(openvswitch,\s*)\d+\.\d+\.\d+`))</OvsSourceVersion>
+    <OvsSourceVersion Condition="'$(OvsAcText)' != ''">$([System.Text.RegularExpressions.Regex]::Match(`$(OvsAcText)`, `(?&lt;=AC_INIT\(openvswitch,\s*)\d+\.\d+\.\d+`))</OvsSourceVersion>
     <Version Condition="'$(Version)' == '' and '$(OvsSourceVersion)' != ''">$(OvsSourceVersion).0</Version>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">

--- a/datapath-windows/ovsext/ovsext.vcxproj
+++ b/datapath-windows/ovsext/ovsext.vcxproj
@@ -131,7 +131,7 @@
          reject the INF). A dev build that must outrank an already-installed
          driver can still override with -p:Version. -->
     <OvsConfigureAc>$(MSBuildThisFileDirectory)..\..\configure.ac</OvsConfigureAc>
-    <OvsAcText Condition="Exists('$(OvsConfigureAc)')">$([System.IO.File]::ReadAllText($(OvsConfigureAc)))</OvsAcText>
+    <OvsAcText Condition="Exists('$(OvsConfigureAc)')">$([System.IO.File]::ReadAllText('$(OvsConfigureAc)'))</OvsAcText>
     <OvsSourceVersion Condition="'$(OvsAcText)' != ''">$([System.Text.RegularExpressions.Regex]::Match(`$(OvsAcText)`, `(?&lt;=AC_INIT\(openvswitch,\s*)\d+\.\d+\.\d+`))</OvsSourceVersion>
     <Version Condition="'$(Version)' == '' and '$(OvsSourceVersion)' != ''">$(OvsSourceVersion).0</Version>
   </PropertyGroup>

--- a/datapath-windows/ovsext/ovsext.vcxproj
+++ b/datapath-windows/ovsext/ovsext.vcxproj
@@ -118,6 +118,11 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
     <OutDir>$(IntDir)</OutDir>
+    <!-- NDIS contract level for the Win10 configs. Overridable on the command
+         line (-p:OvsNdisLevel=685) to produce a higher-contract binary; the
+         declared NDIS version is a hard load-floor, so we ship one binary per
+         supported floor (660 = Server 2016+, 685 = Server 2019+/Win10 21H2). -->
+    <OvsNdisLevel Condition="'$(OvsNdisLevel)'==''">660</OvsNdisLevel>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
@@ -252,13 +257,13 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ClCompile>
     <Midl>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </Midl>
     <ResourceCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|x64'">
@@ -307,24 +312,24 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ClCompile>
     <Midl>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </Midl>
     <ResourceCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10Analyze|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ClCompile>
     <Midl>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </Midl>
     <ResourceCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
@@ -440,9 +445,9 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win8.1 Release|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win8.1 Debug|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win8.1Analyze|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10Analyze|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS640=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Win10Analyze|x64'">%(PreprocessorDefinitions);NDIS_WDM=1;NDIS$(OvsNdisLevel)=1;VersionWithDots=$(Version);VersionWithCommas=$(Version.Replace('.',','))</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>

--- a/datapath-windows/ovsext/ovsext.vcxproj
+++ b/datapath-windows/ovsext/ovsext.vcxproj
@@ -123,6 +123,17 @@
          declared NDIS version is a hard load-floor, so we ship one binary per
          supported floor (660 = Server 2016+, 685 = Server 2019+/Win10 21H2). -->
     <OvsNdisLevel Condition="'$(OvsNdisLevel)'==''">660</OvsNdisLevel>
+    <!-- DriverVer / FILEVERSION version. When not supplied on the command line
+         (-p:Version=x.y.z.w), derive it from the OVS source version in
+         configure.ac (AC_INIT) so a plain MSBuild / Visual Studio build is
+         stamped correctly without anyone having to inject it. This replaces the
+         easy-to-forget external injection (an empty version makes stampinf
+         reject the INF). A dev build that must outrank an already-installed
+         driver can still override with -p:Version. -->
+    <OvsConfigureAc>$(MSBuildThisFileDirectory)..\..\configure.ac</OvsConfigureAc>
+    <OvsAcText Condition="Exists('$(OvsConfigureAc)')">$([System.IO.File]::ReadAllText($(OvsConfigureAc)))</OvsAcText>
+    <OvsSourceVersion Condition="'$(OvsAcText)' != ''">$([System.Text.RegularExpressions.Regex]::Match($(OvsAcText), `(?&lt;=AC_INIT\(openvswitch,\s*)\d+\.\d+\.\d+`))</OvsSourceVersion>
+    <Version Condition="'$(Version)' == '' and '$(OvsSourceVersion)' != ''">$(OvsSourceVersion).0</Version>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />

--- a/datapath-windows/package-dual.ps1
+++ b/datapath-windows/package-dual.ps1
@@ -112,5 +112,7 @@ if ($LASTEXITCODE) { throw "signtool sign DBO_OVSE.cat failed ($LASTEXITCODE)" }
 Write-Host "`n== Package ==" -ForegroundColor Green
 Get-ChildItem $pkg | Select-Object Name, Length, LastWriteTime
 & $signtool verify /pa /c (Join-Path $pkg 'DBO_OVSE.cat') (Join-Path $pkg 'DBO_OVSE.sys')
+if ($LASTEXITCODE) { throw "catalog verify failed for DBO_OVSE.sys ($LASTEXITCODE)" }
 & $signtool verify /pa /c (Join-Path $pkg 'DBO_OVSE.cat') (Join-Path $pkg 'DBO_OVSE60.sys')
+if ($LASTEXITCODE) { throw "catalog verify failed for DBO_OVSE60.sys ($LASTEXITCODE)" }
 Write-Host "`nDual-binary package: $pkg" -ForegroundColor Green

--- a/datapath-windows/package-dual.ps1
+++ b/datapath-windows/package-dual.ps1
@@ -50,9 +50,13 @@ Write-Host "Signing cert: $($cert.Subject) [$thumb]" -ForegroundColor DarkGray
 Write-Host "`n== Building NDIS 6.60 floor ($cfg) ==" -ForegroundColor Cyan
 & (Join-Path $here 'build-driver.ps1') -Config $cfg -NdisLevel 660 -Version $Version -Rebuild
 if ($LASTEXITCODE) { throw 'floor build failed' }
-$floorSys = Join-Path $here "x64\$cfg\package\DBO_OVSE.sys"
-$floorTmp = Join-Path $here "x64\$cfg\DBO_OVSE60.sys"
-Copy-Item $floorSys $floorTmp -Force   # stash before the modern build overwrites it
+$floorSys    = Join-Path $here "x64\$cfg\package\DBO_OVSE.sys"
+$floorPdb    = Join-Path $here "ovsext\x64\$cfg\DBO_OVSE.pdb"
+$floorSysTmp = Join-Path $here "x64\$cfg\DBO_OVSE60.sys"
+$floorPdbTmp = Join-Path $here "x64\$cfg\DBO_OVSE60.pdb"
+# Stash the floor binary + symbols before the modern build overwrites them.
+Copy-Item $floorSys $floorSysTmp -Force
+Copy-Item $floorPdb $floorPdbTmp -Force
 
 Write-Host "`n== Building NDIS 6.85 modern ($cfg) ==" -ForegroundColor Cyan
 & (Join-Path $here 'build-driver.ps1') -Config $cfg -NdisLevel 685 -Version $Version -Rebuild
@@ -64,8 +68,14 @@ $pkg = Join-Path $here "x64\dual-$Config\package"
 if (Test-Path $pkg) { Remove-Item $pkg -Recurse -Force }
 New-Item -ItemType Directory -Force $pkg | Out-Null
 Copy-Item $modernSys (Join-Path $pkg 'DBO_OVSE.sys')   -Force   # 6.85 modern
-Copy-Item $floorTmp  (Join-Path $pkg 'DBO_OVSE60.sys') -Force   # 6.60 floor
+Copy-Item $floorSysTmp (Join-Path $pkg 'DBO_OVSE60.sys') -Force # 6.60 floor
 Copy-Item (Join-Path $here 'packaging\ovsext-dual.inf') (Join-Path $pkg 'ovsext.inf') -Force
+# Symbols + the test certificate, so this dir is a complete driver/ staging set
+# that build-ovn-package.ps1 can consume verbatim.
+Copy-Item (Join-Path $here "ovsext\x64\$cfg\DBO_OVSE.pdb") (Join-Path $pkg 'DBO_OVSE.pdb')   -Force
+Copy-Item $floorPdbTmp                                     (Join-Path $pkg 'DBO_OVSE60.pdb') -Force
+$cer = Join-Path $here "x64\$cfg\package.cer"
+if (Test-Path $cer) { Copy-Item $cer (Join-Path $pkg 'package.cer') -Force }
 
 # 3. Stamp the INF version, embed-sign both binaries, catalog, sign the catalog.
 & $stampinf -f (Join-Path $pkg 'ovsext.inf') -d '*' -v $Version

--- a/datapath-windows/package-dual.ps1
+++ b/datapath-windows/package-dual.ps1
@@ -93,15 +93,20 @@ $cer = Join-Path $here "x64\$cfg\package.cer"
 if (Test-Path $cer) { Copy-Item $cer (Join-Path $pkg 'package.cer') -Force }
 
 # 3. Stamp the INF version, embed-sign both binaries, catalog, sign the catalog.
+# Check every external tool: a silent failure here would leave an unstamped or
+# unsigned package that only fails much later (at install/load on the VM).
 & $stampinf -f (Join-Path $pkg 'ovsext.inf') -d '*' -v $Version
+if ($LASTEXITCODE) { throw "stampinf failed ($LASTEXITCODE)" }
 foreach ($s in 'DBO_OVSE.sys','DBO_OVSE60.sys') {
     & $signtool sign /fd SHA256 /sha1 $thumb /ph (Join-Path $pkg $s) | Out-Null
+    if ($LASTEXITCODE) { throw "signtool sign $s failed ($LASTEXITCODE)" }
 }
 
 $osTokens = '10_X64,Server2016_X64,ServerRS5_X64,10_VB_X64,ServerFE_X64,10_NI_X64,10_GE_X64,10_CO_X64'
 & $inf2cat "/driver:$pkg" "/os:$osTokens" /uselocaltime
 if ($LASTEXITCODE) { throw 'inf2cat failed' }
 & $signtool sign /fd SHA256 /sha1 $thumb /ph (Join-Path $pkg 'DBO_OVSE.cat')
+if ($LASTEXITCODE) { throw "signtool sign DBO_OVSE.cat failed ($LASTEXITCODE)" }
 
 # 4. Verify the catalog covers both binaries.
 Write-Host "`n== Package ==" -ForegroundColor Green

--- a/datapath-windows/package-dual.ps1
+++ b/datapath-windows/package-dual.ps1
@@ -22,12 +22,27 @@
 param(
     [ValidateSet('Release', 'Debug')]
     [string]$Config  = 'Release',
-    [string]$Version = '3.99.0.0'
+    # Empty => derive from the OVS source version in configure.ac (AC_INIT), the
+    # same source the vcxproj uses. Override only to force a specific DriverVer.
+    [string]$Version = ''
 )
 
 $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $cfg  = "Win10$Config"
+
+# Derive the DriverVer version from the OVS source (configure.ac) when not given,
+# so the INF stamp, both binaries and the catalog all carry the real version.
+if (-not $Version) {
+    $acPath = Join-Path $here '..\configure.ac'
+    $ac = Get-Content -Raw -LiteralPath $acPath
+    if ($ac -match 'AC_INIT\(openvswitch,\s*([0-9]+\.[0-9]+\.[0-9]+)') {
+        $Version = "$($Matches[1]).0"
+        Write-Host "Driver version derived from configure.ac: $Version" -ForegroundColor DarkGray
+    } else {
+        throw "Could not derive version from $acPath (no AC_INIT match); pass -Version."
+    }
+}
 
 # Locate the WDK signing/cataloging tools (x86 flavor, as the WDK build uses).
 $wdkBin = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Directory |

--- a/datapath-windows/package-dual.ps1
+++ b/datapath-windows/package-dual.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+  Build and package BOTH NDIS tiers of the dbosoft OVS forwarding extension into a
+  single OS-decorated driver package (test-signed).
+
+.DESCRIPTION
+  Produces one driver package whose INF (packaging\ovsext-dual.inf) installs:
+    * DBO_OVSE.sys   - NDIS 6.85 "modern" binary - on Server 2022 / Windows 11
+    * DBO_OVSE60.sys - NDIS 6.60 "floor"  binary - on older Windows
+
+  Steps: build each tier with build-driver.ps1 -NdisLevel, stage both .sys under
+  distinct names, stamp + catalog (inf2cat) + test-sign the package.
+
+  This is the shippable artifact; the per-config build (build-driver.ps1) still
+  produces single-binary dev packages used by deploy-driver.ps1.
+
+.EXAMPLE
+  pwsh -File package-dual.ps1
+  pwsh -File package-dual.ps1 -Config Release -Version 3.99.0.0
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Release', 'Debug')]
+    [string]$Config  = 'Release',
+    [string]$Version = '3.99.0.0'
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$cfg  = "Win10$Config"
+
+# Locate the WDK signing/cataloging tools (x86 flavor, as the WDK build uses).
+$wdkBin = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Directory |
+    Where-Object { Test-Path (Join-Path $_.FullName 'x86\inf2cat.exe') } |
+    Sort-Object Name -Descending | Select-Object -First 1
+if (-not $wdkBin) { throw 'No WDK bin with inf2cat.exe found.' }
+$inf2cat  = Join-Path $wdkBin.FullName 'x86\inf2cat.exe'
+$stampinf = Join-Path $wdkBin.FullName 'x86\stampinf.exe'
+$signtool = Join-Path $wdkBin.FullName 'x86\signtool.exe'
+Write-Host "WDK tools: $($wdkBin.Name)" -ForegroundColor DarkGray
+
+# Test-signing certificate (the WDK self-signed dev cert the per-config build uses).
+$cert = Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My |
+    Where-Object { $_.Subject -match 'WDKTestCert' } | Select-Object -First 1
+if (-not $cert) { throw 'WDKTestCert not found in CurrentUser\My or LocalMachine\My.' }
+$thumb = $cert.Thumbprint
+Write-Host "Signing cert: $($cert.Subject) [$thumb]" -ForegroundColor DarkGray
+
+# 1. Build both tiers.
+Write-Host "`n== Building NDIS 6.60 floor ($cfg) ==" -ForegroundColor Cyan
+& (Join-Path $here 'build-driver.ps1') -Config $cfg -NdisLevel 660 -Version $Version -Rebuild
+if ($LASTEXITCODE) { throw 'floor build failed' }
+$floorSys = Join-Path $here "x64\$cfg\package\DBO_OVSE.sys"
+$floorTmp = Join-Path $here "x64\$cfg\DBO_OVSE60.sys"
+Copy-Item $floorSys $floorTmp -Force   # stash before the modern build overwrites it
+
+Write-Host "`n== Building NDIS 6.85 modern ($cfg) ==" -ForegroundColor Cyan
+& (Join-Path $here 'build-driver.ps1') -Config $cfg -NdisLevel 685 -Version $Version -Rebuild
+if ($LASTEXITCODE) { throw 'modern build failed' }
+$modernSys = Join-Path $here "x64\$cfg\package\DBO_OVSE.sys"
+
+# 2. Assemble the combined package.
+$pkg = Join-Path $here "x64\dual-$Config\package"
+if (Test-Path $pkg) { Remove-Item $pkg -Recurse -Force }
+New-Item -ItemType Directory -Force $pkg | Out-Null
+Copy-Item $modernSys (Join-Path $pkg 'DBO_OVSE.sys')   -Force   # 6.85 modern
+Copy-Item $floorTmp  (Join-Path $pkg 'DBO_OVSE60.sys') -Force   # 6.60 floor
+Copy-Item (Join-Path $here 'packaging\ovsext-dual.inf') (Join-Path $pkg 'ovsext.inf') -Force
+
+# 3. Stamp the INF version, embed-sign both binaries, catalog, sign the catalog.
+& $stampinf -f (Join-Path $pkg 'ovsext.inf') -d '*' -v $Version
+foreach ($s in 'DBO_OVSE.sys','DBO_OVSE60.sys') {
+    & $signtool sign /fd SHA256 /sha1 $thumb /ph (Join-Path $pkg $s) | Out-Null
+}
+
+$osTokens = '10_X64,Server2016_X64,ServerRS5_X64,10_VB_X64,ServerFE_X64,10_NI_X64,10_GE_X64,10_CO_X64'
+& $inf2cat "/driver:$pkg" "/os:$osTokens" /uselocaltime
+if ($LASTEXITCODE) { throw 'inf2cat failed' }
+& $signtool sign /fd SHA256 /sha1 $thumb /ph (Join-Path $pkg 'DBO_OVSE.cat')
+
+# 4. Verify the catalog covers both binaries.
+Write-Host "`n== Package ==" -ForegroundColor Green
+Get-ChildItem $pkg | Select-Object Name, Length, LastWriteTime
+& $signtool verify /pa /c (Join-Path $pkg 'DBO_OVSE.cat') (Join-Path $pkg 'DBO_OVSE.sys')
+& $signtool verify /pa /c (Join-Path $pkg 'DBO_OVSE.cat') (Join-Path $pkg 'DBO_OVSE60.sys')
+Write-Host "`nDual-binary package: $pkg" -ForegroundColor Green

--- a/datapath-windows/packaging/ovsext-dual.inf
+++ b/datapath-windows/packaging/ovsext-dual.inf
@@ -1,0 +1,147 @@
+;
+; Copyright (c) dbosoft GmbH. All Rights Reserved.
+;
+; Dual-binary package for the dbosoft Open vSwitch forwarding extension.
+;
+; The declared NDIS version is a hard load-floor (a filter that declares a higher
+; MinorNdisVersion than the running OS fails NdisFRegisterFilterDriver), so each OS
+; is given the highest binary it can load:
+;   * Windows Server 2022 (build 20348) and Windows 11 (22000+) -> NDIS 6.85
+;     "modern" binary (DBO_OVSE.sys), run from the driver store (DIRID 13).
+;   * Windows 10 21H2 (19044) up to pre-2022 builds -> NDIS 6.60 "floor" binary
+;     (DBO_OVSE60.sys), run from the driver store (DIRID 13 works on 19044+).
+;   * Older (Windows Server 2016/2019, pre-21H2 Windows 10) -> NDIS 6.60 floor,
+;     copied to %systemroot%\system32\drivers (DIRID 12) because run-from-store
+;     service installation fails on Server 2019.
+;
+; Both binaries are built from one source tree via build-driver.ps1 -NdisLevel.
+;
+
+[version]
+Signature   = "$Windows NT$"
+Class       = NetService
+ClassGUID   = {4D36E974-E325-11CE-BFC1-08002BE10318}
+Provider    = %OVS%
+CatalogFile = DBO_OVSE.cat
+DriverVer   = 10/10/2013,1.0.0.0
+PnpLockdown = 1
+
+[Manufacturer]
+%OVS% = OVS, NTamd64.10.0...20348, NTamd64.10.0...19044, NTamd64
+
+; Windows Server 2022 (20348) and Windows 11 (22000+): NDIS 6.85 modern.
+[OVS.NTamd64.10.0...20348]
+%DBO_OVSE_Desc% = OVS_Modern, DBO_OVSE
+
+; Windows 10 21H2..pre-20348 (19044+): the 6.85 binary cannot load here; use the
+; 6.60 floor binary. Run-from-store (DIRID 13) works on 19044 and later.
+[OVS.NTamd64.10.0...19044]
+%DBO_OVSE_Desc% = OVS_Floor13, DBO_OVSE
+
+; Older (Windows Server 2016/2019, pre-21H2 Windows 10): 6.60 floor, DIRID 12.
+[OVS.NTamd64]
+%DBO_OVSE_Desc% = OVS_Floor12, DBO_OVSE
+
+[SourceDisksNames]
+1 = %DBO_OVSE_Desc%
+
+[SourceDisksFiles]
+DBO_OVSE.sys   = 1
+DBO_OVSE60.sys = 1
+
+[DestinationDirs]
+CF_Modern  = 13
+CF_Floor13 = 13
+CF_Floor12 = 12
+
+;------------------------------------------------------------------ Modern (6.85)
+[OVS_Modern]
+AddReg           = OVS_Ndi
+Characteristics  = 0x40000
+NetCfgInstanceId = "{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
+Copyfiles        = CF_Modern
+
+[CF_Modern]
+DBO_OVSE.sys,,,2
+
+[OVS_Modern.Services]
+AddService = DBO_OVSE,,Svc_Modern
+
+[Svc_Modern]
+DisplayName    = %DBO_OVSE_Desc%
+ServiceType    = 1 ;SERVICE_KERNEL_DRIVER
+StartType      = 1 ;SERVICE_SYSTEM_START
+ErrorControl   = 1 ;SERVICE_ERROR_NORMAL
+ServiceBinary  = %13%\DBO_OVSE.sys
+LoadOrderGroup = NDIS
+Description    = %DBO_OVSE_Desc%
+
+[OVS_Modern.Remove.Services]
+DelService = DBO_OVSE,0x200
+
+;------------------------------------------------------- Floor (6.60), run-from-store
+[OVS_Floor13]
+AddReg           = OVS_Ndi
+Characteristics  = 0x40000
+NetCfgInstanceId = "{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
+Copyfiles        = CF_Floor13
+
+[CF_Floor13]
+DBO_OVSE60.sys,,,2
+
+[OVS_Floor13.Services]
+AddService = DBO_OVSE,,Svc_Floor13
+
+[Svc_Floor13]
+DisplayName    = %DBO_OVSE_Desc%
+ServiceType    = 1
+StartType      = 1
+ErrorControl   = 1
+ServiceBinary  = %13%\DBO_OVSE60.sys
+LoadOrderGroup = NDIS
+Description    = %DBO_OVSE_Desc%
+
+[OVS_Floor13.Remove.Services]
+DelService = DBO_OVSE,0x200
+
+;-------------------------------------------------- Floor (6.60), system32\drivers
+[OVS_Floor12]
+AddReg           = OVS_Ndi
+Characteristics  = 0x40000
+NetCfgInstanceId = "{63E968D9-754E-4704-A5CE-6E3BF7DDF59B}"
+Copyfiles        = CF_Floor12
+
+[CF_Floor12]
+DBO_OVSE60.sys,,,2
+
+[OVS_Floor12.Services]
+AddService = DBO_OVSE,,Svc_Floor12
+
+[Svc_Floor12]
+DisplayName    = %DBO_OVSE_Desc%
+ServiceType    = 1
+StartType      = 1
+ErrorControl   = 1
+ServiceBinary  = %12%\DBO_OVSE60.sys
+LoadOrderGroup = NDIS
+Description    = %DBO_OVSE_Desc%
+
+[OVS_Floor12.Remove.Services]
+DelService = DBO_OVSE,0x200
+
+;------------------------------------------------------------------- Ndi (shared)
+[OVS_Ndi]
+HKR, Ndi,Service,,"DBO_OVSE"
+HKR, Ndi,CoServices,0x00010000,"DBO_OVSE"
+HKR, Ndi,HelpText,,%DBO_OVSE_HelpText%
+HKR, Ndi,FilterClass,,"ms_switch_forward"
+HKR, Ndi,FilterType,0x00010001,0x00000002
+HKR, Ndi\Interfaces,UpperRange,,"noupper"
+HKR, Ndi\Interfaces,LowerRange,,"nolower"
+HKR, Ndi\Interfaces,FilterMediaTypes,,"vmnetextension"
+HKR, Ndi,FilterRunType,0x00010001, 2 ; optional
+
+[Strings]
+OVS = "dbosoft GmbH"
+DBO_OVSE_Desc = "dbosoft Open vSwitch Extension"
+DBO_OVSE_HelpText = "Open vSwitch forwarding switch extension"


### PR DESCRIPTION
Modernize the Windows ovsext forwarding extension from the stale NDIS 6.40 contract to a dual-tier build, and stop relying on injected build metadata.

- The NDIS contract is now an MSBuild knob (`OvsNdisLevel`) producing two binaries: a 6.60 "floor" (Windows Server 2016 and up) and a 6.85 "modern" (Server 2022 / Windows 11). `packaging/ovsext-dual.inf` selects the right one per OS via decorated model sections; `package-dual.ps1` builds and signs both into one package.
- Fix driver load at NDIS >= 6.80: `DriverEntry` now presents `REVISION_3` filter characteristics. A filter that declares `MinorNdisVersion >= 80` while presenting a lower revision is rejected by `NdisFRegisterFilterDriver` and fails to load ("Access is denied").
- Derive `DriverVer` from the OVS source version in `configure.ac` (`AC_INIT`) instead of requiring `-p:Version`, so every build path is stamped automatically.
- L2 offload / RSS / VLAN / checksum / LSO NBL-metadata preservation reviewed and confirmed; RSS v2 and VMMQ negotiate through the modernized pass-through with no extra code.

Validated on Windows Server 2022: both tiers load, attach, and forward (0% loss). Hardware-offload throughput requires a physical-NIC host and is not exercised by the nested test VM.
