### PR TITLE
dpif-windows: fix packet-subscribe EINVAL after datapath detach-promote

### DIFF
--- a/datapath-windows/test-catlet/detach-promote-subscribe-repro.ps1
+++ b/datapath-windows/test-catlet/detach-promote-subscribe-repro.ps1
@@ -1,0 +1,89 @@
+# Focused repro for the detach-promote packet-subscribe EINVAL bug, adapted to a
+# VM that has only LANbond (+ OVS ext).  Proves the FIX: after the default (slot-0)
+# datapath detaches and the survivor is promoted to a non-zero slot, a freshly
+# opened ovs-vswitchd can still subscribe for upcalls (it stamps the resolved
+# dp_ifindex, not a hardcoded 0).  No nested-VM forwarding needed -- the subscribe
+# itself is the discriminator: the old binary exits with "could not subscribe
+# packets (Invalid argument)" here; the fixed binary stays up.
+$ErrorActionPreference = 'Continue'
+$native='C:\ovs-test\native'; $run='C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl="$native\ovs-vsctl.exe"; $dpctl="$native\ovs-dpctl.exe"; $tool="$native\ovsdb-tool.exe"
+$ext='dbosoft Open vSwitch Extension'
+$ANCHOR='ovs-promote-a'   # temp internal switch, enabled FIRST -> dp0 (detached)
+$SURV='LANbond'           # enabled SECOND -> dp1 (promoted survivor)
+
+function DrvState { (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State }
+function AssertVswitchd($where) {
+    if (Get-Process ovs-vswitchd -EA SilentlyContinue) { "vswitchd alive ($where): OK" }
+    else { "*** FAIL: vswitchd NOT running ($where) ***" }
+    $bad = Select-String -Path "$run\ovs-vswitchd.log" -EA SilentlyContinue `
+        -Pattern 'could not subscribe packets','failed to listen on datapath'
+    if ($bad) { "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2 }
+    else { "log clean ($where): no subscribe/listen error" }
+}
+
+"=== 0. binary under test ==="
+& $native\ovs-vswitchd.exe --version 2>&1 | Select-Object -First 1
+(Get-FileHash $native\ovs-vswitchd.exe -Algorithm SHA256).Hash
+
+"=== 1. clean slate ==="
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Disable-VMSwitchExtension -VMSwitchName $SURV -Name $ext -EA Continue | Out-Null
+if (Get-VMSwitch -Name $ANCHOR -EA SilentlyContinue) {
+    Disable-VMSwitchExtension -VMSwitchName $ANCHOR -Name $ext -EA Continue | Out-Null
+} else {
+    New-VMSwitch -Name $ANCHOR -SwitchType Internal | Out-Null
+}
+Start-Sleep 3
+"driver = $(DrvState)"
+
+"=== 2. enable ANCHOR ext FIRST (-> default dp0) ==="
+Enable-VMSwitchExtension -VMSwitchName $ANCHOR -Name $ext -EA Continue | Out-Null
+Start-Sleep 3
+"=== 3. enable SURVIVOR ext SECOND (-> dp1) ==="
+Enable-VMSwitchExtension -VMSwitchName $SURV -Name $ext -EA Continue | Out-Null
+Start-Sleep 3
+"driver = $(DrvState)"
+$SURVID = (Get-VMSwitch -Name $SURV).Id.ToString().ToUpper()
+"--- datapaths (expect two: $ANCHOR GUID + $SURV GUID=$SURVID) ---"
+& $dpctl show 2>&1
+
+"=== 4. bring up OVS, br-probe on the SURVIVOR (dp1) ==="
+Remove-Item "$run\conf.db","$run\*.log","$run\*.pid" -EA SilentlyContinue
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+& $vsctl --timeout=25 add-br br-probe -- set bridge br-probe datapath_type=$SURVID
+Start-Sleep 2
+"=== 5. BASELINE (both dps live): vswitchd must subscribe cleanly ==="
+AssertVswitchd 'baseline'
+
+"=== 6. DETACH THE DEFAULT: disable ANCHOR ext (dp0) -> promotion ==="
+Disable-VMSwitchExtension -VMSwitchName $ANCHOR -Name $ext -EA Continue | Out-Null
+Start-Sleep 4
+"driver = $(DrvState)   (MUST be Running -> no BSOD)"
+"--- datapaths now (expect only $SURV) ---"
+& $dpctl show 2>&1
+
+"=== 7. THE REGRESSION CASE: restart vswitchd, FRESH subscribe vs PROMOTED dp ==="
+Get-Process ovs-vswitchd -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep 2
+Remove-Item "$run\ovs-vswitchd.log" -EA SilentlyContinue   # log scan sees only this run
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 4
+AssertVswitchd 'after restart post-promotion'
+"--- bridge/datapath still usable (recv_set succeeded) ---"
+& $vsctl --timeout=15 show 2>&1 | Select-Object -First 6
+& $dpctl show 2>&1
+
+"=== cleanup: stop daemons, drop temp switch, restore baseline (survivor ext on) ==="
+& $vsctl --timeout=20 del-br br-probe 2>&1 | Out-Null
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Remove-VMSwitch -Name $ANCHOR -Force -EA SilentlyContinue
+"driver = $(DrvState)"
+"REPRO-DONE"

--- a/datapath-windows/test-catlet/detach-promote-subscribe-repro.ps1
+++ b/datapath-windows/test-catlet/detach-promote-subscribe-repro.ps1
@@ -15,12 +15,18 @@ $ANCHOR='ovs-promote-a'   # temp internal switch, enabled FIRST -> dp0 (detached
 $SURV='LANbond'           # enabled SECOND -> dp1 (promoted survivor)
 
 function DrvState { (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State }
+# Records a regression so the script exits non-zero (see the tail). Cleanup still
+# runs, so the test VM is restored before we report failure.
+$script:Failed = $false
 function AssertVswitchd($where) {
     if (Get-Process ovs-vswitchd -EA SilentlyContinue) { "vswitchd alive ($where): OK" }
-    else { "*** FAIL: vswitchd NOT running ($where) ***" }
+    else { "*** FAIL: vswitchd NOT running ($where) ***"; $script:Failed = $true }
     $bad = Select-String -Path "$run\ovs-vswitchd.log" -EA SilentlyContinue `
         -Pattern 'could not subscribe packets','failed to listen on datapath'
-    if ($bad) { "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2 }
+    if ($bad) {
+        "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2
+        $script:Failed = $true
+    }
     else { "log clean ($where): no subscribe/listen error" }
 }
 
@@ -86,4 +92,5 @@ AssertVswitchd 'after restart post-promotion'
 Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
 Remove-VMSwitch -Name $ANCHOR -Force -EA SilentlyContinue
 "driver = $(DrvState)"
-"REPRO-DONE"
+if ($script:Failed) { "REPRO-DONE (FAILED)"; exit 1 }
+"REPRO-DONE (PASSED)"

--- a/datapath-windows/test-catlet/detach-promote-test.ps1
+++ b/datapath-windows/test-catlet/detach-promote-test.ps1
@@ -16,6 +16,15 @@ $ext='dbosoft Open vSwitch Extension'
 $OVERLAY = (Get-VMSwitch -Name eryph_overlay).Id.ToString().ToUpper()
 
 function DrvState { (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State }
+# A subscribe/listen failure makes ovs-vswitchd exit; without this assert a ping
+# can still pass from the kernel flow cache and mask the crash (false green).
+function AssertVswitchd($where) {
+    if (Get-Process ovs-vswitchd -EA SilentlyContinue) { "vswitchd alive ($where): OK" }
+    else { "*** FAIL: vswitchd NOT running ($where) ***" }
+    $bad = Select-String -Path "$run\ovs-vswitchd.log" -EA SilentlyContinue `
+        -Pattern 'could not subscribe packets','failed to listen on datapath'
+    if ($bad) { "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2 }
+}
 function PingVMs($idx) {
     foreach ($vm in 'ub1','ub2') {
         $ll = (Get-VMNetworkAdapter -VMName $vm -EA SilentlyContinue).IPAddresses | Where-Object { $_ -match '^fe80' } | Select-Object -First 1
@@ -60,6 +69,7 @@ Enable-NetAdapter -Name br-int -EA Continue | Out-Null
 Start-Sleep 3
 $idx = (Get-NetAdapter -Name br-int -EA SilentlyContinue).ifIndex
 "=== 5. BASELINE forwarding (default=ovs-test2 anchor, traffic on eryph_overlay dp1) ==="
+AssertVswitchd 'baseline'
 PingVMs $idx
 
 "=== 6. DETACH THE DEFAULT: disable ovs-test2 ext (dp0) -> promotion ==="
@@ -76,12 +86,22 @@ PingVMs $idx
 "--- flows re-installed by upcalls (forwarding evidence) ---"
 & $dpctl dump-flows "${OVERLAY}@ovs-system" 2>&1 | Select-Object -First 4
 
-"=== 8. vswitchd RESTART after promotion (re-stamp pids on global hash) ==="
+"=== 8. vswitchd RESTART after promotion (FRESH subscribe against promoted dp) ==="
+# This is the regression case: the restarted vswitchd re-opens the dpif and
+# re-subscribes for upcalls.  The default datapath is now the PROMOTED survivor
+# (not slot 0), so a packet-subscribe carrying a hardcoded dp_ifindex=0 is
+# rejected EINVAL and vswitchd exits ("could not subscribe packets").
 Get-Process ovs-vswitchd -EA SilentlyContinue | Stop-Process -Force
 Start-Sleep 2
+Remove-Item "$run\ovs-vswitchd.log" -EA SilentlyContinue   # so the log scan only sees this run
 & "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
 Start-Sleep 4
+AssertVswitchd 'after restart post-promotion'
+& $dpctl del-flows "${OVERLAY}@ovs-system" 2>&1 | Out-Null   # force fresh upcall, not cache
+Start-Sleep 1
 PingVMs $idx
+"--- flows must be re-installed by the restarted vswitchd's upcalls ---"
+& $dpctl dump-flows "${OVERLAY}@ovs-system" 2>&1 | Select-Object -First 4
 
 "=== cleanup: stop daemons, restore baseline (overlay ext on, test2 off) ==="
 & $vsctl --timeout=20 del-br br-int 2>&1 | Out-Null

--- a/datapath-windows/test-catlet/detach-promote-test.ps1
+++ b/datapath-windows/test-catlet/detach-promote-test.ps1
@@ -16,14 +16,20 @@ $ext='dbosoft Open vSwitch Extension'
 $OVERLAY = (Get-VMSwitch -Name eryph_overlay).Id.ToString().ToUpper()
 
 function DrvState { (Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State }
+# Records a regression so the script exits non-zero (see the tail). Cleanup still
+# runs, so the test VM is restored before we report failure.
+$script:Failed = $false
 # A subscribe/listen failure makes ovs-vswitchd exit; without this assert a ping
 # can still pass from the kernel flow cache and mask the crash (false green).
 function AssertVswitchd($where) {
     if (Get-Process ovs-vswitchd -EA SilentlyContinue) { "vswitchd alive ($where): OK" }
-    else { "*** FAIL: vswitchd NOT running ($where) ***" }
+    else { "*** FAIL: vswitchd NOT running ($where) ***"; $script:Failed = $true }
     $bad = Select-String -Path "$run\ovs-vswitchd.log" -EA SilentlyContinue `
         -Pattern 'could not subscribe packets','failed to listen on datapath'
-    if ($bad) { "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2 }
+    if ($bad) {
+        "*** FAIL: subscribe/listen error in log ($where) ***"; $bad.Line | Select-Object -Last 2
+        $script:Failed = $true
+    }
 }
 function PingVMs($idx) {
     foreach ($vm in 'ub1','ub2') {
@@ -107,4 +113,5 @@ PingVMs $idx
 & $vsctl --timeout=20 del-br br-int 2>&1 | Out-Null
 Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
 "driver = $(DrvState)"
-"DETACH-TEST-DONE"
+if ($script:Failed) { "DETACH-TEST-DONE (FAILED)"; exit 1 }
+"DETACH-TEST-DONE (PASSED)"

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1134,6 +1134,10 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     dpif->dp_ifindex = dp.dp_ifindex;
     dpif->dp_name = dp_name;
     dpif->user_features = dp.user_features;
+    /* The channel stamps this on the packet subscribe/pend requests, which the
+     * kernel validates against a live datapath.  The default datapath need not
+     * be slot 0 (it is promoted on detach), so use the resolved index. */
+    dpif->channel.dp_ifindex = dp.dp_ifindex;
     ofpbuf_delete(buf);
 
     *dpifp = &dpif->dpif;

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -328,7 +328,7 @@ ovsext_subscribe_packets__(struct ovsext_channel *ch, bool subscribe)
                           OVS_WIN_CONTROL_VERSION);
 
     ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
-    ovs_header->dp_ifindex = 0;
+    ovs_header->dp_ifindex = ch->dp_ifindex;
     nl_msg_put_u8(&request, OVS_NL_ATTR_PACKET_SUBSCRIBE, subscribe ? 1 : 0);
     nl_msg_put_u32(&request, OVS_NL_ATTR_PACKET_PID, ch->pid);
 
@@ -409,7 +409,7 @@ ovsext_recv_wait(struct ovsext_channel *ch)
                               OVS_CTRL_CMD_WIN_PEND_PACKET_REQ,
                               OVS_WIN_CONTROL_VERSION);
         ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
-        ovs_header->dp_ifindex = 0;
+        ovs_header->dp_ifindex = ch->dp_ifindex;
         ovsext_stamp_request(ch, &request);
 
         ok = DeviceIoControl(ch->handle, OVS_IOCTL_WRITE,

--- a/lib/ovsext-channel.h
+++ b/lib/ovsext-channel.h
@@ -35,6 +35,12 @@ struct ovsext_channel {
     OVERLAPPED overlapped;  /* For a pended READ_PACKET / READ_EVENT. */
     HANDLE rx_event;        /* Manual-reset event; parked in poll_wevent_wait(). */
     uint32_t pid;           /* From OVS_IOCTL_GET_PID; the upcall routing key. */
+    uint32_t dp_ifindex;    /* Datapath this channel targets; stamped on the
+                             * packet subscribe/pend requests, which the kernel
+                             * validates against a live datapath.  The default
+                             * datapath is not always slot 0 (it is promoted on
+                             * detach), so this must carry the resolved index,
+                             * not a hardcoded 0. */
     uint32_t next_seq;      /* Netlink sequence allocator for this channel. */
     DWORD read_ioctl;       /* OVS_IOCTL_READ | _READ_EVENT | _READ_PACKET. */
     bool rx_pending;        /* True while an overlapped read is armed. */


### PR DESCRIPTION
The packet subscribe (`OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ`) and packet pend (`OVS_CTRL_CMD_WIN_PEND_PACKET_REQ`) requests in `lib/ovsext-channel.c` hardcoded `ovs_header->dp_ifindex = 0`. Both commands are `validateDpIndex=TRUE`, so the kernel dispatcher resolves the index to a datapath slot up front and rejects the request with EINVAL when that slot is empty.

This only worked because the default datapath was always slot 0. After a runtime detach of the anchor datapath, the kernel promotes the surviving datapath (which keeps its non-zero slot) to be the default and clears slot 0. A freshly opened dpif then resolves its datapath to the survivor's index, but the channel still subscribed with `dp_ifindex=0` → EINVAL → `could not subscribe packets` → `ovs-vswitchd` fails to listen and exits.

Carry the resolved index in `struct ovsext_channel` (set in `dpif_windows_open`) and stamp it on both requests. The rest of the path already keys on the resolved index (the recv filter and the kernel's per-upcall `dpNo` stamp), so this just makes subscribe/pend consistent. Pure userspace, no kernel change.

Also hardens `detach-promote-test.ps1` (assert vswitchd stays alive after the post-promotion restart, scan its log for the subscribe/listen error, and `del-flows` before the post-restart ping so forwarding proves a fresh upcall rather than a stale flow-cache hit that previously masked this failure) and adds a topology-light `detach-promote-subscribe-repro.ps1`.

Verified live on ovs-kerneldev: with the anchor datapath detached and the survivor promoted to a non-zero slot, a restarted ovs-vswitchd subscribes cleanly (process alive, no error in log, bridge usable); driver stays Running through the detach.