### PR TITLE
datapath-windows: userspace-first vport pre-creation

### DIFF
--- a/datapath-windows/include/OvsDpInterfaceExt.h
+++ b/datapath-windows/include/OvsDpInterfaceExt.h
@@ -166,6 +166,7 @@ enum ovs_win_netdev_attr {
 
 #define OVS_WIN_NETDEV_IFF_UP                   (1 << 0)
 #define OVS_WIN_NETDEV_IFF_PROMISC              (1 << 1)
+#define OVS_WIN_NETDEV_IFF_RUNNING              (1 << 2)
 
 typedef struct ovs_dp_stats OVS_DP_STATS;
 typedef enum ovs_vport_type OVS_VPORT_TYPE;

--- a/datapath-windows/ovsext/Event.c
+++ b/datapath-windows/ovsext/Event.c
@@ -155,6 +155,7 @@ OvsPostVportEvent(POVS_VPORT_EVENT_ENTRY event)
     LIST_ENTRY list;
     PLIST_ENTRY entry;
     PIRP irp;
+    UINT32 eventType = event->type;
 
     InitializeListHead(&list);
 
@@ -165,10 +166,9 @@ OvsPostVportEvent(POVS_VPORT_EVENT_ENTRY event)
 
     LIST_FORALL(&ovsEventQueueArr[OVS_MCAST_VPORT_EVENT], link) {
         queue = CONTAINING_RECORD(link, OVS_EVENT_QUEUE, queueLink);
-        if ((event->type & queue->mask) == 0) {
+        if ((eventType & queue->mask) == 0) {
             continue;
         }
-        event->type &= queue->mask;
 
         elem = (POVS_EVENT_QUEUE_ELEM)OvsAllocateMemoryWithTag(
             sizeof(*elem), OVS_EVENT_POOL_TAG);
@@ -180,6 +180,10 @@ OvsPostVportEvent(POVS_VPORT_EVENT_ENTRY event)
         }
 
         RtlCopyMemory(&elem->vportEvent, event, sizeof elem->vportEvent);
+        /* Deliver only the bits this queue subscribed to, without mutating the
+         * shared 'event' -- otherwise a later queue with a disjoint mask would
+         * test an already-stripped type and miss a multi-bit event. */
+        elem->vportEvent.type = eventType & queue->mask;
         InsertTailList(&queue->elemList, &elem->link);
         queue->numElems++;
         OVS_LOG_INFO("Queue: %p, numElems: %d",

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1898,7 +1898,11 @@ CreateNetlinkMesgForNetdev(POVS_VPORT_EXT_INFO info,
         return STATUS_INVALID_BUFFER_SIZE;
     }
 
-    if (info->status != OVS_EVENT_CONNECT) {
+    /* 'status' is a bitmask: NIC_CREATED and CONNECTED both carry
+     * OVS_EVENT_CONNECT, DISCONNECT does not.  Bit-test it so a ghost or a
+     * connected port is admin-up and a disconnected one is admin-down,
+     * regardless of which link bit (if any) accompanies the connect bit. */
+    if (info->status & OVS_EVENT_CONNECT) {
         netdevFlags = OVS_WIN_NETDEV_IFF_UP;
     }
     /*

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -161,13 +161,21 @@ HvCreatePort(POVS_SWITCH_CONTEXT switchContext,
          * given that the port Id and the name are the same and also provided
          * that the other properties that we cache have not changed.
          */
-        if (vport->portType != portParam->PortType) {
+        /*
+         * A userspace-first ghost (hvAttachPending) was created before its
+         * Hyper-V port existed, so it carries no NDIS PortType yet; adopt the
+         * type Hyper-V now supplies (OvsInitVportWithPortParam() sets it below)
+         * rather than rejecting on the uninitialized value.
+         */
+        if (!vport->hvAttachPending &&
+            vport->portType != portParam->PortType) {
             OVS_LOG_INFO("Port add failed due to PortType change, port Id: %u"
                          " old: %u, new: %u", portParam->PortId,
                          vport->portType, portParam->PortType);
             status = STATUS_DATA_NOT_ACCEPTED;
             goto create_port_done;
         }
+        vport->hvAttachPending = FALSE;
         vport->isAbsentOnHv = FALSE;
     } else {
         vport = (POVS_VPORT_ENTRY)OvsAllocateVport();
@@ -462,6 +470,23 @@ HvConnectNic(POVS_SWITCH_CONTEXT switchContext,
 
     if (nicParam->NicType == NdisSwitchNicTypeInternal) {
         OvsBindVportWithIpHelper(vport, switchContext);
+    }
+
+    /*
+     * Notify userspace that the NIC connected and link is up. This lets a
+     * pre-created port's activation be observed without polling. Only ports
+     * already known to OVS userspace (valid portNo) are reported.
+     */
+    if (vport->portNo != OVS_DPPORT_NUMBER_INVALID) {
+        OVS_VPORT_EVENT_ENTRY event;
+        RtlZeroMemory(&event, sizeof event);
+        event.portNo = vport->portNo;
+        event.ovsType = vport->ovsType;
+        event.upcallPid = vport->upcallPid;
+        RtlCopyMemory(&event.ovsName, &vport->ovsName, sizeof event.ovsName);
+        event.type = OVS_EVENT_LINK_UP | OVS_EVENT_CONNECT;
+        event.dpNo = switchContext->dpNo;
+        OvsPostVportEvent(&event);
     }
 
     NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
@@ -1876,6 +1901,15 @@ CreateNetlinkMesgForNetdev(POVS_VPORT_EXT_INFO info,
     if (info->status != OVS_EVENT_CONNECT) {
         netdevFlags = OVS_WIN_NETDEV_IFF_UP;
     }
+    /*
+     * IFF_UP is set for both NIC_CREATED and CONNECTED, so it cannot convey
+     * link state. Report IFF_RUNNING when the vport's NIC is connected
+     * (OVS_EVENT_LINK_UP) so userspace can derive carrier for ports that have
+     * no host interface to read media state from (e.g. VM vNICs / ghosts).
+     */
+    if (info->status & OVS_EVENT_LINK_UP) {
+        netdevFlags |= OVS_WIN_NETDEV_IFF_RUNNING;
+    }
     ok = NlMsgPutTailU32(&nlBuffer, OVS_WIN_NETDEV_ATTR_IF_FLAGS,
                          netdevFlags);
     if (!ok) {
@@ -2298,6 +2332,43 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         portType == OVS_VPORT_TYPE_INTERNAL) {
         /* External and internal ports can also be looked up like VIF ports. */
         vport = OvsFindVportByHvNameA(switchContext, portName);
+
+        if (vport == NULL) {
+            /*
+             * The Hyper-V port with this friendly name is not present yet.
+             * Pre-create a userspace-first vport that is absent on the Hyper-V
+             * switch and is resurrected by HvCreatePort() once a Hyper-V port
+             * with a matching friendly name appears. Until the NIC connects the
+             * port is reported link-down (OVS_STATE_NIC_CREATED) and the
+             * datapath output path, which requires OVS_STATE_CONNECTED, drops
+             * traffic destined to it.
+             */
+            SIZE_T friendlyNameLen = portNameLen - 1; /* exclude the NUL */
+            SIZE_T i;
+
+            if (friendlyNameLen > IF_MAX_STRING_SIZE) {
+                nlError = NL_ERROR_INVAL;
+                goto Cleanup;
+            }
+
+            vport = (POVS_VPORT_ENTRY)OvsAllocateVport();
+            if (vport == NULL) {
+                nlError = NL_ERROR_NOMEM;
+                goto Cleanup;
+            }
+            vportAllocated = TRUE;
+
+            vport->ovsType = portType;
+            vport->ovsState = OVS_STATE_NIC_CREATED;
+            vport->isAbsentOnHv = TRUE;
+            vport->hvAttachPending = TRUE;
+
+            for (i = 0; i < friendlyNameLen; i++) {
+                vport->portFriendlyName.String[i] = (WCHAR)portName[i];
+            }
+            vport->portFriendlyName.Length =
+                (USHORT)(friendlyNameLen * sizeof(WCHAR));
+        }
     } else {
         ASSERT(OvsIsTunnelVportType(portType));
 
@@ -2419,6 +2490,18 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
     status = InitOvsVportCommon(switchContext, vport);
     ASSERT(status == STATUS_SUCCESS);
+
+    if (vport->hvAttachPending) {
+        /*
+         * Account a userspace-first NETDEV/INTERNAL ghost as a Hyper-V vport so
+         * the count balances OvsRemoveAndDeleteVport(), which decrements
+         * numHvVports for NETDEV/INTERNAL ports. A Hyper-V-created port is
+         * counted in UpdateSwitchCtxWithVport(); a ghost never traverses that
+         * path until it is resurrected (with newPort == FALSE), so it would
+         * otherwise be deleted without ever being counted.
+         */
+        switchContext->numHvVports++;
+    }
 
     status = OvsCreateMsgFromVport(vport, msgIn, usrParamsCtx->outputBuffer,
                                    usrParamsCtx->outputLength,

--- a/datapath-windows/ovsext/Vport.h
+++ b/datapath-windows/ovsext/Vport.h
@@ -117,6 +117,11 @@ typedef struct _OVS_VPORT_ENTRY {
     PNL_ATTR                     portOptions;
     BOOLEAN                      isAbsentOnHv; /* Is this port present on the
                                                   Hyper-V switch? */
+    BOOLEAN                      hvAttachPending; /* Userspace-first ghost: the
+                                                  port was created from OVS
+                                                  before its Hyper-V port
+                                                  existed, and is awaiting
+                                                  attach by HvCreatePort(). */
 } OVS_VPORT_ENTRY, *POVS_VPORT_ENTRY;
 
 struct _OVS_SWITCH_CONTEXT;

--- a/datapath-windows/test-catlet/Set-OvsPortName.ps1
+++ b/datapath-windows/test-catlet/Set-OvsPortName.ps1
@@ -60,7 +60,9 @@ function Resolve-SwitchName($hostResource) {
     return $null
 }
 
-$vm = Get-CimInstance -Namespace $ns -ClassName Msvm_ComputerSystem -Filter "ElementName='$VMName'"
+# Escape single quotes for the WQL filter (WQL doubles a literal quote).
+$vmFilter = "ElementName='" + ($VMName -replace "'", "''") + "'"
+$vm = Get-CimInstance -Namespace $ns -ClassName Msvm_ComputerSystem -Filter $vmFilter
 if (-not $vm) { throw "VM '$VMName' not found." }
 $vssd = Get-CimAssociatedInstance -InputObject $vm -ResultClassName Msvm_VirtualSystemSettingData |
         Where-Object { $_.VirtualSystemType -eq 'Microsoft:Hyper-V:System:Realized' } | Select-Object -First 1

--- a/datapath-windows/test-catlet/Set-OvsPortName.ps1
+++ b/datapath-windows/test-catlet/Set-OvsPortName.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+  Set (or list) the OVS port name on a Hyper-V VM network adapter so the Windows
+  OVS forwarding extension (ovsext) binds that adapter to the named OVS port.
+  Multi-switch aware.
+
+.DESCRIPTION
+  ovsext matches an OVS port to a Hyper-V switch port by the port's *friendly
+  name*, which is the ElementName of the Msvm_EthernetPortAllocationSettingData
+  (the adapter<->switch CONNECTION) -- NOT the VM-adapter name that
+  Rename-VMNetworkAdapter / Set-VMNetworkAdapter -Name sets (that is the
+  SyntheticEthernetPortSettingData ElementName, which ovsext ignores).
+
+  This script sets the connection ElementName via
+  Msvm_VirtualSystemManagementService.ModifyResourceSettings -- the same property
+  dotnet-ovn's HyperVOvsPortManager drives (eryph prefixes the name with 'ovs_').
+
+  A VM may have several vNICs on different switches; select the target adapter
+  with -SwitchName (recommended), -MacAddress, or -AdapterName. With no -PortName
+  (or -List) it prints the current adapter -> OVS-port mapping and exits.
+
+.PARAMETER VMName       Target VM (Msvm ElementName).
+.PARAMETER PortName     Desired OVS port name (the name you pass to ovs-vsctl add-port).
+.PARAMETER SwitchName   Select the adapter connected to this vSwitch.
+.PARAMETER MacAddress   Select the adapter with this MAC (any separators ok).
+.PARAMETER AdapterName  Select the adapter by its current VM-adapter name.
+.PARAMETER List         Only list the current mapping; make no change.
+
+.EXAMPLE
+  .\Set-OvsPortName.ps1 -VMName ub1 -List
+.EXAMPLE
+  .\Set-OvsPortName.ps1 -VMName ub1 -PortName ovs_ub1 -SwitchName LANbond
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)][string]$VMName,
+    [string]$PortName,
+    [string]$SwitchName,
+    [string]$MacAddress,
+    [string]$AdapterName,
+    [switch]$List
+)
+$ErrorActionPreference = 'Stop'
+$ns = 'root\virtualization\v2'
+
+function ConvertTo-CimText($instance) {
+    $ser = [Microsoft.Management.Infrastructure.Serialization.CimSerializer]::Create()
+    $opt = [Microsoft.Management.Infrastructure.Serialization.InstanceSerializationOptions]::None
+    [System.Text.Encoding]::Unicode.GetString($ser.Serialize($instance, $opt))
+}
+function Resolve-SwitchName($hostResource) {
+    # HostResource looks like:
+    #   Msvm_VirtualEthernetSwitch.CreationClassName="Msvm_VirtualEthernetSwitch",Name="<switch-guid>"
+    # Match the standalone Name= (the GUID), not the "Name" inside CreationClassName.
+    if ($hostResource -match '(?<![A-Za-z])Name="([^"]+)"') {
+        $id = $Matches[1]
+        $sw = Get-VMSwitch -Id $id -ErrorAction SilentlyContinue
+        if ($sw) { return $sw.Name } else { return $id }
+    }
+    return $null
+}
+
+$vm = Get-CimInstance -Namespace $ns -ClassName Msvm_ComputerSystem -Filter "ElementName='$VMName'"
+if (-not $vm) { throw "VM '$VMName' not found." }
+$vssd = Get-CimAssociatedInstance -InputObject $vm -ResultClassName Msvm_VirtualSystemSettingData |
+        Where-Object { $_.VirtualSystemType -eq 'Microsoft:Hyper-V:System:Realized' } | Select-Object -First 1
+
+$rows = foreach ($sepsd in (Get-CimAssociatedInstance -InputObject $vssd -ResultClassName Msvm_SyntheticEthernetPortSettingData)) {
+    foreach ($epasd in (Get-CimAssociatedInstance -InputObject $sepsd -ResultClassName Msvm_EthernetPortAllocationSettingData)) {
+        [pscustomobject]@{
+            Adapter  = $sepsd.ElementName
+            Mac      = $sepsd.Address
+            PortName = $epasd.ElementName
+            Switch   = Resolve-SwitchName ($epasd.HostResource -join ';')
+            Epasd    = $epasd
+        }
+    }
+}
+
+if ($List -or -not $PortName) {
+    $rows | Select-Object Adapter, Mac, PortName, Switch | Format-Table -Auto
+    if (-not $PortName) { return }
+}
+
+$targets = $rows
+if ($SwitchName)  { $targets = $targets | Where-Object Switch -eq $SwitchName }
+if ($MacAddress)  { $m = ($MacAddress -replace '[^0-9A-Fa-f]', '').ToUpper(); $targets = $targets | Where-Object { ($_.Mac -replace '[^0-9A-Fa-f]', '').ToUpper() -eq $m } }
+if ($AdapterName) { $targets = $targets | Where-Object Adapter -eq $AdapterName }
+
+if (-not $targets) { throw "No adapter on '$VMName' matches (switch=$SwitchName mac=$MacAddress adapter=$AdapterName)." }
+if (($targets | Measure-Object).Count -gt 1) {
+    throw "Ambiguous match ($(($targets | ForEach-Object { "$($_.Adapter)@$($_.Switch)" }) -join ', ')). Narrow with -SwitchName / -MacAddress / -AdapterName."
+}
+
+$t = $targets[0]
+$epasd = $t.Epasd
+$old = $epasd.ElementName
+if ($old -eq $PortName) { "No change: '$($t.Adapter)' on '$($t.Switch)' OVS port name already = '$PortName'."; return }
+$epasd.ElementName = $PortName
+
+if ($PSCmdlet.ShouldProcess("$VMName adapter '$($t.Adapter)' on '$($t.Switch)'", "set OVS port name '$old' -> '$PortName'")) {
+    $vmms = Get-CimInstance -Namespace $ns -ClassName Msvm_VirtualSystemManagementService
+    $res = $vmms | Invoke-CimMethod -MethodName ModifyResourceSettings -Arguments @{ ResourceSettings = @((ConvertTo-CimText $epasd)) }
+    switch ($res.ReturnValue) {
+        0    { "OK: '$($t.Adapter)' on '$($t.Switch)' OVS port name = '$PortName' (was '$old')." }
+        4096 { "Job started ($($res.Job)); change applied asynchronously." }
+        default { throw "ModifyResourceSettings failed, ReturnValue=$($res.ReturnValue)." }
+    }
+}

--- a/datapath-windows/test-catlet/precreate-test.ps1
+++ b/datapath-windows/test-catlet/precreate-test.ps1
@@ -1,0 +1,47 @@
+# RFC-0029 NETDEV pre-create ("ghost") validation, run inside ovs-kerneldev.
+# Brings up OVS on the LANbond switch, adds a NETDEV port whose Hyper-V adapter
+# does not exist, and checks it is accepted (ofport > 0, link-down, no error)
+# rather than rejected (ofport = -1). Then deletes it to exercise the ghost
+# delete/counter-balance path. Self-stopping so the SSH session returns.
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"; $tool = "$native\ovsdb-tool.exe"
+$dp = (Get-VMSwitch -Name LANbond).Id.ToString().ToUpper()
+
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep 1
+foreach ($f in 'conf.db','ovsdb-server.log','ovs-vswitchd.log','ovsdb-server.pid','ovs-vswitchd.pid') {
+    $p = Join-Path $run $f
+    if (Test-Path $p) { Remove-Item $p -Force -EA SilentlyContinue }
+}
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+
+& $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$dp
+Start-Sleep 2
+
+"=== TEST: pre-create NETDEV port 'ghost_test' with NO Hyper-V backing ==="
+& $vsctl --timeout=25 add-port br-int ghost_test
+Start-Sleep 2
+"ofport     (NEW driver: expect > 0 ; OLD would be -1): " + (& $vsctl --timeout=10 get interface ghost_test ofport)
+"error      (expect empty / []):                        " + (& $vsctl --timeout=10 get interface ghost_test error)
+"link_state (expect down):                              " + (& $vsctl --timeout=10 get interface ghost_test link_state)
+"=== ovs-dpctl show (ghost_test should appear under the datapath) ==="
+& $dpctl show
+"=== del-port ghost_test (ghost delete / counter balance / no bugcheck) ==="
+& $vsctl --timeout=25 del-port br-int ghost_test
+Start-Sleep 1
+"=== ovs-dpctl show after del ==="
+& $dpctl show
+"=== driver state after add+del ==="
+(Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+
+& $vsctl --timeout=10 del-br br-int 2>&1 | Out-Null
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+"PRECREATE-TEST-DONE"

--- a/datapath-windows/test-catlet/resurrect-test.ps1
+++ b/datapath-windows/test-catlet/resurrect-test.ps1
@@ -1,0 +1,68 @@
+# RFC-0029 ghost RESURRECTION validation, run inside ovs-kerneldev.
+# Pre-creates ghost port 'ghost_ub1' while ub1 is Off, starts ub1 (whose vNIC is
+# named ghost_ub1 on LANbond), and checks the ghost resurrects in place (same
+# ofport, single port) and actually forwards (ping ub1 link-local through the
+# datapath = proof the kernel vport went OVS_STATE_CONNECTED). Self-stopping.
+$ErrorActionPreference = 'Continue'
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+foreach ($v in 'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR') { Set-Item "env:$v" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $dpctl = "$native\ovs-dpctl.exe"; $tool = "$native\ovsdb-tool.exe"
+$dp = (Get-VMSwitch -Name LANbond).Id.ToString().ToUpper()
+$port = 'ghost_ub1'
+
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+Start-Sleep 1
+foreach ($f in 'conf.db','ovsdb-server.log','ovs-vswitchd.log','ovsdb-server.pid','ovs-vswitchd.pid') {
+    $p = Join-Path $run $f; if (Test-Path $p) { Remove-Item $p -Force -EA SilentlyContinue }
+}
+& $tool create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+& "$native\ovsdb-server.exe" "$run\conf.db" -vconsole:off --remote=punix:db.sock --log-file="$run\ovsdb-server.log" --pidfile --detach | Out-Null
+Start-Sleep 1
+& $vsctl --no-wait init
+& "$native\ovs-vswitchd.exe" -vconsole:off -vfile:info --log-file="$run\ovs-vswitchd.log" --pidfile --detach | Out-Null
+Start-Sleep 2
+& $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$dp
+Start-Sleep 2
+
+"=== pre-create ghost '$port' (ub1 Off, no HV port yet) ==="
+& $vsctl --timeout=25 add-port br-int $port
+Start-Sleep 2
+$ofBefore = (& $vsctl --timeout=10 get interface $port ofport)
+"ofport BEFORE start: $ofBefore"
+"link_state BEFORE:   " + (& $vsctl --timeout=10 get interface $port link_state)
+
+"=== start ub1 (its vNIC 'ghost_ub1' on LANbond should resurrect the ghost) ==="
+Start-VM -Name ub1 -EA Continue
+# wait for boot + vNIC connect + guest link-local
+for ($i=0; $i -lt 14; $i++) {
+    Start-Sleep 6
+    $ll = (Get-VMNetworkAdapter -VMName ub1 -EA SilentlyContinue).IPAddresses | Where-Object { $_ -match '^fe80' } | Select-Object -First 1
+    if ($ll) { break }
+}
+Start-Sleep 3
+$ofAfter = (& $vsctl --timeout=10 get interface $port ofport)
+"ofport AFTER start:  $ofAfter   (resurrection = SAME ofport, no churn)"
+"link_state AFTER:    " + (& $vsctl --timeout=10 get interface $port link_state)
+"ub1 vNIC status:     " + ((Get-VMNetworkAdapter -VMName ub1).Status -join ',')
+"ub1 link-local:      $ll"
+"=== dpctl show (expect single '$port', no duplicate) ==="
+& $dpctl show
+
+"=== forwarding proof: ping ub1 link-local through br-int ==="
+Enable-NetAdapter -Name br-int -EA Continue
+Start-Sleep 3
+$idx = (Get-NetAdapter -Name br-int -EA SilentlyContinue).ifIndex
+if ($ll -and $idx) {
+    ping -6 -n 4 "$ll%$idx"
+    "ping exit=$LASTEXITCODE  (0 = forwarded through the resurrected datapath port)"
+} else { "no link-local or br-int ifIndex; ll=$ll idx=$idx" }
+
+"=== driver state ==="
+(Get-CimInstance Win32_SystemDriver -Filter "Name='DBO_OVSE'").State
+
+Stop-VM -Name ub1 -Force -TurnOff -EA Continue
+& $vsctl --timeout=10 del-port br-int $port 2>&1 | Out-Null
+& $vsctl --timeout=10 del-br br-int 2>&1 | Out-Null
+Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+"RESURRECT-TEST-DONE"

--- a/datapath-windows/test-catlet/run-resurrect.ps1
+++ b/datapath-windows/test-catlet/run-resurrect.ps1
@@ -1,0 +1,63 @@
+# RFC-0029 ghost->live + carrier validation, designed to run as a detached
+# scheduled task (no ssh pipe to hang). Writes progress incrementally to
+# C:\ovs-test\rr-result.txt and ALWAYS self-stops via try/finally.
+$ErrorActionPreference = 'Continue'
+$out = 'C:\ovs-test\rr-result.txt'
+Set-Content -Path $out -Value "RR start $(Get-Date -Format o)" -Encoding utf8
+function Log($m) { Add-Content -Path $out -Value $m -Encoding utf8 }
+
+$native = 'C:\ovs-test\native'; $run = 'C:\ovs-test\run'
+$env:Path = "$native;$env:Path"
+'OVS_RUNDIR','OVS_LOGDIR','OVS_DBDIR','OVS_SYSCONFDIR' | ForEach-Object { Set-Item "env:$_" $run }
+$vsctl = "$native\ovs-vsctl.exe"; $port = 'ovs_ub1'
+
+try {
+    Stop-VM -Name ub1 -Force -TurnOff -EA SilentlyContinue
+    Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+    Start-Sleep 1
+    foreach ($f in 'conf.db','ovs-vswitchd.log','ovsdb-server.log','ovsdb-server.pid','ovs-vswitchd.pid') {
+        $p = Join-Path $run $f; if (Test-Path $p) { Remove-Item $p -Force }
+    }
+    & "$native\ovsdb-tool.exe" create "$run\conf.db" "$native\vswitch.ovsschema" | Out-Null
+    Start-Process -FilePath "$native\ovsdb-server.exe" -WindowStyle Hidden `
+        -RedirectStandardOutput "$run\dbo.out" -RedirectStandardError "$run\dbo.err" -ArgumentList `
+        "$run\conf.db",'-vconsole:off','--remote=punix:db.sock',"--log-file=$run\ovsdb-server.log",'--pidfile'
+    Start-Sleep 2
+    & $vsctl --no-wait init
+    Start-Process -FilePath "$native\ovs-vswitchd.exe" -WindowStyle Hidden `
+        -RedirectStandardOutput "$run\vsw.out" -RedirectStandardError "$run\vsw.err" -ArgumentList `
+        '-vconsole:off','-vfile:info',"--log-file=$run\ovs-vswitchd.log",'--pidfile'
+    Start-Sleep 3
+    $dp = (Get-VMSwitch -Name LANbond).Id.ToString().ToUpper()
+    & $vsctl --timeout=25 add-br br-int -- set bridge br-int datapath_type=$dp
+    Start-Sleep 2
+    & $vsctl --timeout=25 add-port br-int $port
+    Start-Sleep 2
+    Log "GHOST  ofport=$(& $vsctl get interface $port ofport)  link_state=$(& $vsctl get interface $port link_state)"
+
+    Log "Start-VM ub1..."
+    Start-VM -Name ub1
+    for ($i=0; $i -lt 14; $i++) {
+        Start-Sleep 6
+        $ll = (Get-VMNetworkAdapter -VMName ub1 -EA SilentlyContinue).IPAddresses | Where-Object { $_ -match '^fe80' } | Select-Object -First 1
+        if ($ll) { break }
+    }
+    Start-Sleep 3
+    Log "LIVE t0  ofport=$(& $vsctl get interface $port ofport)  link_state=$(& $vsctl get interface $port link_state)"
+    Start-Sleep 4
+    Log "LIVE t1  link_state=$(& $vsctl get interface $port link_state)"
+    Start-Sleep 4
+    Log "LIVE t2  link_state=$(& $vsctl get interface $port link_state)"
+    Log "ub1 vNIC status=$((Get-VMNetworkAdapter -VMName ub1 | Select-Object -Expand Status) -join ',')  ll=$ll"
+    Log "--- interface row ---"
+    foreach($c in 'admin_state','link_state','link_resets','mtu','mac_in_use','error','ofport','ifindex'){
+        Log "$c = $(& $vsctl get interface $port $c)"
+    }
+}
+catch { Log "ERROR: $_" }
+finally {
+    Stop-VM -Name ub1 -Force -TurnOff -EA SilentlyContinue
+    & $vsctl --timeout=10 del-br br-int 2>&1 | Out-Null
+    Get-Process ovs-vswitchd,ovsdb-server -EA SilentlyContinue | Stop-Process -Force
+    Log "RR-DONE"
+}

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -108,6 +108,13 @@ static int netdev_windows_init_(void);
  * OVS_WIN_NL_NETDEV_FAMILY_ID. */
 static struct ovsext_channel ovs_win_netdev_channel;
 
+/* Result of the one-time 'ovs_win_netdev_channel' open (0 on success), ENODEV
+ * until first attempted.  Lets the construct path tell an absent device (the
+ * channel is open, the kernel just has no such vport -> ENODEV) from a failed
+ * open (non-zero here), so the latter is not silently deferred into a
+ * placeholder, while preserving the real errno for callers and logs. */
+static int netdev_windows_channel_error = ENODEV;
+
 
 static bool
 is_netdev_windows_class(const struct netdev_class *netdev_class)
@@ -125,23 +132,26 @@ netdev_windows_cast(const struct netdev *netdev_)
 static int
 netdev_windows_init_(void)
 {
-    int error = 0;
     static struct ovsthread_once once = OVSTHREAD_ONCE_INITIALIZER;
 
     if (ovsthread_once_start(&once)) {
         /* XXX: The channel lives for the process lifetime; there is no
          * netdev-provider teardown hook to close it. */
-        error = ovsext_channel_open(&ovs_win_netdev_channel);
-        if (error) {
+        netdev_windows_channel_error =
+            ovsext_channel_open(&ovs_win_netdev_channel);
+        if (netdev_windows_channel_error) {
             VLOG_ERR("Failed to open the ovsext datapath device (%s). "
                      "The Open vSwitch kernel extension is probably not loaded.",
-                     ovs_strerror(error));
+                     ovs_strerror(netdev_windows_channel_error));
         }
 
         ovsthread_once_done(&once);
     }
 
-    return error;
+    /* The open result is assigned only inside the once-block, so a caller after
+     * the first attempt would otherwise see success; return the persisted errno
+     * so driver-not-loaded is distinguishable from other open failures. */
+    return netdev_windows_channel_error;
 }
 
 static struct netdev *
@@ -192,7 +202,12 @@ netdev_windows_system_construct(struct netdev *netdev_)
      * refresh in netdev_windows_run() once the device appears. */
     {
         const char *t = netdev_get_type(&netdev->up);
-        bool deferrable = !strcmp(t, "internal") || !strcmp(t, "system");
+        /* Only defer when the channel is open, so a real ENODEV (the kernel has
+         * no such vport) is deferred but a missing kernel extension (the channel
+         * never opened) still fails netdev_open() instead of producing a
+         * placeholder that hides the unavailable datapath. */
+        bool deferrable = (!strcmp(t, "internal") || !strcmp(t, "system"))
+                          && !netdev_windows_channel_error;
         if (ret && !(deferrable && ret == ENODEV)) {
             return ret;
         }
@@ -701,6 +716,8 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
     LIST_FOR_EACH (netdev, list_node, &netdev_windows_list) {
         bool carrier;
         uint32_t old_flags = netdev->ifi_flags;
+        struct eth_addr old_mac = netdev->mac;
+        int old_mtu = netdev->mtu;
         bool changed = false;
 
         if (netdev_windows_query_carrier(netdev, &carrier)
@@ -711,10 +728,14 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
             VLOG_DBG("%s: carrier %s", netdev_get_name(&netdev->up),
                      carrier ? "up" : "down");
         }
-        /* netdev_windows_query_carrier() re-syncs the cached admin flags from
-         * the kernel; a transition (notably a resurrected ghost coming up)
-         * must wake the status refresh that publishes admin_state/link_state. */
-        if (netdev->ifi_flags != old_flags) {
+        /* netdev_windows_query_carrier() re-syncs the cached admin flags, MAC
+         * and MTU from the kernel; any of these changing (notably a resurrected
+         * ghost coming up or gaining its real MAC without an IFF_UP transition)
+         * must bump change_seq so consumers re-read etheraddr/mtu and the status
+         * refresh re-publishes admin_state/link_state. */
+        if (netdev->ifi_flags != old_flags
+            || !eth_addr_equals(netdev->mac, old_mac)
+            || netdev->mtu != old_mtu) {
             changed = true;
         }
         if (changed) {

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -412,11 +412,14 @@ netdev_windows_get_mtu(const struct netdev *netdev_, int *mtup)
     int error = 0;
 
     ovs_mutex_lock(&netdev_windows_list_mutex);
-    ovs_assert((netdev->cache_valid & VALID_MTU) != 0);
-    if (netdev->cache_valid & VALID_MTU) {
+    if ((netdev->cache_valid & VALID_MTU) && netdev->mtu) {
         *mtup = netdev->mtu;
     } else {
-        error = EINVAL;
+        /* A userspace-first ghost has no kernel MTU yet (the deferred construct
+         * zero-fills it); report it as unknown so callers fall back to a default
+         * rather than treating 0 as a valid MTU.  A real MTU arrives with the
+         * next refresh once the device is present. */
+        error = EOPNOTSUPP;
     }
     ovs_mutex_unlock(&netdev_windows_list_mutex);
     return error;
@@ -751,6 +754,7 @@ static void
 netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
 {
     struct netdev_windows_probe *probes;
+    struct shash by_name = SHASH_INITIALIZER(&by_name);
     struct netdev_windows *netdev;
     long long int now = time_msec();
     size_t n = 0, cap, i;
@@ -771,6 +775,8 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
         p->in_mac = netdev->mac;
         p->in_luid = netdev->if_luid;
         p->in_luid_valid = netdev->if_luid_valid;
+        /* netdev names are unique, so the name keys back to its probe in O(1). */
+        shash_add(&by_name, p->name, p);
     }
     ovs_mutex_unlock(&netdev_windows_list_mutex);
 
@@ -780,17 +786,16 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
 
     ovs_mutex_lock(&netdev_windows_list_mutex);
     LIST_FOR_EACH (netdev, list_node, &netdev_windows_list) {
-        for (i = 0; i < n; i++) {
-            if (!strcmp(probes[i].name, netdev_get_name(&netdev->up))) {
-                if (netdev_windows_probe_commit(netdev, &probes[i])) {
-                    netdev_change_seq_changed(&netdev->up);
-                }
-                break;
-            }
+        struct netdev_windows_probe *p =
+            shash_find_data(&by_name, netdev_get_name(&netdev->up));
+
+        if (p && netdev_windows_probe_commit(netdev, p)) {
+            netdev_change_seq_changed(&netdev->up);
         }
     }
     ovs_mutex_unlock(&netdev_windows_list_mutex);
 
+    shash_destroy(&by_name);
     for (i = 0; i < n; i++) {
         free(probes[i].name);
     }

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -815,6 +815,7 @@ netdev_windows_wait(const struct netdev_class *netdev_class OVS_UNUSED)
     .wait               = netdev_windows_wait,                          \
     .get_etheraddr      = netdev_windows_get_etheraddr,                 \
     .set_etheraddr      = netdev_windows_set_etheraddr,                 \
+    .get_mtu            = netdev_windows_get_mtu,                       \
     .get_carrier        = netdev_windows_get_carrier,                   \
     .get_carrier_resets = netdev_windows_get_carrier_resets,            \
     .update_flags       = netdev_windows_update_flags,                  \

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -412,7 +412,8 @@ netdev_windows_get_mtu(const struct netdev *netdev_, int *mtup)
     int error = 0;
 
     ovs_mutex_lock(&netdev_windows_list_mutex);
-    if ((netdev->cache_valid & VALID_MTU) && netdev->mtu) {
+    ovs_assert((netdev->cache_valid & VALID_MTU) != 0);
+    if (netdev->mtu) {
         *mtup = netdev->mtu;
     } else {
         /* A userspace-first ghost has no kernel MTU yet (the deferred construct
@@ -573,6 +574,9 @@ netdev_windows_internal_construct(struct netdev *netdev_)
  * needs, snapshotted under the lock. */
 struct netdev_windows_probe {
     char *name;                        /* owned; the netdev's unique identity. */
+    const struct netdev_windows *owner; /* identity guard (compared, not deref'd):
+                                         * rejects a same-named port deleted and
+                                         * re-created during the probe window. */
     struct eth_addr in_mac;            /* cached MAC, to reuse a resolved LUID. */
     NET_LUID in_luid;
     bool in_luid_valid;
@@ -580,7 +584,7 @@ struct netdev_windows_probe {
     bool kernel_valid;                 /* the OVS_WIN_NETDEV_CMD_GET succeeded. */
     uint32_t ifi_flags;
     struct eth_addr mac;
-    int mtu;
+    uint32_t mtu;                      /* matches the kernel u32 / cached field. */
     bool carrier_valid;                /* a link state was determined. */
     bool carrier;
     bool luid_valid;                   /* resolved host-interface LUID. */
@@ -772,6 +776,7 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
 
         memset(p, 0, sizeof *p);
         p->name = xstrdup(netdev_get_name(&netdev->up));
+        p->owner = netdev;
         p->in_mac = netdev->mac;
         p->in_luid = netdev->if_luid;
         p->in_luid_valid = netdev->if_luid_valid;
@@ -789,7 +794,11 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
         struct netdev_windows_probe *p =
             shash_find_data(&by_name, netdev_get_name(&netdev->up));
 
-        if (p && netdev_windows_probe_commit(netdev, p)) {
+        /* Commit only if this is the very netdev the probe was taken from: a
+         * name match alone could hit a same-named replacement created during
+         * the probe window, which must not receive stale data. */
+        if (p && p->owner == netdev
+            && netdev_windows_probe_commit(netdev, p)) {
             netdev_change_seq_changed(&netdev->up);
         }
     }

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -178,11 +178,24 @@ netdev_windows_system_construct(struct netdev *netdev_)
 
     /* Query the attributes and runtime status of the netdev. */
     ret = query_netdev(netdev_get_name(&netdev->up), &info, &buf);
-    /* "Internal" netdevs do not exist in the kernel yet.  They need to be
-     * transformed into a netdev object and passed to dpif_port_add(), which
-     * will add them to the kernel.  */
-    if (strcmp(netdev_get_type(&netdev->up), "internal") && ret) {
-        return ret;
+    /* Build a placeholder netdev only when the kernel reports the device truly
+     * absent (ENODEV).  An "internal" netdev does not exist in the kernel yet:
+     * it is created later by passing the netdev object to dpif_port_add().  A
+     * "system" (NETDEV) port whose backing Hyper-V adapter is not present yet
+     * is deferred the same way so dpif_port_add() pre-creates a userspace-first
+     * ghost vport, resurrected when the Hyper-V port appears.  This mirrors
+     * netdev-linux.c, which ignores ENODEV at construct only for these cases;
+     * any other query error -- or an absent device of a non-deferrable type --
+     * is a real failure and must fail netdev_open().  On the deferred path
+     * query_netdev() zero-initializes 'info' and NULLs 'buf', so the netdev is
+     * built from sane defaults and resynced from the kernel by the periodic
+     * refresh in netdev_windows_run() once the device appears. */
+    {
+        const char *t = netdev_get_type(&netdev->up);
+        bool deferrable = !strcmp(t, "internal") || !strcmp(t, "system");
+        if (ret && !(deferrable && ret == ENODEV)) {
+            return ret;
+        }
     }
     ofpbuf_delete(buf);
 
@@ -534,7 +547,10 @@ netdev_windows_resolve_luid(struct netdev_windows *netdev)
     ULONG i;
 
     if (!(netdev->cache_valid & VALID_ETHERADDR)
+        || eth_addr_is_zero(netdev->mac)
         || GetIfTable2(&table) != NO_ERROR || table == NULL) {
+        /* No usable MAC to match (e.g. a ghost constructed while its device was
+         * absent) -- do not match a host pseudo-interface with a zero MAC. */
         return false;
     }
     for (i = 0; i < table->NumEntries; i++) {
@@ -551,34 +567,82 @@ netdev_windows_resolve_luid(struct netdev_windows *netdev)
     return netdev->if_luid_valid;
 }
 
-/* Queries the current media carrier of 'netdev' from the Windows IP Helper.  On
- * success stores it in '*carrier' and returns true; on failure leaves '*carrier'
- * untouched and returns false (caller keeps its cached value).
+/* Re-syncs 'netdev''s cached device properties (admin flags, MAC, MTU) from its
+ * kernel vport and reports the datapath link state.  Windows has no asynchronous
+ * device-change notification; the Linux netdev keeps 'ifi_flags' current from
+ * rtnetlink RTM_NEWLINK messages, and the periodic refresh in
+ * netdev_windows_run() is the equivalent resync point here.  This matters for a
+ * userspace-first ghost (constructed while its Hyper-V adapter was absent, so
+ * query_netdev() failed and the cached flags came up empty): once the port is
+ * resurrected the vport reports OVS_WIN_NETDEV_IFF_UP, without which the shared
+ * netdev_get_carrier() would short-circuit the interface to admin-down.  On
+ * success stores the kernel link state (OVS_WIN_NETDEV_IFF_RUNNING) in '*up' and
+ * returns true. */
+static bool
+netdev_windows_refresh_kernel(struct netdev_windows *netdev, bool *up)
+{
+    struct netdev_windows_netdev_info info;
+    struct ofpbuf *buf;
+
+    if (query_netdev(netdev_get_name(&netdev->up), &info, &buf)) {
+        return false;
+    }
+
+    netdev->ifi_flags = dp_to_netdev_ifi_flags(info.ifi_flags);
+    netdev->cache_valid |= VALID_IFFLAG;
+    /* A changed MAC (notably a ghost gaining its real address at resurrection)
+     * invalidates the cached host-interface LUID, which is keyed by MAC. */
+    if (!eth_addr_equals(netdev->mac, info.mac_address)) {
+        netdev->if_luid_valid = false;
+    }
+    netdev->mac = info.mac_address;
+    netdev->cache_valid |= VALID_ETHERADDR;
+    netdev->mtu = info.mtu;
+    netdev->cache_valid |= VALID_MTU;
+
+    *up = (info.ifi_flags & OVS_WIN_NETDEV_IFF_RUNNING) != 0;
+    ofpbuf_delete(buf);
+    return true;
+}
+
+/* Queries the current carrier of 'netdev'.  On success stores it in '*carrier'
+ * and returns true; on failure leaves '*carrier' untouched and returns false
+ * (caller keeps its cached value).
  *
- * The Hyper-V extensible switch does not deliver an external adapter's
- * link-state change down to a forwarding extension (the ovsext datapath): the
- * NIC status indication is consumed at the switch's miniport/protocol edge, so
- * the datapath never sees a member's carrier go down.  This is not specific to
- * teaming -- it holds for any external NIC, SET member or single adapter.  The
- * host network stack does track each adapter's media state, so carrier is read
- * from MIB_IF_ROW2.MediaConnectState here. */
+ * Two link-state sources are combined.  A physical adapter / SET member
+ * resolves to a host interface whose MIB_IF_ROW2.MediaConnectState detects a
+ * physical link-down that the datapath port state cannot see -- the Hyper-V
+ * switch consumes the NIC status indication at its miniport/protocol edge and
+ * never delivers it to the forwarding extension.  A virtual port (a VM vNIC, or
+ * a userspace-first ghost awaiting attach) has no host interface and no host
+ * MAC to match, so the kernel datapath link state (IFF_RUNNING) is the only
+ * truth.  Carrier is media-up AND kernel-up where both apply, else whichever is
+ * available. */
 static bool
 netdev_windows_query_carrier(struct netdev_windows *netdev, bool *carrier)
 {
+    bool kernel_up = false;
+    bool have_kernel = netdev_windows_refresh_kernel(netdev, &kernel_up);
     MIB_IF_ROW2 row;
 
-    if (!netdev->if_luid_valid && !netdev_windows_resolve_luid(netdev)) {
-        return false;
+    if (netdev->if_luid_valid || netdev_windows_resolve_luid(netdev)) {
+        memset(&row, 0, sizeof row);
+        row.InterfaceLuid = netdev->if_luid;
+        if (GetIfEntry2(&row) != NO_ERROR) {
+            /* The adapter likely went away; re-resolve the LUID next tick. */
+            netdev->if_luid_valid = false;
+        } else {
+            bool media = (row.MediaConnectState == MediaConnectStateConnected);
+            *carrier = have_kernel ? (kernel_up && media) : media;
+            return true;
+        }
     }
-    memset(&row, 0, sizeof row);
-    row.InterfaceLuid = netdev->if_luid;
-    if (GetIfEntry2(&row) != NO_ERROR) {
-        /* The adapter likely went away; re-resolve the LUID next tick. */
-        netdev->if_luid_valid = false;
-        return false;
+
+    if (have_kernel) {
+        *carrier = kernel_up;
+        return true;
     }
-    *carrier = (row.MediaConnectState == MediaConnectStateConnected);
-    return true;
+    return false;
 }
 
 static int
@@ -624,14 +688,25 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
     ovs_mutex_lock(&netdev_windows_list_mutex);
     LIST_FOR_EACH (netdev, list_node, &netdev_windows_list) {
         bool carrier;
+        uint32_t old_flags = netdev->ifi_flags;
+        bool changed = false;
 
         if (netdev_windows_query_carrier(netdev, &carrier)
             && carrier != netdev->carrier) {
             netdev->carrier = carrier;
             netdev->carrier_resets++;
-            netdev_change_seq_changed(&netdev->up);
+            changed = true;
             VLOG_DBG("%s: carrier %s", netdev_get_name(&netdev->up),
                      carrier ? "up" : "down");
+        }
+        /* netdev_windows_query_carrier() re-syncs the cached admin flags from
+         * the kernel; a transition (notably a resurrected ghost coming up)
+         * must wake the status refresh that publishes admin_state/link_state. */
+        if (netdev->ifi_flags != old_flags) {
+            changed = true;
+        }
+        if (changed) {
+            netdev_change_seq_changed(&netdev->up);
         }
     }
     ovs_mutex_unlock(&netdev_windows_list_mutex);

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -562,19 +562,39 @@ netdev_windows_internal_construct(struct netdev *netdev_)
 }
 
 
-/* Resolves and caches 'netdev''s host interface LUID by matching its MAC in the
- * system interface table.  This walk of the full table happens at most once per
- * netdev (and again only if the interface disappears); the per-poll carrier read
- * then uses a single-interface GetIfEntry2() instead of re-enumerating every
- * tick.  Returns true once 'if_luid' is valid. */
+/* One netdev's link state, gathered by the periodic refresh without holding
+ * netdev_windows_list_mutex (the per-port kernel/host I/O would otherwise block
+ * every netdev API call for the duration of all the round trips) and committed
+ * back under the lock.  'name' is the stable identity used to match the result
+ * to the still-listed netdev; the 'in_*' fields are the cached inputs the probe
+ * needs, snapshotted under the lock. */
+struct netdev_windows_probe {
+    char *name;                        /* owned; the netdev's unique identity. */
+    struct eth_addr in_mac;            /* cached MAC, to reuse a resolved LUID. */
+    NET_LUID in_luid;
+    bool in_luid_valid;
+
+    bool kernel_valid;                 /* the OVS_WIN_NETDEV_CMD_GET succeeded. */
+    uint32_t ifi_flags;
+    struct eth_addr mac;
+    int mtu;
+    bool carrier_valid;                /* a link state was determined. */
+    bool carrier;
+    bool luid_valid;                   /* resolved host-interface LUID. */
+    NET_LUID if_luid;
+};
+
+/* Finds the host interface LUID whose MAC is 'mac' by matching the system
+ * interface table.  Returns true and stores it in '*luid' on a match.  Touches
+ * no netdev state, so it is safe to call without netdev_windows_list_mutex. */
 static bool
-netdev_windows_resolve_luid(struct netdev_windows *netdev)
+netdev_windows_lookup_luid(struct eth_addr mac, NET_LUID *luid)
 {
     MIB_IF_TABLE2 *table = NULL;
+    bool found = false;
     ULONG i;
 
-    if (!(netdev->cache_valid & VALID_ETHERADDR)
-        || eth_addr_is_zero(netdev->mac)
+    if (eth_addr_is_zero(mac)
         || GetIfTable2(&table) != NO_ERROR || table == NULL) {
         /* No usable MAC to match (e.g. a ghost constructed while its device was
          * absent) -- do not match a host pseudo-interface with a zero MAC. */
@@ -584,57 +604,24 @@ netdev_windows_resolve_luid(struct netdev_windows *netdev)
         const MIB_IF_ROW2 *row = &table->Table[i];
 
         if (row->PhysicalAddressLength == ETH_ADDR_LEN
-            && !memcmp(row->PhysicalAddress, netdev->mac.ea, ETH_ADDR_LEN)) {
-            netdev->if_luid = row->InterfaceLuid;
-            netdev->if_luid_valid = true;
+            && !memcmp(row->PhysicalAddress, mac.ea, ETH_ADDR_LEN)) {
+            *luid = row->InterfaceLuid;
+            found = true;
             break;
         }
     }
     FreeMibTable(table);
-    return netdev->if_luid_valid;
+    return found;
 }
 
-/* Re-syncs 'netdev''s cached device properties (admin flags, MAC, MTU) from its
- * kernel vport and reports the datapath link state.  Windows has no asynchronous
- * device-change notification; the Linux netdev keeps 'ifi_flags' current from
- * rtnetlink RTM_NEWLINK messages, and the periodic refresh in
- * netdev_windows_run() is the equivalent resync point here.  This matters for a
+/* Gathers 'p''s link state from the kernel vport and the host interface,
+ * performing all the I/O without touching any netdev or the list mutex.
+ *
+ * The kernel GET re-syncs admin flags, MAC and MTU; this matters for a
  * userspace-first ghost (constructed while its Hyper-V adapter was absent, so
- * query_netdev() failed and the cached flags came up empty): once the port is
- * resurrected the vport reports OVS_WIN_NETDEV_IFF_UP, without which the shared
- * netdev_get_carrier() would short-circuit the interface to admin-down.  On
- * success stores the kernel link state (OVS_WIN_NETDEV_IFF_RUNNING) in '*up' and
- * returns true. */
-static bool
-netdev_windows_refresh_kernel(struct netdev_windows *netdev, bool *up)
-{
-    struct netdev_windows_netdev_info info;
-    struct ofpbuf *buf;
-
-    if (query_netdev(netdev_get_name(&netdev->up), &info, &buf)) {
-        return false;
-    }
-
-    netdev->ifi_flags = dp_to_netdev_ifi_flags(info.ifi_flags);
-    netdev->cache_valid |= VALID_IFFLAG;
-    /* A changed MAC (notably a ghost gaining its real address at resurrection)
-     * invalidates the cached host-interface LUID, which is keyed by MAC. */
-    if (!eth_addr_equals(netdev->mac, info.mac_address)) {
-        netdev->if_luid_valid = false;
-    }
-    netdev->mac = info.mac_address;
-    netdev->cache_valid |= VALID_ETHERADDR;
-    netdev->mtu = info.mtu;
-    netdev->cache_valid |= VALID_MTU;
-
-    *up = (info.ifi_flags & OVS_WIN_NETDEV_IFF_RUNNING) != 0;
-    ofpbuf_delete(buf);
-    return true;
-}
-
-/* Queries the current carrier of 'netdev'.  On success stores it in '*carrier'
- * and returns true; on failure leaves '*carrier' untouched and returns false
- * (caller keeps its cached value).
+ * the flags came up empty): once the port is resurrected the vport reports
+ * OVS_WIN_NETDEV_IFF_UP, without which netdev_get_carrier() would short-circuit
+ * the interface to admin-down.
  *
  * Two link-state sources are combined.  A physical adapter / SET member
  * resolves to a host interface whose MIB_IF_ROW2.MediaConnectState detects a
@@ -645,31 +632,82 @@ netdev_windows_refresh_kernel(struct netdev_windows *netdev, bool *up)
  * MAC to match, so the kernel datapath link state (IFF_RUNNING) is the only
  * truth.  Carrier is media-up AND kernel-up where both apply, else whichever is
  * available. */
-static bool
-netdev_windows_query_carrier(struct netdev_windows *netdev, bool *carrier)
+static void
+netdev_windows_probe_gather(struct netdev_windows_probe *p)
 {
+    struct netdev_windows_netdev_info info;
+    struct ofpbuf *buf;
     bool kernel_up = false;
-    bool have_kernel = netdev_windows_refresh_kernel(netdev, &kernel_up);
+    struct eth_addr mac;
+    NET_LUID luid = p->in_luid;
+    bool luid_valid;
     MIB_IF_ROW2 row;
 
-    if (netdev->if_luid_valid || netdev_windows_resolve_luid(netdev)) {
-        memset(&row, 0, sizeof row);
-        row.InterfaceLuid = netdev->if_luid;
-        if (GetIfEntry2(&row) != NO_ERROR) {
-            /* The adapter likely went away; re-resolve the LUID next tick. */
-            netdev->if_luid_valid = false;
-        } else {
-            bool media = (row.MediaConnectState == MediaConnectStateConnected);
-            *carrier = have_kernel ? (kernel_up && media) : media;
-            return true;
-        }
+    if (!query_netdev(p->name, &info, &buf)) {
+        p->kernel_valid = true;
+        p->ifi_flags = dp_to_netdev_ifi_flags(info.ifi_flags);
+        p->mac = info.mac_address;
+        p->mtu = info.mtu;
+        kernel_up = (info.ifi_flags & OVS_WIN_NETDEV_IFF_RUNNING) != 0;
+        ofpbuf_delete(buf);
     }
 
-    if (have_kernel) {
-        *carrier = kernel_up;
-        return true;
+    /* Match the host interface on the freshest MAC.  A changed MAC (a ghost
+     * gaining its real address at resurrection) invalidates a cached LUID. */
+    mac = p->kernel_valid ? p->mac : p->in_mac;
+    luid_valid = p->in_luid_valid && eth_addr_equals(mac, p->in_mac);
+    if (!luid_valid) {
+        luid_valid = netdev_windows_lookup_luid(mac, &luid);
     }
-    return false;
+
+    if (luid_valid) {
+        memset(&row, 0, sizeof row);
+        row.InterfaceLuid = luid;
+        if (GetIfEntry2(&row) != NO_ERROR) {
+            /* The adapter likely went away; re-resolve the LUID next tick. */
+            luid_valid = false;
+        } else {
+            bool media = (row.MediaConnectState == MediaConnectStateConnected);
+            p->carrier = p->kernel_valid ? (kernel_up && media) : media;
+            p->carrier_valid = true;
+        }
+    }
+    if (!p->carrier_valid && p->kernel_valid) {
+        p->carrier = kernel_up;
+        p->carrier_valid = true;
+    }
+    p->luid_valid = luid_valid;
+    p->if_luid = luid;
+}
+
+/* Commits a gathered probe to its 'netdev', returning true if anything the
+ * change sequence covers (admin flags, MAC, MTU or carrier) changed. */
+static bool
+netdev_windows_probe_commit(struct netdev_windows *netdev,
+                            const struct netdev_windows_probe *p)
+    OVS_REQUIRES(netdev_windows_list_mutex)
+{
+    bool changed = false;
+
+    if (p->kernel_valid) {
+        changed = netdev->ifi_flags != p->ifi_flags
+                  || !eth_addr_equals(netdev->mac, p->mac)
+                  || netdev->mtu != p->mtu;
+        netdev->ifi_flags = p->ifi_flags;
+        netdev->mac = p->mac;
+        netdev->mtu = p->mtu;
+        netdev->cache_valid |= VALID_IFFLAG | VALID_ETHERADDR | VALID_MTU;
+    }
+    netdev->if_luid = p->if_luid;
+    netdev->if_luid_valid = p->luid_valid;
+
+    if (p->carrier_valid && p->carrier != netdev->carrier) {
+        netdev->carrier = p->carrier;
+        netdev->carrier_resets++;
+        changed = true;
+        VLOG_DBG("%s: carrier %s", p->name, p->carrier ? "up" : "down");
+    }
+    return changed;
 }
 
 static int
@@ -697,15 +735,25 @@ netdev_windows_get_carrier_resets(const struct netdev *netdev_)
     return resets;
 }
 
-/* Periodically re-queries the media carrier of every Windows netdev and, on a
- * transition, bumps the change sequence so dependent logic (notably bonding)
- * re-evaluates which members are usable.  The whole list is refreshed together
- * regardless of which class triggered the tick. */
+/* Periodically re-queries every Windows netdev's link state and, on a change to
+ * carrier / admin flags / MAC / MTU, bumps the change sequence so dependent
+ * logic (notably bonding) re-evaluates it.  The whole list is refreshed
+ * together regardless of which class triggered the tick.
+ *
+ * The per-port kernel/host I/O runs outside netdev_windows_list_mutex: the lock
+ * is taken only to snapshot the probe inputs and again to commit the results,
+ * so it never spans the DeviceIoControl/GetIfEntry2 round trips and cannot
+ * block unrelated netdev API calls for their duration.  Results are matched
+ * back by the netdev's stable, unique name, so a port deleted during the probe
+ * window is simply skipped (no reference is held across the I/O, avoiding a
+ * lock-order inversion with netdev_unref()'s destruct path). */
 static void
 netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
 {
+    struct netdev_windows_probe *probes;
     struct netdev_windows *netdev;
     long long int now = time_msec();
+    size_t n = 0, cap, i;
 
     if (now < netdev_windows_next_refresh) {
         return;
@@ -713,36 +761,40 @@ netdev_windows_run(const struct netdev_class *netdev_class OVS_UNUSED)
     netdev_windows_next_refresh = now + NETDEV_WINDOWS_CARRIER_INTERVAL_MS;
 
     ovs_mutex_lock(&netdev_windows_list_mutex);
+    cap = ovs_list_size(&netdev_windows_list);
+    probes = cap ? xmalloc(cap * sizeof *probes) : NULL;
     LIST_FOR_EACH (netdev, list_node, &netdev_windows_list) {
-        bool carrier;
-        uint32_t old_flags = netdev->ifi_flags;
-        struct eth_addr old_mac = netdev->mac;
-        int old_mtu = netdev->mtu;
-        bool changed = false;
+        struct netdev_windows_probe *p = &probes[n++];
 
-        if (netdev_windows_query_carrier(netdev, &carrier)
-            && carrier != netdev->carrier) {
-            netdev->carrier = carrier;
-            netdev->carrier_resets++;
-            changed = true;
-            VLOG_DBG("%s: carrier %s", netdev_get_name(&netdev->up),
-                     carrier ? "up" : "down");
-        }
-        /* netdev_windows_query_carrier() re-syncs the cached admin flags, MAC
-         * and MTU from the kernel; any of these changing (notably a resurrected
-         * ghost coming up or gaining its real MAC without an IFF_UP transition)
-         * must bump change_seq so consumers re-read etheraddr/mtu and the status
-         * refresh re-publishes admin_state/link_state. */
-        if (netdev->ifi_flags != old_flags
-            || !eth_addr_equals(netdev->mac, old_mac)
-            || netdev->mtu != old_mtu) {
-            changed = true;
-        }
-        if (changed) {
-            netdev_change_seq_changed(&netdev->up);
+        memset(p, 0, sizeof *p);
+        p->name = xstrdup(netdev_get_name(&netdev->up));
+        p->in_mac = netdev->mac;
+        p->in_luid = netdev->if_luid;
+        p->in_luid_valid = netdev->if_luid_valid;
+    }
+    ovs_mutex_unlock(&netdev_windows_list_mutex);
+
+    for (i = 0; i < n; i++) {
+        netdev_windows_probe_gather(&probes[i]);
+    }
+
+    ovs_mutex_lock(&netdev_windows_list_mutex);
+    LIST_FOR_EACH (netdev, list_node, &netdev_windows_list) {
+        for (i = 0; i < n; i++) {
+            if (!strcmp(probes[i].name, netdev_get_name(&netdev->up))) {
+                if (netdev_windows_probe_commit(netdev, &probes[i])) {
+                    netdev_change_seq_changed(&netdev->up);
+                }
+                break;
+            }
         }
     }
     ovs_mutex_unlock(&netdev_windows_list_mutex);
+
+    for (i = 0; i < n; i++) {
+        free(probes[i].name);
+    }
+    free(probes);
 }
 
 static void

--- a/lib/netdev-windows.c
+++ b/lib/netdev-windows.c
@@ -374,28 +374,37 @@ netdev_windows_get_etheraddr(const struct netdev *netdev_,
                              struct eth_addr *mac)
 {
     struct netdev_windows *netdev = netdev_windows_cast(netdev_);
+    int error = 0;
 
+    /* netdev_windows_run() re-syncs 'mac'/'cache_valid' from the kernel under
+     * this mutex; read them under the same lock since netdev APIs may be called
+     * from other threads. */
+    ovs_mutex_lock(&netdev_windows_list_mutex);
     ovs_assert((netdev->cache_valid & VALID_ETHERADDR) != 0);
     if (netdev->cache_valid & VALID_ETHERADDR) {
         *mac = netdev->mac;
     } else {
-        return EINVAL;
+        error = EINVAL;
     }
-    return 0;
+    ovs_mutex_unlock(&netdev_windows_list_mutex);
+    return error;
 }
 
 static int
 netdev_windows_get_mtu(const struct netdev *netdev_, int *mtup)
 {
     struct netdev_windows *netdev = netdev_windows_cast(netdev_);
+    int error = 0;
 
+    ovs_mutex_lock(&netdev_windows_list_mutex);
     ovs_assert((netdev->cache_valid & VALID_MTU) != 0);
     if (netdev->cache_valid & VALID_MTU) {
         *mtup = netdev->mtu;
     } else {
-        return EINVAL;
+        error = EINVAL;
     }
-    return 0;
+    ovs_mutex_unlock(&netdev_windows_list_mutex);
+    return error;
 }
 
 /* This functionality is not really required by the datapath.
@@ -416,15 +425,18 @@ netdev_windows_update_flags(struct netdev *netdev_,
                             enum netdev_flags *old_flagsp)
 {
     struct netdev_windows *netdev = netdev_windows_cast(netdev_);
+    int error = 0;
 
+    ovs_mutex_lock(&netdev_windows_list_mutex);
     ovs_assert((netdev->cache_valid & VALID_IFFLAG) != 0);
     if (netdev->cache_valid & VALID_IFFLAG) {
         *old_flagsp = netdev->ifi_flags;
         /* Setting the interface flags is not supported. */
     } else {
-        return EINVAL;
+        error = EINVAL;
     }
-    return 0;
+    ovs_mutex_unlock(&netdev_windows_list_mutex);
+    return error;
 }
 
 /* Looks up in the ARP table entry for a given 'ip'. If it is found, the

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -1778,6 +1778,13 @@ test_netdev_refresh(struct mock_kernel *m)
     CHECK(netdev_get_change_seq(netdev) != seq0);
 
     netdev_close(netdev);
+
+    /* A userspace-first ghost (the device is absent at construct) has no kernel
+     * MTU yet; get_mtu must report it unknown rather than a bogus 0. */
+    m->nd_present = false;
+    CHECK(netdev_open("nd-ghost", "system", &netdev) == 0);
+    CHECK(netdev_get_mtu(netdev, &mtu) != 0);
+    netdev_close(netdev);
 }
 
 /* Concurrency for the refactored refresh: netdev_windows_run() now does its
@@ -1929,8 +1936,8 @@ main(int argc, char *argv[])
     test_meters(dpif, &mock);
     test_feature_negotiation(dpif, &mock);
 
-    /* The "system" netdev provider shares the mock ovsext transport. */
-    netdev_register_provider(&netdev_windows_class);
+    /* The "system" netdev provider shares the mock ovsext transport; it is
+     * registered by netdev_initialize() the first time a netdev is opened. */
     test_netdev_refresh(&mock);
     test_netdev_refresh_concurrent(&mock);
 

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -37,6 +37,8 @@
 
 #include "dpif.h"
 #include "ct-dpif.h"
+#include "netdev.h"
+#include "netdev-provider.h"
 #include "openvswitch/ofp-meter.h"
 #include "ovsext-channel.h"
 #include "dp-packet.h"
@@ -50,6 +52,9 @@
 #include "packets.h"
 #include "unaligned.h"
 #include "util.h"
+#include "ovs-atomic.h"
+#include "ovs-thread.h"
+#include "timeval.h"
 
 /* The ovsext ABI (IOCTL codes, fixed genl family ids, struct ovs_header). */
 #include "OvsDpInterfaceExt.h"
@@ -150,6 +155,16 @@ struct mock_kernel {
      * omits them (modelling an older kernel that never negotiates). */
     uint32_t dp_user_features;
     bool     dp_echo_features;
+
+    /* OVS_WIN_NETDEV family state.  The netdev provider's construct and its
+     * periodic netdev_windows_run() refresh query this; the latter commits it to
+     * the netdev's cached admin flags / MAC / MTU / carrier. */
+    bool     nd_present;       /* GET succeeds (the vport exists). */
+    uint32_t nd_type;
+    uint32_t nd_port_no;
+    struct eth_addr nd_mac;
+    uint32_t nd_mtu;
+    uint32_t nd_flags;         /* OVS_WIN_NETDEV_IFF_*. */
 };
 
 /* ---- record builders ----------------------------------------------------- */
@@ -555,6 +570,43 @@ mock_dp_transact(struct mock_kernel *m, const void *in, DWORD in_len,
     return TRUE;
 }
 
+/* Answers an OVS_WIN_NETDEV_CMD_GET as OvsCreateMsgFromVport does: NL_ERROR_NODEV
+ * when the vport is absent, else a reply carrying the programmed
+ * port_no/type/name/mac/mtu/if_flags. */
+static BOOL
+mock_netdev_get(struct mock_kernel *m, const void *in OVS_UNUSED,
+                DWORD in_len OVS_UNUSED, void *out, DWORD out_len, DWORD *bytes)
+{
+    uint64_t stub[512 / 8];
+    struct ofpbuf r;
+    struct ovs_header *ovs_header;
+    DWORD n;
+
+    if (!m->nd_present) {
+        return reply_nlmsgerr(ENODEV, out, out_len, bytes);
+    }
+
+    ofpbuf_use_stub(&r, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&r, 0, OVS_WIN_NL_NETDEV_FAMILY_ID, 0,
+                          OVS_WIN_NETDEV_CMD_GET, 1);
+    ovs_header = ofpbuf_put_uninit(&r, sizeof *ovs_header);
+    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+    nl_msg_put_u32(&r, OVS_WIN_NETDEV_ATTR_PORT_NO, m->nd_port_no);
+    nl_msg_put_u32(&r, OVS_WIN_NETDEV_ATTR_TYPE, m->nd_type);
+    nl_msg_put_string(&r, OVS_WIN_NETDEV_ATTR_NAME, "nd-test");
+    nl_msg_put_unspec(&r, OVS_WIN_NETDEV_ATTR_MAC_ADDR, &m->nd_mac,
+                      sizeof m->nd_mac);
+    nl_msg_put_u32(&r, OVS_WIN_NETDEV_ATTR_MTU, m->nd_mtu);
+    nl_msg_put_u32(&r, OVS_WIN_NETDEV_ATTR_IF_FLAGS, m->nd_flags);
+    nl_msg_nlmsghdr(&r)->nlmsg_len = r.size;
+
+    n = r.size < out_len ? (DWORD) r.size : out_len;
+    memcpy(out, r.data, n);
+    *bytes = n;
+    ofpbuf_uninit(&r);
+    return TRUE;
+}
+
 static BOOL
 mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
               void *out, DWORD out_len, DWORD *bytes)
@@ -593,6 +645,9 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
 
     case OVS_WIN_NL_DATAPATH_FAMILY_ID:
         return mock_dp_transact(m, in, in_len, out, out_len, bytes);
+
+    case OVS_WIN_NL_NETDEV_FAMILY_ID:
+        return mock_netdev_get(m, in, in_len, out, out_len, bytes);
 
     case OVS_WIN_NL_FLOW_FAMILY_ID:
         switch (m->flow_reply) {
@@ -1678,6 +1733,145 @@ test_meters(struct dpif *dpif, struct mock_kernel *m)
     CHECK(stats.n_bands == 1);
 }
 
+/* The "system" netdev provider refreshes its cached admin flags / MAC / MTU /
+ * carrier from the kernel in netdev_windows_run().  Construct one against the
+ * mock, change the kernel-reported state, run one refresh tick, and confirm the
+ * new MAC/MTU are committed, carrier follows the link bit, and change_seq is
+ * bumped -- exercising the lock-free snapshot/gather/commit path. */
+static void
+test_netdev_refresh(struct mock_kernel *m)
+{
+    const struct eth_addr mac_a = { .ea = { 0x02, 0, 0, 0, 0, 0x0a } };
+    const struct eth_addr mac_b = { .ea = { 0x02, 0, 0, 0, 0, 0x0b } };
+    struct netdev *netdev;
+    struct eth_addr got;
+    uint64_t seq0;
+    int mtu;
+
+    printf("test_netdev_refresh:\n");
+    mock_reset_content(m);
+
+    /* Construct-time state: admin-up, link-up, MAC A, MTU 1400. */
+    m->nd_present = true;
+    m->nd_type = OVS_VPORT_TYPE_NETDEV;
+    m->nd_port_no = 7;
+    m->nd_mac = mac_a;
+    m->nd_mtu = 1400;
+    m->nd_flags = OVS_WIN_NETDEV_IFF_UP | OVS_WIN_NETDEV_IFF_RUNNING;
+
+    CHECK(netdev_open("nd-test", "system", &netdev) == 0);
+    CHECK(netdev_get_etheraddr(netdev, &got) == 0 && eth_addr_equals(got, mac_a));
+    seq0 = netdev_get_change_seq(netdev);
+
+    /* The kernel now reports a new MAC and MTU and the link going down (no
+     * RUNNING).  'nd-test' has no host interface matching its synthetic MAC, so
+     * carrier resolves purely from the kernel link state. */
+    m->nd_mac = mac_b;
+    m->nd_mtu = 1500;
+    m->nd_flags = OVS_WIN_NETDEV_IFF_UP;
+
+    netdev_windows_class.run(&netdev_windows_class);
+
+    CHECK(netdev_get_etheraddr(netdev, &got) == 0 && eth_addr_equals(got, mac_b));
+    CHECK(netdev_get_mtu(netdev, &mtu) == 0 && mtu == 1500);
+    CHECK(!netdev_get_carrier(netdev));
+    CHECK(netdev_get_change_seq(netdev) != seq0);
+
+    netdev_close(netdev);
+}
+
+/* Concurrency for the refactored refresh: netdev_windows_run() now does its
+ * per-port I/O without holding netdev_windows_list_mutex and re-takes it only to
+ * commit, so a reader calling netdev APIs must coexist with it.  A reader thread
+ * hammers the cached fields while the main thread drives many refresh/commit
+ * cycles (time is warped past the 1s gate), each flipping the kernel-reported
+ * MAC.  The commit writes the 6-byte MAC under the lock, so the locked reader
+ * must only ever see a fully-written MAC (0xAA.. or 0xBB..); a torn value means
+ * the lock was dropped.  The test also wedges if the lock discipline can
+ * deadlock against a concurrent reader. */
+#define NDC_REFRESH_ITERS 2000
+
+static struct netdev *ndc_netdev;
+static const struct eth_addr ndc_mac_a = { .ea = { 0xaa, 0xaa, 0xaa, 0xaa,
+                                                   0xaa, 0xaa } };
+static const struct eth_addr ndc_mac_b = { .ea = { 0xbb, 0xbb, 0xbb, 0xbb,
+                                                   0xbb, 0xbb } };
+static atomic_bool ndc_stop;
+static atomic_bool ndc_torn;
+static atomic_uint64_t ndc_reads;
+
+static void *
+ndc_reader(void *arg OVS_UNUSED)
+{
+    uint64_t reads = 0;
+    bool stop = false;
+
+    while (!stop) {
+        struct eth_addr got;
+        int mtu;
+
+        if (netdev_get_etheraddr(ndc_netdev, &got) == 0
+            && !eth_addr_equals(got, ndc_mac_a)
+            && !eth_addr_equals(got, ndc_mac_b)) {
+            atomic_store_relaxed(&ndc_torn, true);
+        }
+        netdev_get_mtu(ndc_netdev, &mtu);
+        netdev_get_carrier(ndc_netdev);
+        reads++;
+        atomic_read_relaxed(&ndc_stop, &stop);
+    }
+    atomic_store_relaxed(&ndc_reads, reads);
+    return NULL;
+}
+
+static void
+test_netdev_refresh_concurrent(struct mock_kernel *m)
+{
+    pthread_t reader;
+    uint64_t reads;
+    bool torn;
+    int i;
+
+    printf("test_netdev_refresh_concurrent:\n");
+    mock_reset_content(m);
+    m->nd_present = true;
+    m->nd_type = OVS_VPORT_TYPE_NETDEV;
+    m->nd_port_no = 9;
+    m->nd_mac = ndc_mac_a;
+    m->nd_mtu = 1400;
+    m->nd_flags = OVS_WIN_NETDEV_IFF_UP | OVS_WIN_NETDEV_IFF_RUNNING;
+
+    CHECK(netdev_open("nd-conc", "system", &ndc_netdev) == 0);
+
+    atomic_init(&ndc_stop, false);
+    atomic_init(&ndc_torn, false);
+    atomic_init(&ndc_reads, 0);
+    reader = ovs_thread_create("nd-reader", ndc_reader, NULL);
+
+    for (i = 0; i < NDC_REFRESH_ITERS; i++) {
+        m->nd_mac = (i & 1) ? ndc_mac_b : ndc_mac_a;
+        netdev_windows_class.run(&netdev_windows_class);
+        /* Jump past the refresh gate so the next run() actually executes. */
+        timeval_warp(2000);
+    }
+
+    atomic_store_relaxed(&ndc_stop, true);
+    xpthread_join(reader, NULL);
+
+    atomic_read_relaxed(&ndc_torn, &torn);
+    atomic_read_relaxed(&ndc_reads, &reads);
+    CHECK(!torn);            /* the reader never saw a partially-written MAC. */
+    CHECK(reads > 0);        /* the reader actually ran alongside the refresh. */
+
+    /* The last iteration set MAC B; if it committed, the gate was really
+     * defeated and run() executed every iteration (not skipped as a no-op). */
+    struct eth_addr final_mac;
+    CHECK(netdev_get_etheraddr(ndc_netdev, &final_mac) == 0
+          && eth_addr_equals(final_mac, ndc_mac_b));
+
+    netdev_close(ndc_netdev);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1734,6 +1928,11 @@ main(int argc, char *argv[])
     test_ct_limits(dpif, &mock);
     test_meters(dpif, &mock);
     test_feature_negotiation(dpif, &mock);
+
+    /* The "system" netdev provider shares the mock ovsext transport. */
+    netdev_register_provider(&netdev_windows_class);
+    test_netdev_refresh(&mock);
+    test_netdev_refresh_concurrent(&mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -588,7 +588,7 @@ mock_netdev_get(struct mock_kernel *m, const void *in OVS_UNUSED,
 
     ofpbuf_use_stub(&r, stub, sizeof stub);
     nl_msg_put_genlmsghdr(&r, 0, OVS_WIN_NL_NETDEV_FAMILY_ID, 0,
-                          OVS_WIN_NETDEV_CMD_GET, 1);
+                          OVS_WIN_NETDEV_CMD_GET, OVS_WIN_NETDEV_VERSION);
     ovs_header = ofpbuf_put_uninit(&r, sizeof *ovs_header);
     ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
     nl_msg_put_u32(&r, OVS_WIN_NETDEV_ATTR_PORT_NO, m->nd_port_no);
@@ -1770,6 +1770,9 @@ test_netdev_refresh(struct mock_kernel *m)
     m->nd_mtu = 1500;
     m->nd_flags = OVS_WIN_NETDEV_IFF_UP;
 
+    /* Jump past the 1s refresh gate so this run() executes regardless of any
+     * earlier test having armed netdev_windows_next_refresh. */
+    timeval_warp(2000);
     netdev_windows_class.run(&netdev_windows_class);
 
     CHECK(netdev_get_etheraddr(netdev, &got) == 0 && eth_addr_equals(got, mac_b));
@@ -1805,29 +1808,31 @@ static const struct eth_addr ndc_mac_b = { .ea = { 0xbb, 0xbb, 0xbb, 0xbb,
                                                    0xbb, 0xbb } };
 static atomic_bool ndc_stop;
 static atomic_bool ndc_torn;
-static atomic_uint64_t ndc_reads;
+static atomic_bool ndc_saw_a;       /* reader observed MAC A while refreshing. */
+static atomic_bool ndc_saw_b;       /* reader observed MAC B while refreshing. */
 
 static void *
 ndc_reader(void *arg OVS_UNUSED)
 {
-    uint64_t reads = 0;
     bool stop = false;
 
     while (!stop) {
         struct eth_addr got;
         int mtu;
 
-        if (netdev_get_etheraddr(ndc_netdev, &got) == 0
-            && !eth_addr_equals(got, ndc_mac_a)
-            && !eth_addr_equals(got, ndc_mac_b)) {
-            atomic_store_relaxed(&ndc_torn, true);
+        if (netdev_get_etheraddr(ndc_netdev, &got) == 0) {
+            if (eth_addr_equals(got, ndc_mac_a)) {
+                atomic_store_relaxed(&ndc_saw_a, true);
+            } else if (eth_addr_equals(got, ndc_mac_b)) {
+                atomic_store_relaxed(&ndc_saw_b, true);
+            } else {
+                atomic_store_relaxed(&ndc_torn, true);
+            }
         }
         netdev_get_mtu(ndc_netdev, &mtu);
         netdev_get_carrier(ndc_netdev);
-        reads++;
         atomic_read_relaxed(&ndc_stop, &stop);
     }
-    atomic_store_relaxed(&ndc_reads, reads);
     return NULL;
 }
 
@@ -1835,8 +1840,7 @@ static void
 test_netdev_refresh_concurrent(struct mock_kernel *m)
 {
     pthread_t reader;
-    uint64_t reads;
-    bool torn;
+    bool torn, saw_a, saw_b;
     int i;
 
     printf("test_netdev_refresh_concurrent:\n");
@@ -1852,7 +1856,8 @@ test_netdev_refresh_concurrent(struct mock_kernel *m)
 
     atomic_init(&ndc_stop, false);
     atomic_init(&ndc_torn, false);
-    atomic_init(&ndc_reads, 0);
+    atomic_init(&ndc_saw_a, false);
+    atomic_init(&ndc_saw_b, false);
     reader = ovs_thread_create("nd-reader", ndc_reader, NULL);
 
     for (i = 0; i < NDC_REFRESH_ITERS; i++) {
@@ -1866,9 +1871,12 @@ test_netdev_refresh_concurrent(struct mock_kernel *m)
     xpthread_join(reader, NULL);
 
     atomic_read_relaxed(&ndc_torn, &torn);
-    atomic_read_relaxed(&ndc_reads, &reads);
+    atomic_read_relaxed(&ndc_saw_a, &saw_a);
+    atomic_read_relaxed(&ndc_saw_b, &saw_b);
     CHECK(!torn);            /* the reader never saw a partially-written MAC. */
-    CHECK(reads > 0);        /* the reader actually ran alongside the refresh. */
+    /* The reader observed BOTH alternating MACs, proving it actually overlapped
+     * the refresh/commit cycles (not merely ran before or after them). */
+    CHECK(saw_a && saw_b);
 
     /* The last iteration set MAC B; if it committed, the gate was really
      * defeated and run() executed every iteration (not skipped as a no-op). */


### PR DESCRIPTION
ovs-vswitchd can now pre-create a NETDEV/INTERNAL "ghost" vport by name before its Hyper-V port exists; the kernel resurrects it in place when the VM's vNIC connects. This removes that add-port requires to be synced with VM livecycle events and enables OVN live-migration pre-binding.

**Kernel (ovsext)**
- `OvsNewVportCmdHandler` allocates a ghost (`isAbsentOnHv`, `hvAttachPending`, `OVS_STATE_NIC_CREATED`), populating `portFriendlyName` from the OVS name so `HvCreatePort` resurrects it; `numHvVports` stays balanced on teardown.
- `HvCreatePort` skips the NDIS `portType` equality check for ghosts; `HvConnectNic` posts `OVS_EVENT_LINK_UP|CONNECT` on attach.
- `Event.c`: stop mutating the shared `event->type` while masking per queue (a later disjoint-mask queue could miss a multi-bit event).
- Add `OVS_WIN_NETDEV_IFF_RUNNING` and map vport status to `IFF_UP`/`IFF_RUNNING`.

**Userspace (netdev-windows)**
- Defer construct for an absent `system`/`internal` device, gated on `ENODEV` (matching `netdev-linux`), so `dpif_port_add` creates the ghost.
- Re-sync cached `ifi_flags`/MAC/MTU from the kernel on each carrier poll — the Windows analog of Linux rtnetlink `ifi_flags` updates. Without `NETDEV_UP` the shared `netdev_get_carrier()` short-circuits `link_state` to down, so a resurrected ghost reported `link_state=down` despite forwarding; this fixes it. Also invalidate the MAC-keyed host LUID cache when the MAC changes.
