### PR TITLE
dpif-windows: fix upcall truncation and dpif-contract divergences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,11 @@ set(OVS_INCLUDES
   "${PTHREADS_ROOT}/include" "${OPENSSL_ROOT}/include")
 set(OVS_DEFS HAVE_CONFIG_H _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
              _WINSOCK_DEPRECATED_NO_WARNINGS)
+# -DOVS_ASAN=ON instruments every OVS target with AddressSanitizer (MSVC
+# /fsanitize=address), so the unit tests catch heap overruns / use-after-free in
+# the userspace marshalling.  Off by default; use a dedicated build directory.
+option(OVS_ASAN "Build with AddressSanitizer instrumentation" OFF)
+
 function(ovs_setup t)
   target_include_directories(${t} PRIVATE ${OVS_INCLUDES})
   target_compile_definitions(${t} PRIVATE ${OVS_DEFS})
@@ -223,6 +228,12 @@ function(ovs_setup t)
   # strips them at compile time -> vlog module self-registration dies and ovs-vsctl
   # aborts ('no destination, level, or module "reconnect"').
   target_compile_options(${t} PRIVATE /Zc:inline-)
+  if(OVS_ASAN)
+    # MSVC ASAN is incompatible with the /RTC checks and incremental/edit-and-
+    # continue linking; /fsanitize=address auto-links the ASAN runtime.
+    target_compile_options(${t} PRIVATE /fsanitize=address /Oy-)
+    target_link_options(${t} PRIVATE /INCREMENTAL:NO)
+  endif()
 endfunction()
 ovs_setup(openvswitch)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,15 @@ set(OVS_DEFS HAVE_CONFIG_H _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
              _WINSOCK_DEPRECATED_NO_WARNINGS)
 # -DOVS_ASAN=ON instruments every OVS target with AddressSanitizer (MSVC
 # /fsanitize=address), so the unit tests catch heap overruns / use-after-free in
-# the userspace marshalling.  Off by default; use a dedicated build directory.
+# the userspace marshalling.  Off by default; use a dedicated build directory and
+# a Release/RelWithDebInfo config (build --config Release).  MSVC's ASAN is
+# incompatible with the runtime checks (/RTC1) the Debug config injects, so strip
+# them here to keep a Debug+ASAN build from failing to link.
 option(OVS_ASAN "Build with AddressSanitizer instrumentation" OFF)
+if(OVS_ASAN)
+  string(REGEX REPLACE "/RTC[1csu]+" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+  string(REGEX REPLACE "/RTC[1csu]+" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+endif()
 
 function(ovs_setup t)
   target_include_directories(${t} PRIVATE ${OVS_INCLUDES})

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -842,13 +842,15 @@ dpif_windows_enumerate(struct sset *all_dps,
     struct ofpbuf msg;
     int error;
 
-    /* Every datapath is reported with the conventional name "ovs-system" (as on
-     * Linux); the switch identity lives in the dpif type.  A per-switch alias
-     * class (type == a switch GUID) reports "ovs-system" iff its switch's
-     * datapath exists, so it shows as "<switch-guid>@ovs-system".  The base
-     * "system" class reports "ovs-system" for the default (lowest) datapath
-     * ("system@ovs-system").  Thus "ovs-dpctl show" lists each switch once plus
-     * the default. */
+    /* The kernel reports each datapath's OVS_DP_ATTR_NAME as its switch GUID
+     * (OvsDpFillInfo writes dpGuidName, falling back to "ovs-system" only when
+     * empty), and the per-switch alias resolution below matches on that GUID.
+     * enumerate() then advertises each datapath's dpif NAME as "ovs-system"
+     * (the conventional "<name>@ovs-system" display): a per-switch alias class
+     * (type == a switch GUID) is listed iff its datapath exists, plus the base
+     * "system" class for the default (lowest) datapath.  Do NOT "simplify" the
+     * matching to assume the kernel name is literally "ovs-system" -- it is the
+     * switch GUID, and datapath_type=<switch-guid> resolution depends on it. */
     bool specific = strcmp(dpif_class->type, OVS_WINDOWS_DEFAULT_DP_TYPE) != 0;
 
     error = ovsext_channel_open(&channel);
@@ -1250,7 +1252,10 @@ dpif_windows_port_add__(struct dpif_windows *dpif, const char *name,
     if (!error) {
         *port_nop = reply.port_no;
         ofpbuf_delete(buf);
-    } else if (error == EBUSY && *port_nop != ODPP_NONE) {
+    } else if ((error == EBUSY || error == EEXIST)
+               && *port_nop != ODPP_NONE) {
+        /* ovsext maps a port-number conflict to NL_ERROR_EXIST (EEXIST), not
+         * EBUSY as the Linux kernel does. */
         VLOG_INFO("%s: requested port %"PRIu32" is in use",
                   dpif_name(&dpif->dpif), *port_nop);
     }
@@ -1406,8 +1411,8 @@ dpif_windows_port_get_pid(const struct dpif *dpif_,
 }
 
 struct dpif_windows_port_state {
-    struct ovsext_dump dump;
-    struct ofpbuf buf;
+    struct ovsext_dump dump;    /* Owns the per-record buffer; each dumped port
+                                 * name is valid until the next dump_next. */
 };
 
 static int
@@ -1431,7 +1436,6 @@ dpif_windows_port_dump_start(const struct dpif *dpif_, void **statep)
     ovsext_dump_start(&state->dump, &dpif->channel, buf);
     ofpbuf_delete(buf);
 
-    ofpbuf_init(&state->buf, 4096);
     return 0;
 }
 
@@ -1467,7 +1471,6 @@ dpif_windows_port_dump_done(const struct dpif *dpif_ OVS_UNUSED, void *state_)
     struct dpif_windows_port_state *state = state_;
     int error = ovsext_dump_done(&state->dump);
 
-    ofpbuf_uninit(&state->buf);
     free(state);
     return error;
 }
@@ -1548,7 +1551,11 @@ static int
 dpif_windows_flow_dump_destroy(struct dpif_flow_dump *dump_)
 {
     struct dpif_windows_flow_dump *dump = dpif_windows_flow_dump_cast(dump_);
-    int status = ovsext_dump_done(&dump->dump);
+    /* A per-record decode failure was stashed in dump->status (the dump
+     * interface defers all error reporting to here); surface it, but still
+     * call ovsext_dump_done() to release the transport cursor/buffer. */
+    int done = ovsext_dump_done(&dump->dump);
+    int status = dump->status ? dump->status : done;
 
     free(dump);
     return status;
@@ -1557,7 +1564,9 @@ dpif_windows_flow_dump_destroy(struct dpif_flow_dump *dump_)
 struct dpif_windows_flow_dump_thread {
     struct dpif_flow_dump_thread up;
     struct dpif_windows_flow_dump *dump;
-    struct ofpbuf nl_flows;     /* Borrowed views of the dump buffer. */
+    struct ofpbuf nl_flows;     /* Holds this batch's records (each returned
+                                 * dpif_flow points into here, so all entries of
+                                 * a batch stay valid until the next call). */
 };
 
 static struct dpif_windows_flow_dump_thread *
@@ -1596,20 +1605,39 @@ dpif_windows_flow_dump_next(struct dpif_flow_dump_thread *thread_,
     struct dpif_windows_flow_dump_thread *thread
         = dpif_windows_flow_dump_thread_cast(thread_);
     struct dpif_windows_flow_dump *dump = thread->dump;
+    size_t offsets[FLOW_DUMP_MAX_BATCH];
+    size_t lengths[FLOW_DUMP_MAX_BATCH];
+    int n_records = 0;
     int n_flows = 0;
+    int i;
 
     max_flows = MIN(max_flows, FLOW_DUMP_MAX_BATCH);
 
-    while (n_flows < max_flows) {
-        struct dpif_windows_flow datapath_flow;
+    /* Pass 1: pull each record out of the transport (which reuses one buffer
+     * per read) and copy it into the per-thread accumulation buffer, recording
+     * its offset.  Decoding is deferred to pass 2 because appending here may
+     * reallocate 'nl_flows' and move earlier records. */
+    ofpbuf_clear(&thread->nl_flows);
+    while (n_records < max_flows) {
         struct ofpbuf nl_flow;
-        int error;
 
         if (!ovsext_dump_next(&dump->dump, &nl_flow)) {
             break;
         }
+        offsets[n_records] = thread->nl_flows.size;
+        lengths[n_records] = nl_flow.size;
+        ofpbuf_put(&thread->nl_flows, nl_flow.data, nl_flow.size);
+        n_records++;
+    }
 
-        error = dpif_windows_flow_from_ofpbuf(&datapath_flow, &nl_flow);
+    /* Pass 2: decode from the now-stable buffer.  Every returned dpif_flow
+     * points into 'nl_flows', so all entries stay valid until the next call. */
+    for (i = 0; i < n_records; i++) {
+        struct dpif_windows_flow datapath_flow;
+        struct ofpbuf nl_flow = ofpbuf_const_initializer(
+            (char *) thread->nl_flows.data + offsets[i], lengths[i]);
+        int error = dpif_windows_flow_from_ofpbuf(&datapath_flow, &nl_flow);
+
         if (error) {
             dump->status = error;
             break;
@@ -1693,10 +1721,13 @@ dpif_windows_operate__(struct dpif_windows *dpif, struct dpif_op **ops,
             if (!error && put->stats) {
                 struct dpif_windows_flow reply_flow;
 
-                if (reply
-                    && !dpif_windows_flow_from_ofpbuf(&reply_flow, reply)) {
+                error = reply ? dpif_windows_flow_from_ofpbuf(&reply_flow, reply)
+                              : EINVAL;
+                if (!error) {
                     dpif_windows_flow_get_stats(&reply_flow, put->stats);
                 } else {
+                    /* A stats-requested put must surface a bad/missing echo as
+                     * an error, not report success with zeroed stats. */
                     memset(put->stats, 0, sizeof *put->stats);
                 }
             }
@@ -1716,8 +1747,9 @@ dpif_windows_operate__(struct dpif_windows *dpif, struct dpif_op **ops,
             if (!error && del->stats) {
                 struct dpif_windows_flow reply_flow;
 
-                if (reply
-                    && !dpif_windows_flow_from_ofpbuf(&reply_flow, reply)) {
+                error = reply ? dpif_windows_flow_from_ofpbuf(&reply_flow, reply)
+                              : EINVAL;
+                if (!error) {
                     dpif_windows_flow_get_stats(&reply_flow, del->stats);
                 } else {
                     memset(del->stats, 0, sizeof *del->stats);
@@ -1737,36 +1769,50 @@ dpif_windows_operate__(struct dpif_windows *dpif, struct dpif_op **ops,
             if (!error) {
                 struct dpif_windows_flow reply_flow;
 
-                if (reply
-                    && !dpif_windows_flow_from_ofpbuf(&reply_flow, reply)) {
+                /* A genuine miss arrives as an in-band NLMSG_ERROR -> ENOENT
+                 * from the transact above; a non-NULL reply that fails to
+                 * decode is a protocol error (EINVAL), not a miss. */
+                error = reply ? dpif_windows_flow_from_ofpbuf(&reply_flow, reply)
+                              : EINVAL;
+                if (!error) {
                     dpif_windows_flow_to_dpif_flow(get->flow, &reply_flow);
-                    /* The decoded flow points into 'reply'; copy the actions
-                     * into the caller-provided buffer and leave 'reply'
-                     * attached below is not possible, so copy here. */
-                    if (get->buffer && reply_flow.key) {
+                    /* to_dpif_flow leaves get->flow pointing into 'reply',
+                     * which is freed below.  Copy key/mask/actions into the
+                     * caller's buffer.  Do every ofpbuf_put() FIRST (each may
+                     * grow/realloc and move the base) and only then capture the
+                     * pointers via ofpbuf_at(), so none dangle. */
+                    if (get->buffer) {
+                        size_t act_ofs, key_ofs, mask_ofs;
+
                         ofpbuf_clear(get->buffer);
+                        act_ofs = get->buffer->size;
                         if (reply_flow.actions_len) {
                             ofpbuf_put(get->buffer, reply_flow.actions,
                                        reply_flow.actions_len);
-                            get->flow->actions =
-                                ofpbuf_at(get->buffer, 0, 0);
-                            get->flow->actions_len = reply_flow.actions_len;
                         }
+                        key_ofs = get->buffer->size;
                         if (reply_flow.key_len) {
-                            get->flow->key =
-                                ofpbuf_put(get->buffer, reply_flow.key,
-                                           reply_flow.key_len);
-                            get->flow->key_len = reply_flow.key_len;
+                            ofpbuf_put(get->buffer, reply_flow.key,
+                                       reply_flow.key_len);
                         }
+                        mask_ofs = get->buffer->size;
                         if (reply_flow.mask_len) {
-                            get->flow->mask =
-                                ofpbuf_put(get->buffer, reply_flow.mask,
-                                           reply_flow.mask_len);
-                            get->flow->mask_len = reply_flow.mask_len;
+                            ofpbuf_put(get->buffer, reply_flow.mask,
+                                       reply_flow.mask_len);
                         }
+
+                        get->flow->actions = reply_flow.actions_len
+                            ? ofpbuf_at(get->buffer, act_ofs,
+                                        reply_flow.actions_len) : NULL;
+                        get->flow->actions_len = reply_flow.actions_len;
+                        get->flow->key = ofpbuf_at(get->buffer, key_ofs,
+                                                   reply_flow.key_len);
+                        get->flow->key_len = reply_flow.key_len;
+                        get->flow->mask = reply_flow.mask_len
+                            ? ofpbuf_at(get->buffer, mask_ofs,
+                                        reply_flow.mask_len) : NULL;
+                        get->flow->mask_len = reply_flow.mask_len;
                     }
-                } else {
-                    error = ENOENT;
                 }
             }
             break;
@@ -1804,20 +1850,14 @@ dpif_windows_operate__(struct dpif_windows *dpif, struct dpif_op **ops,
 }
 
 static void
-dpif_windows_operate(struct dpif *dpif_, struct dpif_op **ops, size_t n_ops,
-                     enum dpif_offload_type offload_type)
+dpif_windows_operate(struct dpif *dpif_, struct dpif_op **ops, size_t n_ops)
 {
     struct dpif_windows *dpif = dpif_windows_cast(dpif_);
 
-    /* Windows has no hardware-offload (netdev flow API) path; behave as the
-     * DPIF_OFFLOAD_NEVER branch of dpif-netlink. */
-    if (offload_type == DPIF_OFFLOAD_ALWAYS) {
-        for (size_t i = 0; i < n_ops; i++) {
-            ops[i]->error = EOPNOTSUPP;
-        }
-        return;
-    }
-
+    /* The dpif_class->operate contract (dpif-provider.h) takes no offload_type:
+     * dpif_operate() resolves DPIF_OFFLOAD_* before dispatching to the provider
+     * and never passes DPIF_OFFLOAD_ALWAYS down (Windows has no netdev flow-API
+     * offload).  The previous 4-arg signature read an indeterminate register. */
     while (n_ops > 0) {
         size_t chunk = dpif_windows_operate__(dpif, ops, n_ops);
 
@@ -1866,8 +1906,12 @@ parse_odp_packet(struct dpif_windows *dpif, struct ofpbuf *buf,
         return EINVAL;
     }
 
-    /* (Re)set ALL fields of '*upcall' on successful return. */
+    /* (Re)set ALL fields of '*upcall' on successful return.  The caller's
+     * dupcall is not zero-initialized, so 'pid' must be set explicitly even
+     * though the ovsext upcall carries no per-packet PID (matches
+     * dpif-netlink's parse_odp_packet). */
     upcall->type = type;
+    upcall->pid = 0;
     upcall->key = CONST_CAST(struct nlattr *,
                              nl_attr_get(a[OVS_PACKET_ATTR_KEY]));
     upcall->key_len = nl_attr_get_size(a[OVS_PACKET_ATTR_KEY]);

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1920,8 +1920,8 @@ parse_odp_packet(struct dpif_windows *dpif, struct ofpbuf *buf,
         return EINVAL;
     }
 
-    /* (Re)set ALL fields of '*upcall' on successful return.  The caller's
-     * dupcall is not zero-initialized, so 'pid' must be set explicitly even
+    /* (Re)set ALL fields of '*upcall' on successful return.  The caller does
+     * not zero-initialize the upcall, so 'pid' must be set explicitly even
      * though the ovsext upcall carries no per-packet PID (matches
      * dpif-netlink's parse_odp_packet). */
     upcall->type = type;

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1479,15 +1479,11 @@ static int
 dpif_windows_port_poll(const struct dpif *dpif_ OVS_UNUSED,
                        char **devnamep OVS_UNUSED)
 {
-    /* Report "no change".  The ovsext driver DOES expose a vport-change channel
-     * (OVS_WIN_NL_VPORT_MCGRP_ID, posted by OvsPostVportEvent and read via
-     * OVS_IOCTL_READ_EVENT), and the old dpif-netlink _WIN32 path consumed it by
-     * joining the mcgroup; this provider has not yet wired an event notifier
-     * through ovsext-channel, so kernel-initiated vport changes (Hyper-V NIC
-     * teardown, live-migration churn, renumber) go unobserved here.  Explicit
-     * userspace add/del_port still reconcile odp_to_ofport on the normal path.
-     * Restoring the notifier (mirroring the packet-subscribe path) is tracked as
-     * a follow-up and pairs with the RFC-0029 live-migration work. */
+    /* Report "no change": this provider does not subscribe to the ovsext
+     * vport-change event channel (OVS_WIN_NL_VPORT_MCGRP_ID, delivered via
+     * OVS_IOCTL_READ_EVENT), so kernel-initiated vport changes -- a Hyper-V NIC
+     * teardown, live-migration churn, a port renumber -- are not reported here.
+     * Explicit userspace add/del_port still reconcile odp_to_ofport directly. */
     return EAGAIN;
 }
 
@@ -1875,7 +1871,7 @@ dpif_windows_operate(struct dpif *dpif_, struct dpif_op **ops, size_t n_ops)
     /* The dpif_class->operate contract (dpif-provider.h) takes no offload_type:
      * dpif_operate() resolves DPIF_OFFLOAD_* before dispatching to the provider
      * and never passes DPIF_OFFLOAD_ALWAYS down (Windows has no netdev flow-API
-     * offload).  The previous 4-arg signature read an indeterminate register. */
+     * offload). */
     while (n_ops > 0) {
         size_t chunk = dpif_windows_operate__(dpif, ops, n_ops);
 
@@ -1982,12 +1978,11 @@ parse_odp_packet(struct dpif_windows *dpif, struct ofpbuf *buf,
  * recv_set() for the same reason.
  *
  * The dump runs on its own dedicated channel/handle (ovsext_dump_start), so it
- * no longer shares a cursor with this dpif's main channel; the SETs below could
- * be interleaved with the dump safely.  The port numbers are still collected
- * first and the SETs issued afterwards because it keeps the dump a single tight
- * loop and avoids holding two operations in flight.  recv_set() runs on the main
- * thread before the upcall handler threads start, so the channel is not used
- * concurrently here.
+ * does not share a cursor with this dpif's main channel and the SETs below could
+ * safely interleave with it; they are issued only after the dump completes
+ * anyway, to keep the dump a single tight loop without two operations in flight.
+ * recv_set() runs on the main thread before the upcall handler threads start, so
+ * the channel is not used concurrently here.
  */
 static void
 dpif_windows_refresh_port_upcall_pids(struct dpif_windows *dpif)

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1479,9 +1479,15 @@ static int
 dpif_windows_port_poll(const struct dpif *dpif_ OVS_UNUSED,
                        char **devnamep OVS_UNUSED)
 {
-    /* The ovsext driver has no vport-change multicast notification channel;
-     * dpif-netlink relies on OVS_VPORT_MCGROUP which the Windows driver does
-     * not expose.  Report "no change". */
+    /* Report "no change".  The ovsext driver DOES expose a vport-change channel
+     * (OVS_WIN_NL_VPORT_MCGRP_ID, posted by OvsPostVportEvent and read via
+     * OVS_IOCTL_READ_EVENT), and the old dpif-netlink _WIN32 path consumed it by
+     * joining the mcgroup; this provider has not yet wired an event notifier
+     * through ovsext-channel, so kernel-initiated vport changes (Hyper-V NIC
+     * teardown, live-migration churn, renumber) go unobserved here.  Explicit
+     * userspace add/del_port still reconcile odp_to_ofport on the normal path.
+     * Restoring the notifier (mirroring the packet-subscribe path) is tracked as
+     * a follow-up and pairs with the RFC-0029 live-migration work. */
     return EAGAIN;
 }
 
@@ -1805,13 +1811,25 @@ dpif_windows_operate__(struct dpif_windows *dpif, struct dpif_op **ops,
                             ? ofpbuf_at(get->buffer, act_ofs,
                                         reply_flow.actions_len) : NULL;
                         get->flow->actions_len = reply_flow.actions_len;
-                        get->flow->key = ofpbuf_at(get->buffer, key_ofs,
-                                                   reply_flow.key_len);
+                        get->flow->key = reply_flow.key_len
+                            ? ofpbuf_at(get->buffer, key_ofs,
+                                        reply_flow.key_len) : NULL;
                         get->flow->key_len = reply_flow.key_len;
                         get->flow->mask = reply_flow.mask_len
                             ? ofpbuf_at(get->buffer, mask_ofs,
                                         reply_flow.mask_len) : NULL;
                         get->flow->mask_len = reply_flow.mask_len;
+                    } else {
+                        /* No caller storage: to_dpif_flow left key/mask/actions
+                         * pointing into 'reply', which is freed below.  Drop
+                         * them rather than hand back dangling pointers; the ufid
+                         * and stats (value-copied) stay valid. */
+                        get->flow->key = NULL;
+                        get->flow->key_len = 0;
+                        get->flow->mask = NULL;
+                        get->flow->mask_len = 0;
+                        get->flow->actions = NULL;
+                        get->flow->actions_len = 0;
                     }
                 }
             }
@@ -1963,11 +1981,13 @@ parse_odp_packet(struct dpif_windows *dpif, struct ofpbuf *buf,
  * dpif_netlink_refresh_handlers_vport_dispatch, which Linux runs from
  * recv_set() for the same reason.
  *
- * The ovsext channel has a single stateful dump cursor, so the port numbers are
- * collected first and the SETs issued only after the dump completes; a transact
- * issued mid-dump would re-arm and destroy the cursor.  recv_set() runs on the
- * main thread before the upcall handler threads are started, so the channel is
- * not used concurrently here.
+ * The dump runs on its own dedicated channel/handle (ovsext_dump_start), so it
+ * no longer shares a cursor with this dpif's main channel; the SETs below could
+ * be interleaved with the dump safely.  The port numbers are still collected
+ * first and the SETs issued afterwards because it keeps the dump a single tight
+ * loop and avoids holding two operations in flight.  recv_set() runs on the main
+ * thread before the upcall handler threads start, so the channel is not used
+ * concurrently here.
  */
 static void
 dpif_windows_refresh_port_upcall_pids(struct dpif_windows *dpif)

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -373,11 +373,19 @@ ovsext_recv(struct ovsext_channel *ch, struct ofpbuf *buf)
 {
     DWORD bytes = 0;
 
-    /* Same shape as nl_sock_recv__()'s _WIN32 path: a synchronous read of one
-     * queued message into the buffer's tailroom. */
+    /* The driver dequeues one queued message and copies it into the supplied
+     * output buffer, truncating it to the output length.  The caller's buffer
+     * can be small (the upcall handler hands us a 512-byte stub), while a packet
+     * upcall carries a full frame plus its flow key and so is frequently larger;
+     * reading straight into that stub would silently truncate the message and
+     * drop its trailing OVS_PACKET_ATTR_PACKET, failing the netlink policy parse.
+     * Mirror nl_sock_recv__()'s _WIN32 path: read into a buffer large enough for
+     * any Netlink message (64 kB, the max attribute length), then grow 'buf' to
+     * hold the result. */
+    uint8_t tail[65536];
+
     if (!ovsext_dev_ioctl(ch, ch->read_ioctl, NULL, 0,
-                          ofpbuf_tail(buf), ofpbuf_tailroom(buf),
-                          &bytes)) {
+                          tail, sizeof tail, &bytes)) {
         VLOG_DBG("read IOCTL failed (%s)", ovs_lasterror_to_string());
         return EINVAL;
     }
@@ -387,7 +395,7 @@ ovsext_recv(struct ovsext_channel *ch, struct ofpbuf *buf)
     if (bytes < sizeof(struct nlmsghdr)) {
         return EINVAL;
     }
-    buf->size += bytes;
+    ofpbuf_put(buf, tail, bytes);
     return 0;
 }
 

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -445,6 +445,15 @@ ovsext_recv(struct ovsext_channel *ch, struct ofpbuf *buf)
 void
 ovsext_recv_wait(struct ovsext_channel *ch)
 {
+    /* A mock transport is synchronous: there is no real overlapped device to
+     * pend on (ch->handle is a token, not a Win32 handle), and any queued
+     * message is already available to ovsext_recv.  Wake the poll loop so the
+     * caller retries the recv immediately. */
+    if (ovsext_transport) {
+        poll_immediate_wake();
+        return;
+    }
+
     /* Mirror nl_sock_wait()/pend_io_request(): if no overlapped read is
      * pending, arm one with OVS_CTRL_CMD_WIN_PEND_PACKET_REQ so the driver
      * signals 'rx_event' when a packet is ready; then park on the event. */

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -59,6 +59,18 @@ ovsext_dev_open(void)
                       NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
 }
 
+/* When 'last_err' is ERROR_NOT_FOUND the ovsext device handle is gone (driver
+ * reload / NDIS detach) and cannot even be closed; the only recovery is to
+ * crash so the service manager restarts us and re-opens the device.  Mirrors
+ * netlink-socket.c lost_communication(). */
+static void
+ovsext_check_lost_communication(DWORD last_err)
+{
+    if (last_err == ERROR_NOT_FOUND) {
+        ovs_abort(0, "lost communication with the ovsext kernel device");
+    }
+}
+
 /* Wraps DeviceIoControl so the mock can intercept it.  'in' is logically const
  * (the request); DeviceIoControl's prototype is non-const, hence the cast. */
 static BOOL
@@ -66,12 +78,22 @@ ovsext_dev_ioctl(struct ovsext_channel *ch, DWORD code,
                  const void *in, DWORD in_len,
                  void *out, DWORD out_len, DWORD *bytes)
 {
+    BOOL ok;
+
     if (ovsext_transport) {
         return ovsext_transport->ioctl(ovsext_transport->aux, ch->handle, code,
                                        in, in_len, out, out_len, bytes);
     }
-    return DeviceIoControl(ch->handle, code, CONST_CAST(void *, in), in_len,
-                           out, out_len, bytes, NULL);
+    ok = DeviceIoControl(ch->handle, code, CONST_CAST(void *, in), in_len,
+                         out, out_len, bytes, NULL);
+    if (!ok) {
+        /* A lost kernel handle (driver reload, NDIS detach-promote race)
+         * surfaces as ERROR_NOT_FOUND; there is no recovery and no reopen path
+         * in this provider, so abort instead of returning EINVAL forever (which
+         * would wedge vswitchd with a dead handle -- no flows, no upcalls). */
+        ovsext_check_lost_communication(GetLastError());
+    }
+    return ok;
 }
 
 static void
@@ -243,13 +265,29 @@ void
 ovsext_dump_start(struct ovsext_dump *dump, struct ovsext_channel *ch,
                   const struct ofpbuf *request)
 {
-    dump->channel = ch;
     dump->status = 0;
+    dump->buf = NULL;
+    dump->own_channel_open = false;
+
+    /* Open a dedicated channel for this dump.  The kernel dump cursor is per
+     * file handle (OvsSetupDumpStart), so sharing 'ch' (the dpif's main
+     * channel) with concurrent transactions or with other in-flight dumps
+     * would race the cursor.  This mirrors netlink's per-dump pooled socket
+     * (nl_pool_alloc).  'ch' supplies only the datapath the request is already
+     * addressed to; the dump uses its own pid/seq/handle. */
+    dump->status = ovsext_channel_open(&dump->own_channel);
+    if (dump->status) {
+        dump->channel = NULL;
+        return;
+    }
+    dump->own_channel_open = true;
+    dump->own_channel.dp_ifindex = ch->dp_ifindex;
+    dump->channel = &dump->own_channel;
     dump->buf = ofpbuf_new(OVSEXT_REPLY_MAX);
 
     /* OVS_IOCTL_WRITE (OVS_WRITE_DEV_OP) -> OvsSetupDumpStart in the driver.
      * ovsext_send() stamps the request's len/seq/pid, as nl_sock_send does. */
-    dump->status = ovsext_send(ch, request);
+    dump->status = ovsext_send(dump->channel, request);
 }
 
 bool
@@ -307,6 +345,11 @@ ovsext_dump_done(struct ovsext_dump *dump)
 {
     ofpbuf_delete(dump->buf);
     dump->buf = NULL;
+    if (dump->own_channel_open) {
+        ovsext_channel_close(&dump->own_channel);
+        dump->own_channel_open = false;
+    }
+    dump->channel = NULL;
     return dump->status;
 }
 

--- a/lib/ovsext-channel.h
+++ b/lib/ovsext-channel.h
@@ -59,7 +59,13 @@ struct ovsext_channel {
  * dev-op the driver routes e.g. OVS_VPORT_CMD_GET to the single-object getter,
  * which fails with EINVAL when no port is named. */
 struct ovsext_dump {
-    struct ovsext_channel *channel;
+    struct ovsext_channel *channel;   /* Points at 'own_channel'. */
+    struct ovsext_channel own_channel; /* Dedicated handle: the kernel dump
+                                        * cursor is per file handle, so a dump
+                                        * must not share a channel with
+                                        * concurrent transactions or with other
+                                        * dumps (parallel revalidators). */
+    bool own_channel_open;
     struct ofpbuf *buf;         /* Per-record read buffer, owned here. */
     int status;                 /* 0, or first error encountered. */
 };

--- a/lib/ovsext-channel.h
+++ b/lib/ovsext-channel.h
@@ -59,7 +59,8 @@ struct ovsext_channel {
  * dev-op the driver routes e.g. OVS_VPORT_CMD_GET to the single-object getter,
  * which fails with EINVAL when no port is named. */
 struct ovsext_dump {
-    struct ovsext_channel *channel;   /* Points at 'own_channel'. */
+    struct ovsext_channel *channel;   /* Points at 'own_channel', or NULL if the
+                                       * dump channel failed to open. */
     struct ovsext_channel own_channel; /* Dedicated handle: the kernel dump
                                         * cursor is per file handle, so a dump
                                         * must not share a channel with

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -100,6 +100,7 @@ struct mock_kernel {
     struct mock_handle handles[MOCK_MAX_HANDLES];
     int n_open;                 /* Currently open handles. */
     int peak_open;              /* High-water mark of n_open. */
+    bool fail_open;             /* Force the next device open to fail (ENODEV). */
 
     /* Programmable dump content. */
     struct mock_record dp[MOCK_MAX_RECORDS];    int n_dp;
@@ -205,11 +206,12 @@ build_flow_bad(struct mock_record *r)
     finish_record(r, &b);
 }
 
-/* Builds an OVS_PACKET_CMD_ACTION upcall whose total size exceeds 'frame_len'.
- * The PACKET attribute is written LAST (as the kernel's OvsCreateQueueNlPacket
- * does), so a truncating read drops it and the policy parse fails. */
+/* Builds an OVS_PACKET_CMD_ACTION upcall on datapath 'dp_ifindex' whose total
+ * size exceeds 'frame_len'.  The PACKET attribute is written LAST (as the
+ * kernel's OvsCreateQueueNlPacket does), so a truncating read drops it and the
+ * policy parse fails. */
 static void
-build_packet_upcall(struct mock_record *r, size_t frame_len)
+build_packet_upcall(struct mock_record *r, int dp_ifindex, size_t frame_len)
 {
     uint64_t stub[MOCK_RECORD_CAP / 8];
     struct ofpbuf b;
@@ -221,7 +223,7 @@ build_packet_upcall(struct mock_record *r, size_t frame_len)
     nl_msg_put_genlmsghdr(&b, 0, OVS_WIN_NL_PACKET_FAMILY_ID, 0,
                           OVS_PACKET_CMD_ACTION, OVS_PACKET_VERSION);
     ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
-    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+    ovs_header->dp_ifindex = dp_ifindex;
 
     key_ofs = nl_msg_start_nested(&b, OVS_PACKET_ATTR_KEY);
     nl_msg_put_u32(&b, OVS_KEY_ATTR_IN_PORT, 7);
@@ -412,6 +414,9 @@ mock_open(void *aux)
     struct mock_kernel *m = aux;
     int i;
 
+    if (m->fail_open) {
+        return INVALID_HANDLE_VALUE;    /* model a device-open failure */
+    }
     for (i = 0; i < MOCK_MAX_HANDLES; i++) {
         if (!m->handles[i].in_use) {
             m->handles[i].in_use = true;
@@ -447,6 +452,7 @@ mock_reset_content(struct mock_kernel *m)
     m->n_flow = 0;
     m->pkt_head = 0;
     m->pkt_len = 0;
+    m->fail_open = false;
     m->flow_reply = FR_ACK;
     /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
     m->n_dp = 1;
@@ -526,7 +532,7 @@ test_recv_large_upcall(struct dpif *dpif, struct mock_kernel *m)
 
     printf("test_recv_large_upcall:\n");
     mock_reset_content(m);
-    build_packet_upcall(&rec, frame_len);
+    build_packet_upcall(&rec, MOCK_DP_IFINDEX, frame_len);
     mock_queue_packet(m, &rec);
 
     ofpbuf_use_stub(&buf, stub, sizeof stub);
@@ -542,6 +548,36 @@ test_recv_large_upcall(struct dpif *dpif, struct mock_kernel *m)
     CHECK(upcall.pid == 0);
 
     /* Queue is now drained. */
+    ofpbuf_clear(&buf);
+    CHECK(dpif_recv(dpif, 0, &upcall, &buf) == EAGAIN);
+    ofpbuf_uninit(&buf);
+}
+
+/* dpif_windows_recv drains upcalls destined for another datapath and returns
+ * only the one matching this dpif's dp_ifindex.  Queue a foreign-datapath
+ * upcall ahead of a matching one and check the foreign one is skipped. */
+static void
+test_recv_multi_dp_filter(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct mock_record other, mine;
+    struct dpif_upcall upcall;
+    uint64_t stub[2048 / 8];
+    struct ofpbuf buf;
+    int error;
+
+    printf("test_recv_multi_dp_filter:\n");
+    mock_reset_content(m);
+    build_packet_upcall(&other, MOCK_DP_IFINDEX + 7, 256);   /* foreign dp */
+    build_packet_upcall(&mine, MOCK_DP_IFINDEX, 256);        /* this dp */
+    mock_queue_packet(m, &other);
+    mock_queue_packet(m, &mine);
+
+    ofpbuf_use_stub(&buf, stub, sizeof stub);
+    memset(&upcall, 0, sizeof upcall);
+    error = dpif_recv(dpif, 0, &upcall, &buf);
+    CHECK(error == 0);                       /* the foreign one was drained */
+    CHECK(upcall.type == DPIF_UC_ACTION);
+
     ofpbuf_clear(&buf);
     CHECK(dpif_recv(dpif, 0, &upcall, &buf) == EAGAIN);
     ofpbuf_uninit(&buf);
@@ -657,6 +693,36 @@ test_flow_dump_deferred_error(struct dpif *dpif, struct mock_kernel *m)
     CHECK(dpif_flow_dump_destroy(dump) == EINVAL);
 }
 
+/* A dump opens its own channel; if that device open fails, the error must
+ * propagate: flow_dump_next yields nothing and flow_dump_destroy returns it. */
+static void
+test_flow_dump_open_failure(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_dump_types types = { .ovs_flows = true };
+    struct dpif_flow_dump *dump;
+    struct dpif_flow_dump_thread *thread;
+    struct dpif_flow batch[8];
+    int n_flows = 0;
+
+    printf("test_flow_dump_open_failure:\n");
+    mock_reset_content(m);
+    m->n_flow = 1;
+    build_flow_record(&m->flow[0], 55, false);
+
+    m->fail_open = true;        /* the dump's dedicated channel open fails */
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+    while (dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch)) > 0) {
+        n_flows++;
+    }
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(n_flows == 0);
+    CHECK(dpif_flow_dump_destroy(dump) == ENODEV);
+    m->fail_open = false;
+    /* The main channel is still healthy. */
+    CHECK(dpif_flow_flush(dpif) == 0);
+}
+
 /* Regression (audit #7/#10): FLOW_GET copies the reply's key/mask/actions into
  * the caller's buffer.  All ofpbuf_put()s must happen before the pointers are
  * captured (a later put can realloc and move the base) and the copy must be
@@ -727,6 +793,49 @@ test_flow_get_hit(struct dpif *dpif, struct mock_kernel *m)
     CHECK(result.stats.n_packets == 5 && result.stats.n_bytes == 500);
 
     ofpbuf_uninit(&buffer);
+    ofpbuf_uninit(&reqkey);
+}
+
+/* FLOW_GET with no caller storage (get->buffer == NULL): the provider must not
+ * hand back key/mask/actions pointers into the freed reply.  They are returned
+ * as NULL while stats stay valid.  Without the guard these dangle (ASAN). */
+static void
+test_flow_get_null_buffer(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_get get;
+    struct dpif_flow result;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    uint64_t reqkey_stub[64 / 8];
+    struct ofpbuf reqkey;
+
+    printf("test_flow_get_null_buffer:\n");
+    mock_reset_content(m);
+    m->flow_reply = FR_ECHO;
+    build_flow_record(&m->flow_echo, 42, true);
+
+    ofpbuf_use_stub(&reqkey, reqkey_stub, sizeof reqkey_stub);
+    nl_msg_put_u32(&reqkey, OVS_KEY_ATTR_IN_PORT, 42);
+
+    memset(&result, 0, sizeof result);
+    memset(&get, 0, sizeof get);
+    get.key = reqkey.data;
+    get.key_len = reqkey.size;
+    get.buffer = NULL;
+    get.flow = &result;
+
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_GET;
+    op.flow_get = get;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+
+    CHECK(op.error == 0);
+    CHECK(result.key == NULL && result.key_len == 0);
+    CHECK(result.mask == NULL && result.mask_len == 0);
+    CHECK(result.actions == NULL && result.actions_len == 0);
+    CHECK(result.stats.n_packets == 5 && result.stats.n_bytes == 500);
+
     ofpbuf_uninit(&reqkey);
 }
 
@@ -830,6 +939,59 @@ test_flow_put_stats(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
+/* Regression (audit #8): the FLOW_DEL stats path is identical to FLOW_PUT and
+ * was fixed in the same commit -- a bad/missing echo must surface as an error,
+ * and a good echo must populate the stats. */
+static void
+test_flow_del_stats(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_stats stats;
+    struct dpif_flow_del del;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    uint64_t keybuf[64 / 8];
+    struct ofpbuf key;
+
+    printf("test_flow_del_stats:\n");
+
+    ofpbuf_use_stub(&key, keybuf, sizeof keybuf);
+    nl_msg_put_u32(&key, OVS_KEY_ATTR_IN_PORT, 1);
+
+    /* Missing echo -> error. */
+    mock_reset_content(m);
+    m->flow_reply = FR_EMPTYECHO;
+    memset(&stats, 0xab, sizeof stats);
+    memset(&del, 0, sizeof del);
+    del.key = key.data;
+    del.key_len = key.size;
+    del.stats = &stats;
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_DEL;
+    op.flow_del = del;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+    CHECK(op.error == EINVAL);
+
+    /* Good echo -> stats populated. */
+    mock_reset_content(m);
+    m->flow_reply = FR_ECHO;
+    build_flow_record(&m->flow_echo, 1, true);
+    memset(&stats, 0, sizeof stats);
+    memset(&del, 0, sizeof del);
+    del.key = key.data;
+    del.key_len = key.size;
+    del.stats = &stats;
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_DEL;
+    op.flow_del = del;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+    CHECK(op.error == 0);
+    CHECK(stats.n_packets == 5 && stats.n_bytes == 500);
+
+    ofpbuf_uninit(&key);
+}
+
 /* Regression (audit, operate signature): the class 'operate' is the 3-arg
  * contract; dpif_operate resolves offload before dispatch.  Drive a multi-op
  * batch through the public path to exercise it end to end. */
@@ -894,12 +1056,16 @@ main(int argc, char *argv[])
 
     test_bringup(dpif);
     test_recv_large_upcall(dpif, &mock);
+    test_recv_multi_dp_filter(dpif, &mock);
     test_flow_dump_multi_record(dpif, &mock);
     test_per_dump_channel(dpif, &mock);
     test_flow_dump_deferred_error(dpif, &mock);
+    test_flow_dump_open_failure(dpif, &mock);
     test_flow_get_hit(dpif, &mock);
+    test_flow_get_null_buffer(dpif, &mock);
     test_flow_get_miss_vs_malformed(dpif, &mock);
     test_flow_put_stats(dpif, &mock);
+    test_flow_del_stats(dpif, &mock);
     test_operate_batch(dpif, &mock);
 
     dpif_close(dpif);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -13,9 +13,17 @@
  * no VM are involved, so the provider's userspace marshalling can be exercised
  * (and ASAN-checked: configure with -DOVS_ASAN=ON) on a dev box.
  *
- * The mock answers just what ofproto's backer bring-up drives: GET_PID, the
- * datapath OVS_DP_CMD_GET, an (empty) vport dump, flow flush/put, and the
- * packet-subscribe write.  That sequence is replayed by main(). */
+ * The mock reproduces the kernel quirks that hid real bugs:
+ *   - READ copies the dequeued message TRUNCATED to the caller's output length
+ *     (so an undersized recv buffer drops the trailing attribute);
+ *   - the dump cursor is PER FILE HANDLE (so a dump must use its own handle);
+ *   - a dump is a WRITE(NLM_F_DUMP) that arms the cursor, then one record per
+ *     READ, ended by a zero-length read (no NLMSG_DONE).
+ *
+ * Each test programs the mock's dump/packet/transact content, drives the
+ * provider through the public dpif API, and asserts the contract.  The tests
+ * regression-guard the divergences fixed in commits f18d4e34 (recv truncation)
+ * and b7d08a2f (the dpif-netlink contract audit). */
 
 #include <config.h>
 
@@ -28,6 +36,7 @@
 
 #include "dpif.h"
 #include "ovsext-channel.h"
+#include "dp-packet.h"
 #include "flow.h"
 #include "odp-util.h"
 #include "netlink.h"
@@ -36,6 +45,7 @@
 #include "openvswitch/ofpbuf.h"
 #include "openvswitch/vlog.h"
 #include "packets.h"
+#include "unaligned.h"
 #include "util.h"
 
 /* The ovsext ABI (IOCTL codes, fixed genl family ids, struct ovs_header). */
@@ -44,34 +54,83 @@
 #define MOCK_DP_IFINDEX 1
 #define MOCK_PID        0x1234u
 
+#define MOCK_MAX_HANDLES 8
+#define MOCK_MAX_RECORDS 8
+#define MOCK_RECORD_CAP  8192
+
+/* ---- test bookkeeping ---------------------------------------------------- */
+
+static int failures;
+
+#define CHECK(cond) do {                                                    \
+        if (cond) {                                                         \
+            printf("    ok: %s\n", #cond);                                  \
+        } else {                                                           \
+            printf("    FAIL: %s (%s:%d)\n", #cond, __FILE__, __LINE__);    \
+            failures++;                                                    \
+        }                                                                  \
+    } while (0)
+
 /* ---- mock "kernel" state ------------------------------------------------- */
 
 enum mock_dump { DUMP_NONE, DUMP_VPORT, DUMP_FLOW, DUMP_DP };
 
-struct mock_kernel {
-    enum mock_dump dump;    /* Armed by an OVS_IOCTL_WRITE w/ NLM_F_DUMP. */
-    int dp_records_left;    /* DP dump emits one record, then EOF. */
+/* How an OVS_IOCTL_TRANSACT against the FLOW family answers. */
+enum flow_reply {
+    FR_ACK,         /* Success, empty reply (no NLM_F_ECHO output). */
+    FR_ECHO,        /* Success, return m->flow_echo (a full flow w/ stats). */
+    FR_EMPTYECHO,   /* Echo requested but driver returns 0 bytes (a fault). */
+    FR_ENOENT,      /* In-band NLMSG_ERROR, -ENOENT (a genuine miss). */
+    FR_MALFORMED,   /* Non-error reply that fails to decode (protocol fault). */
 };
 
-/* Finalize 'b' as a reply and copy it to the IOCTL output buffer. */
-static BOOL
-reply_copy(struct ofpbuf *b, void *out, DWORD out_len, DWORD *bytes)
+struct mock_record {
+    uint8_t data[MOCK_RECORD_CAP];
+    size_t len;
+};
+
+/* The kernel dump cursor lives on the file handle, so model per-handle. */
+struct mock_handle {
+    bool in_use;
+    enum mock_dump dump;        /* Which family's dump this handle is walking. */
+    int cursor;                 /* Next record index for that dump. */
+};
+
+struct mock_kernel {
+    struct mock_handle handles[MOCK_MAX_HANDLES];
+    int n_open;                 /* Currently open handles. */
+    int peak_open;              /* High-water mark of n_open. */
+
+    /* Programmable dump content. */
+    struct mock_record dp[MOCK_MAX_RECORDS];    int n_dp;
+    struct mock_record vport[MOCK_MAX_RECORDS]; int n_vport;
+    struct mock_record flow[MOCK_MAX_RECORDS];  int n_flow;
+
+    /* Queued packet upcalls, delivered one per OVS_IOCTL_READ_PACKET. */
+    struct mock_record pkt[MOCK_MAX_RECORDS];   int pkt_head, pkt_len;
+
+    /* OVS_IOCTL_TRANSACT scripting for the FLOW family. */
+    enum flow_reply flow_reply;
+    struct mock_record flow_echo;
+    struct mock_record flow_bad;
+};
+
+/* ---- record builders ----------------------------------------------------- */
+
+/* Finalizes 'b' (a request/reply under construction) into 'r'. */
+static void
+finish_record(struct mock_record *r, struct ofpbuf *b)
 {
     nl_msg_nlmsghdr(b)->nlmsg_len = b->size;
-    if (b->size > out_len) {
-        ofpbuf_uninit(b);
-        SetLastError(ERROR_INSUFFICIENT_BUFFER);
-        return FALSE;
-    }
-    memcpy(out, b->data, b->size);
-    *bytes = (DWORD) b->size;
+    ovs_assert(b->size <= sizeof r->data);
+    memcpy(r->data, b->data, b->size);
+    r->len = b->size;
     ofpbuf_uninit(b);
-    return TRUE;
 }
 
-/* Build an OVS_DP_CMD_GET reply (name + stats), as OvsDpFillInfo does. */
-static BOOL
-mock_dp_get(void *out, DWORD out_len, DWORD *bytes)
+/* Builds an OVS_DP_CMD_GET reply (name + stats), as OvsDpFillInfo does. */
+static void
+build_dp_record(struct mock_record *r)
 {
     uint64_t stub[1024 / 8];
     struct ofpbuf b;
@@ -86,43 +145,167 @@ mock_dp_get(void *out, DWORD out_len, DWORD *bytes)
     nl_msg_put_string(&b, OVS_DP_ATTR_NAME, "ovs-system");
     memset(&stats, 0, sizeof stats);
     nl_msg_put_unspec(&b, OVS_DP_ATTR_STATS, &stats, sizeof stats);
-    return reply_copy(&b, out, out_len, bytes);
+    finish_record(r, &b);
+}
+
+/* Builds an OVS_FLOW record with a distinct key (varying 'in_port').  When
+ * 'rich' it also carries a mask, padded actions and stats (so it round-trips a
+ * full flow), used to exercise the FLOW_GET copy path. */
+static void
+build_flow_record(struct mock_record *r, uint32_t in_port, bool rich)
+{
+    uint64_t stub[MOCK_RECORD_CAP / 8];
+    struct ofpbuf b;
+    struct ovs_header *ovs_header;
+    size_t key_ofs;
+
+    ofpbuf_use_stub(&b, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&b, 0, OVS_WIN_NL_FLOW_FAMILY_ID, 0,
+                          OVS_FLOW_CMD_NEW, OVS_FLOW_VERSION);
+    ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
+    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+
+    key_ofs = nl_msg_start_nested(&b, OVS_FLOW_ATTR_KEY);
+    nl_msg_put_u32(&b, OVS_KEY_ATTR_IN_PORT, in_port);
+    nl_msg_end_nested(&b, key_ofs);
+
+    if (rich) {
+        size_t mask_ofs = nl_msg_start_nested(&b, OVS_FLOW_ATTR_MASK);
+        nl_msg_put_u32(&b, OVS_KEY_ATTR_IN_PORT, 0xffffffff);
+        nl_msg_end_nested(&b, mask_ofs);
+
+        /* OVS_FLOW_ATTR_ACTIONS is validated as NL_A_NESTED (any length); a big
+         * blob forces the caller's get->buffer to realloc while copying. */
+        uint8_t acts[1500];
+        memset(acts, 0xCD, sizeof acts);
+        nl_msg_put_unspec(&b, OVS_FLOW_ATTR_ACTIONS, acts, sizeof acts);
+
+        struct ovs_flow_stats fstats;
+        put_32aligned_u64(&fstats.n_packets, 5);
+        put_32aligned_u64(&fstats.n_bytes, 500);
+        nl_msg_put_unspec(&b, OVS_FLOW_ATTR_STATS, &fstats, sizeof fstats);
+    }
+    finish_record(r, &b);
+}
+
+/* Builds a FLOW record carrying neither a key nor a ufid: a structurally valid
+ * netlink message that dpif_windows_flow_from_ofpbuf rejects (EINVAL). */
+static void
+build_flow_bad(struct mock_record *r)
+{
+    uint64_t stub[256 / 8];
+    struct ofpbuf b;
+    struct ovs_header *ovs_header;
+
+    ofpbuf_use_stub(&b, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&b, 0, OVS_WIN_NL_FLOW_FAMILY_ID, 0,
+                          OVS_FLOW_CMD_NEW, OVS_FLOW_VERSION);
+    ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
+    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+    finish_record(r, &b);
+}
+
+/* Builds an OVS_PACKET_CMD_ACTION upcall whose total size exceeds 'frame_len'.
+ * The PACKET attribute is written LAST (as the kernel's OvsCreateQueueNlPacket
+ * does), so a truncating read drops it and the policy parse fails. */
+static void
+build_packet_upcall(struct mock_record *r, size_t frame_len)
+{
+    uint64_t stub[MOCK_RECORD_CAP / 8];
+    struct ofpbuf b;
+    struct ovs_header *ovs_header;
+    size_t key_ofs;
+    uint8_t *frame;
+
+    ofpbuf_use_stub(&b, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&b, 0, OVS_WIN_NL_PACKET_FAMILY_ID, 0,
+                          OVS_PACKET_CMD_ACTION, OVS_PACKET_VERSION);
+    ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
+    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+
+    key_ofs = nl_msg_start_nested(&b, OVS_PACKET_ATTR_KEY);
+    nl_msg_put_u32(&b, OVS_KEY_ATTR_IN_PORT, 7);
+    nl_msg_end_nested(&b, key_ofs);
+
+    frame = nl_msg_put_unspec_uninit(&b, OVS_PACKET_ATTR_PACKET, frame_len);
+    memset(frame, 0xAB, frame_len);
+    memset(frame, 0, 12);           /* dst+src MAC */
+    frame[12] = 0x08;               /* ethertype = IPv4 */
+    frame[13] = 0x00;
+    finish_record(r, &b);
+}
+
+/* ---- mock IOCTL handlers ------------------------------------------------- */
+
+/* Copies 'r' into the IOCTL output buffer, truncated to 'out_len' exactly as
+ * the driver copies a dequeued message into the caller's buffer. */
+static BOOL
+record_copy(const struct mock_record *r, void *out, DWORD out_len, DWORD *bytes)
+{
+    DWORD n = r->len < out_len ? (DWORD) r->len : out_len;
+
+    memcpy(out, r->data, n);
+    *bytes = n;
+    return TRUE;
+}
+
+/* Builds an in-band NLMSG_ERROR reply carrying errno 'err'. */
+static BOOL
+reply_nlmsgerr(int err, void *out, DWORD out_len, DWORD *bytes)
+{
+    struct nlmsghdr *nlh;
+    struct nlmsgerr *e;
+    size_t len = NLMSG_HDRLEN + sizeof *e;
+
+    if (out_len < len) {
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        return FALSE;
+    }
+    memset(out, 0, len);
+    nlh = out;
+    nlh->nlmsg_len = (uint32_t) len;
+    nlh->nlmsg_type = NLMSG_ERROR;
+    e = (struct nlmsgerr *) ((char *) out + NLMSG_HDRLEN);
+    e->error = -err;
+    *bytes = (DWORD) len;
+    return TRUE;
 }
 
 static BOOL
-mock_transact(struct mock_kernel *m OVS_UNUSED, const void *in, DWORD in_len,
+mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
               void *out, DWORD out_len, DWORD *bytes)
 {
     const struct nlmsghdr *nlh = in;
-    const struct genlmsghdr *genl;
 
     *bytes = 0;
     if (in_len < NLMSG_HDRLEN + GENL_HDRLEN) {
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
     }
-    genl = ALIGNED_CAST(const struct genlmsghdr *,
-                        (const char *) in + NLMSG_HDRLEN);
 
     switch (nlh->nlmsg_type) {
     case OVS_WIN_NL_DATAPATH_FAMILY_ID:
-        if (genl->cmd == OVS_DP_CMD_GET || genl->cmd == OVS_DP_CMD_SET) {
-            return mock_dp_get(out, out_len, bytes);
-        }
-        return TRUE;            /* ack with no payload */
+        return record_copy(&m->dp[0], out, out_len, bytes);
 
     case OVS_WIN_NL_FLOW_FAMILY_ID:
+        switch (m->flow_reply) {
+        case FR_ECHO:      return record_copy(&m->flow_echo, out, out_len, bytes);
+        case FR_MALFORMED: return record_copy(&m->flow_bad, out, out_len, bytes);
+        case FR_ENOENT:    return reply_nlmsgerr(ENOENT, out, out_len, bytes);
+        case FR_EMPTYECHO: return TRUE;   /* 0 bytes despite echo request */
+        case FR_ACK:
+        default:           return TRUE;   /* ack, empty reply */
+        }
+
     case OVS_WIN_NL_VPORT_FAMILY_ID:
     case OVS_WIN_NL_PACKET_FAMILY_ID:
     default:
-        /* Success with empty reply (the driver returns 0 bytes for ops that
-         * neither fail nor carry NLM_F_ECHO output). */
-        return TRUE;
+        return TRUE;            /* success, empty reply */
     }
 }
 
 static BOOL
-mock_write(struct mock_kernel *m, const void *in, DWORD in_len, DWORD *bytes)
+mock_write(struct mock_handle *h, const void *in, DWORD in_len, DWORD *bytes)
 {
     const struct nlmsghdr *nlh = in;
 
@@ -132,42 +315,68 @@ mock_write(struct mock_kernel *m, const void *in, DWORD in_len, DWORD *bytes)
         return FALSE;
     }
 
-    /* A WRITE carrying NLM_F_DUMP arms the per-handle dump cursor. */
+    /* A WRITE carrying NLM_F_DUMP arms this handle's dump cursor. */
     if (nlh->nlmsg_flags & NLM_F_DUMP) {
+        h->cursor = 0;
         switch (nlh->nlmsg_type) {
-        case OVS_WIN_NL_VPORT_FAMILY_ID:   m->dump = DUMP_VPORT; break;
-        case OVS_WIN_NL_FLOW_FAMILY_ID:    m->dump = DUMP_FLOW;  break;
-        case OVS_WIN_NL_DATAPATH_FAMILY_ID:
-            m->dump = DUMP_DP;
-            m->dp_records_left = 1;
-            break;
-        default: break;
+        case OVS_WIN_NL_VPORT_FAMILY_ID:    h->dump = DUMP_VPORT; break;
+        case OVS_WIN_NL_FLOW_FAMILY_ID:     h->dump = DUMP_FLOW;  break;
+        case OVS_WIN_NL_DATAPATH_FAMILY_ID: h->dump = DUMP_DP;    break;
+        default:                            h->dump = DUMP_NONE;  break;
         }
     }
-    /* Other writes (e.g. OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ) just succeed. */
+    /* Other writes (subscribe/pend) just succeed. */
     return TRUE;
 }
 
+/* OVS_IOCTL_READ: one record from this handle's armed dump, or 0 bytes (EOF). */
 static BOOL
-mock_read(struct mock_kernel *m, void *out, DWORD out_len, DWORD *bytes)
+mock_read_dump(struct mock_kernel *m, struct mock_handle *h,
+               void *out, DWORD out_len, DWORD *bytes)
 {
-    *bytes = 0;
+    const struct mock_record *recs = NULL;
+    int n = 0;
 
-    if (m->dump == DUMP_DP && m->dp_records_left > 0) {
-        m->dp_records_left--;
-        return mock_dp_get(out, out_len, bytes);   /* one DP record */
+    *bytes = 0;
+    switch (h->dump) {
+    case DUMP_DP:    recs = m->dp;    n = m->n_dp;    break;
+    case DUMP_VPORT: recs = m->vport; n = m->n_vport; break;
+    case DUMP_FLOW:  recs = m->flow;  n = m->n_flow;  break;
+    case DUMP_NONE:  default:         return TRUE;    /* nothing armed */
     }
 
-    /* Empty read = end of dump (no vports/flows on this mock datapath). */
-    m->dump = DUMP_NONE;
+    if (h->cursor >= n) {
+        h->dump = DUMP_NONE;        /* exhausted: zero-length read = EOF */
+        return TRUE;
+    }
+    return record_copy(&recs[h->cursor++], out, out_len, bytes);
+}
+
+/* OVS_IOCTL_READ_PACKET: dequeue one queued upcall, truncated to out_len. */
+static BOOL
+mock_read_packet(struct mock_kernel *m, void *out, DWORD out_len, DWORD *bytes)
+{
+    *bytes = 0;
+    if (m->pkt_len == 0) {
+        return TRUE;                /* nothing queued: 0 bytes = EAGAIN */
+    }
+    record_copy(&m->pkt[m->pkt_head], out, out_len, bytes);
+    m->pkt_head = (m->pkt_head + 1) % MOCK_MAX_RECORDS;
+    m->pkt_len--;
     return TRUE;
 }
 
 static BOOL
-mock_ioctl(void *aux, HANDLE handle OVS_UNUSED, DWORD code,
+mock_ioctl(void *aux, HANDLE handle, DWORD code,
            const void *in, DWORD in_len, void *out, DWORD out_len, DWORD *bytes)
 {
     struct mock_kernel *m = aux;
+    int slot = (int) (intptr_t) handle - 1;
+    struct mock_handle *h;
+
+    ovs_assert(slot >= 0 && slot < MOCK_MAX_HANDLES);
+    h = &m->handles[slot];
+    ovs_assert(h->in_use);
 
     switch (code) {
     case OVS_IOCTL_GET_PID: {
@@ -183,11 +392,14 @@ mock_ioctl(void *aux, HANDLE handle OVS_UNUSED, DWORD code,
     case OVS_IOCTL_TRANSACT:
         return mock_transact(m, in, in_len, out, out_len, bytes);
     case OVS_IOCTL_WRITE:
-        return mock_write(m, in, in_len, bytes);
+        return mock_write(h, in, in_len, bytes);
     case OVS_IOCTL_READ:
-    case OVS_IOCTL_READ_EVENT:
+        return mock_read_dump(m, h, out, out_len, bytes);
     case OVS_IOCTL_READ_PACKET:
-        return mock_read(m, out, out_len, bytes);
+        return mock_read_packet(m, out, out_len, bytes);
+    case OVS_IOCTL_READ_EVENT:
+        *bytes = 0;
+        return TRUE;
     default:
         SetLastError(ERROR_INVALID_FUNCTION);
         return FALSE;
@@ -195,21 +407,68 @@ mock_ioctl(void *aux, HANDLE handle OVS_UNUSED, DWORD code,
 }
 
 static HANDLE
-mock_open(void *aux OVS_UNUSED)
+mock_open(void *aux)
 {
-    /* Any non-INVALID token; the channel only passes it back to mock_ioctl. */
-    return (HANDLE) (intptr_t) 0x4242;
+    struct mock_kernel *m = aux;
+    int i;
+
+    for (i = 0; i < MOCK_MAX_HANDLES; i++) {
+        if (!m->handles[i].in_use) {
+            m->handles[i].in_use = true;
+            m->handles[i].dump = DUMP_NONE;
+            m->handles[i].cursor = 0;
+            m->n_open++;
+            if (m->n_open > m->peak_open) {
+                m->peak_open = m->n_open;
+            }
+            return (HANDLE) (intptr_t) (i + 1);
+        }
+    }
+    return INVALID_HANDLE_VALUE;
 }
 
 static void
-mock_close(void *aux OVS_UNUSED, HANDLE handle OVS_UNUSED)
+mock_close(void *aux, HANDLE handle)
 {
+    struct mock_kernel *m = aux;
+    int slot = (int) (intptr_t) handle - 1;
+
+    if (slot >= 0 && slot < MOCK_MAX_HANDLES && m->handles[slot].in_use) {
+        m->handles[slot].in_use = false;
+        m->n_open--;
+    }
 }
 
-/* ---- bring-up replay ----------------------------------------------------- */
+/* Clears per-test programmable content (not the live handle table). */
+static void
+mock_reset_content(struct mock_kernel *m)
+{
+    m->n_vport = 0;
+    m->n_flow = 0;
+    m->pkt_head = 0;
+    m->pkt_len = 0;
+    m->flow_reply = FR_ACK;
+    /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
+    m->n_dp = 1;
+    build_dp_record(&m->dp[0]);
+    m->peak_open = m->n_open;
+}
 
 static void
-replay_bringup(struct dpif *dpif)
+mock_queue_packet(struct mock_kernel *m, const struct mock_record *r)
+{
+    int tail = (m->pkt_head + m->pkt_len) % MOCK_MAX_RECORDS;
+    ovs_assert(m->pkt_len < MOCK_MAX_RECORDS);
+    m->pkt[tail] = *r;
+    m->pkt_len++;
+}
+
+/* ---- tests --------------------------------------------------------------- */
+
+/* The bring-up sequence open_dpif_backer drives: flush, port dump, a flow_put
+ * probe and recv_set.  Smoke test that the provider survives it. */
+static void
+test_bringup(struct dpif *dpif)
 {
     struct dpif_port_dump port_dump;
     struct dpif_port port;
@@ -221,17 +480,13 @@ replay_bringup(struct dpif *dpif)
     struct dpif_op op;
     struct dpif_op *ops[1];
 
-    /* 1. flow_flush (first datapath op open_dpif_backer performs). */
-    dpif_flow_flush(dpif);
-    printf("  flow_flush ok\n");
+    printf("test_bringup:\n");
+    CHECK(dpif_flow_flush(dpif) == 0);
 
-    /* 2. enumerate stale ports (empty on the mock). */
     DPIF_PORT_FOR_EACH (&port, &port_dump, dpif) {
-        printf("  port %s\n", port.name);
+        /* No ports on the mock datapath. */
     }
-    printf("  port_dump ok\n");
 
-    /* 3. a flow_put probe, like check_recirc()/check_support(). */
     memset(&flow, 0, sizeof flow);
     flow.dl_type = htons(ETH_TYPE_IP);
     ofpbuf_use_stack(&key, &keybuf, sizeof keybuf);
@@ -249,23 +504,373 @@ replay_bringup(struct dpif *dpif)
     op.flow_put = put;
     ops[0] = &op;
     dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
-    printf("  flow_put op error=%d\n", op.error);
+    CHECK(op.error == 0);
 
-    /* 4. enable upcalls (OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ write). */
-    dpif_recv_set(dpif, true);
-    printf("  recv_set ok\n");
+    CHECK(dpif_recv_set(dpif, true) == 0);
+}
+
+/* Regression (commit f18d4e34): a full-frame upcall larger than the caller's
+ * recv stub must arrive whole.  The provider reads into its own 64 kB buffer
+ * and grows the caller's ofpbuf; reading straight into the small stub would let
+ * the mock's truncate-to-output-length drop the trailing PACKET attribute and
+ * fail the parse, exactly as it dropped DHCP/controller upcalls on eryph. */
+static void
+test_recv_large_upcall(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct mock_record rec;
+    struct dpif_upcall upcall;
+    uint64_t stub[512 / 8];     /* matches recv_upcalls' undersized stub */
+    struct ofpbuf buf;
+    const size_t frame_len = 1480;
+    int error;
+
+    printf("test_recv_large_upcall:\n");
+    mock_reset_content(m);
+    build_packet_upcall(&rec, frame_len);
+    mock_queue_packet(m, &rec);
+
+    ofpbuf_use_stub(&buf, stub, sizeof stub);
+    memset(&upcall, 0xff, sizeof upcall);   /* poison: nothing pre-zeroed */
+    error = dpif_recv(dpif, 0, &upcall, &buf);
+
+    CHECK(error == 0);
+    CHECK(upcall.type == DPIF_UC_ACTION);
+    CHECK(dp_packet_size(&upcall.packet) == frame_len);
+
+    /* Regression (audit #11): pid must be explicitly cleared even though the
+     * caller's upcall was not zero-initialized. */
+    CHECK(upcall.pid == 0);
+
+    /* Queue is now drained. */
+    ofpbuf_clear(&buf);
+    CHECK(dpif_recv(dpif, 0, &upcall, &buf) == EAGAIN);
+    ofpbuf_uninit(&buf);
+}
+
+/* Regression (audit, flow_dump_next aliasing): a batch of N dumped flows must
+ * each stay valid and distinct.  The transport reuses one buffer per record, so
+ * a naive loop that kept decoded pointers would return N aliases of the last
+ * record.  Program three flows with distinct keys and check they differ. */
+static void
+test_flow_dump_multi_record(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_dump_types types = { .ovs_flows = true };
+    struct dpif_flow_dump *dump;
+    struct dpif_flow_dump_thread *thread;
+    struct dpif_flow batch[8];
+    uint8_t keys[8][256];       /* copied out while the thread is alive */
+    size_t key_lens[8];
+    int total = 0;
+    int n, i;
+
+    printf("test_flow_dump_multi_record:\n");
+    mock_reset_content(m);
+    m->n_flow = 3;
+    build_flow_record(&m->flow[0], 100, false);
+    build_flow_record(&m->flow[1], 200, false);
+    build_flow_record(&m->flow[2], 300, false);
+
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+
+    /* A returned flow's key points into the thread's batch buffer and is only
+     * valid until the next dump_next / thread_destroy, so snapshot the bytes
+     * here.  Aliasing (the bug) makes every key in the batch identical. */
+    while ((n = dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch))) > 0) {
+        for (i = 0; i < n && total < ARRAY_SIZE(keys); i++) {
+            ovs_assert(batch[i].key_len <= sizeof keys[0]);
+            memcpy(keys[total], batch[i].key, batch[i].key_len);
+            key_lens[total] = batch[i].key_len;
+            total++;
+        }
+    }
+
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(dpif_flow_dump_destroy(dump) == 0);
+
+    CHECK(total == 3);
+    if (total == 3) {
+        CHECK(key_lens[0] > 0);
+        CHECK(key_lens[0] == key_lens[1] && key_lens[1] == key_lens[2]);
+        CHECK(memcmp(keys[0], keys[1], key_lens[0]) != 0);
+        CHECK(memcmp(keys[1], keys[2], key_lens[1]) != 0);
+        CHECK(memcmp(keys[0], keys[2], key_lens[0]) != 0);
+    }
+}
+
+/* Regression (audit #3): each dump must run on its own kernel handle, because
+ * the dump cursor is per handle.  Sharing the dpif's channel would race
+ * concurrent transactions and parallel revalidator dumps.  Observe that a flow
+ * dump opens a second handle (peak concurrency rises above the lone main
+ * channel). */
+static void
+test_per_dump_channel(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_dump_types types = { .ovs_flows = true };
+    struct dpif_flow_dump *dump;
+    struct dpif_flow_dump_thread *thread;
+    struct dpif_flow batch[8];
+
+    printf("test_per_dump_channel:\n");
+    mock_reset_content(m);
+    m->n_flow = 1;
+    build_flow_record(&m->flow[0], 111, false);
+
+    /* Baseline: only the dpif's main channel is open. */
+    CHECK(m->n_open == 1);
+    m->peak_open = m->n_open;
+
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+    while (dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch)) > 0) {
+        /* drain */
+    }
+    /* The dump's dedicated handle was open during the walk. */
+    CHECK(m->peak_open >= 2);
+
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(dpif_flow_dump_destroy(dump) == 0);
+}
+
+/* Regression (audit #6): a malformed record encountered mid-dump is reported by
+ * flow_dump_destroy (the dump interface defers all error reporting to it). */
+static void
+test_flow_dump_deferred_error(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_dump_types types = { .ovs_flows = true };
+    struct dpif_flow_dump *dump;
+    struct dpif_flow_dump_thread *thread;
+    struct dpif_flow batch[8];
+
+    printf("test_flow_dump_deferred_error:\n");
+    mock_reset_content(m);
+    m->n_flow = 2;
+    build_flow_record(&m->flow[0], 123, false);   /* good */
+    build_flow_bad(&m->flow[1]);                   /* undecodable */
+
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+    while (dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch)) > 0) {
+        /* drain */
+    }
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(dpif_flow_dump_destroy(dump) == EINVAL);
+}
+
+/* Regression (audit #7/#10): FLOW_GET copies the reply's key/mask/actions into
+ * the caller's buffer.  All ofpbuf_put()s must happen before the pointers are
+ * captured (a later put can realloc and move the base) and the copy must be
+ * unconditional.  A rich flow plus a tiny output buffer forces a realloc; ASAN
+ * catches a dangling read, and the field checks catch a wrong/missing copy. */
+static void
+test_flow_get_hit(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_get get;
+    struct dpif_flow result;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    uint64_t keybuf[64 / 8];     /* deliberately tiny: forces realloc on put */
+    struct ofpbuf buffer;
+    uint64_t reqkey_stub[64 / 8];
+    struct ofpbuf reqkey;
+    const struct nlattr *in_port;
+
+    printf("test_flow_get_hit:\n");
+    mock_reset_content(m);
+    m->flow_reply = FR_ECHO;
+    build_flow_record(&m->flow_echo, 42, true);
+
+    /* A minimal request key (the mock ignores it and returns flow_echo). */
+    ofpbuf_use_stub(&reqkey, reqkey_stub, sizeof reqkey_stub);
+    nl_msg_put_u32(&reqkey, OVS_KEY_ATTR_IN_PORT, 42);
+
+    ofpbuf_use_stub(&buffer, keybuf, sizeof keybuf);
+    memset(&result, 0, sizeof result);
+    memset(&get, 0, sizeof get);
+    get.key = reqkey.data;
+    get.key_len = reqkey.size;
+    get.buffer = &buffer;
+    get.flow = &result;
+
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_GET;
+    op.flow_get = get;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+
+    CHECK(op.error == 0);
+    CHECK(result.key_len > 0);
+    CHECK(result.mask != NULL && result.mask_len > 0);
+    CHECK(result.actions != NULL && result.actions_len == 1500);
+    /* Dereference every copied region: a dangling pointer left by a realloc
+     * between captures is a heap-use-after-free here (caught under ASAN), and a
+     * corrupt copy fails the content checks even without ASAN. */
+    in_port = nl_attr_find__(result.key, result.key_len, OVS_KEY_ATTR_IN_PORT);
+    CHECK(in_port != NULL && nl_attr_get_u32(in_port) == 42);
+    if (result.actions && result.actions_len == 1500) {
+        const uint8_t *acts = (const uint8_t *) result.actions;
+        bool all_cd = true;
+        size_t k;
+        for (k = 0; k < result.actions_len; k++) {
+            if (acts[k] != 0xCD) {
+                all_cd = false;
+                break;
+            }
+        }
+        CHECK(all_cd);
+    }
+    if (result.mask && result.mask_len) {
+        const struct nlattr *m_in =
+            nl_attr_find__(result.mask, result.mask_len, OVS_KEY_ATTR_IN_PORT);
+        CHECK(m_in != NULL && nl_attr_get_u32(m_in) == 0xffffffff);
+    }
+    CHECK(result.stats.n_packets == 5 && result.stats.n_bytes == 500);
+
+    ofpbuf_uninit(&buffer);
+    ofpbuf_uninit(&reqkey);
+}
+
+/* Regression (audit #9): a genuine miss is the in-band NLMSG_ERROR -> ENOENT; a
+ * non-NULL reply that fails to decode is a protocol error (EINVAL), not a miss
+ * reported as ENOENT. */
+static void
+test_flow_get_miss_vs_malformed(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_get get;
+    struct dpif_flow result;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    uint64_t buf_stub[256 / 8];
+    struct ofpbuf buffer;
+    uint64_t reqkey_stub[64 / 8];
+    struct ofpbuf reqkey;
+
+    printf("test_flow_get_miss_vs_malformed:\n");
+    mock_reset_content(m);
+    build_flow_bad(&m->flow_bad);
+
+    ofpbuf_use_stub(&reqkey, reqkey_stub, sizeof reqkey_stub);
+    nl_msg_put_u32(&reqkey, OVS_KEY_ATTR_IN_PORT, 9);
+
+    for (int malformed = 0; malformed <= 1; malformed++) {
+        m->flow_reply = malformed ? FR_MALFORMED : FR_ENOENT;
+
+        ofpbuf_use_stub(&buffer, buf_stub, sizeof buf_stub);
+        memset(&result, 0, sizeof result);
+        memset(&get, 0, sizeof get);
+        get.key = reqkey.data;
+        get.key_len = reqkey.size;
+        get.buffer = &buffer;
+        get.flow = &result;
+
+        memset(&op, 0, sizeof op);
+        op.type = DPIF_OP_FLOW_GET;
+        op.flow_get = get;
+        ops[0] = &op;
+        dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+
+        CHECK(op.error == (malformed ? EINVAL : ENOENT));
+        ofpbuf_uninit(&buffer);
+    }
+    ofpbuf_uninit(&reqkey);
+}
+
+/* Regression (audit #8): a stats-requested FLOW_PUT must surface a bad/missing
+ * echo as an error, not report success with zeroed stats.  A good echo must
+ * populate the stats. */
+static void
+test_flow_put_stats(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_stats stats;
+    struct dpif_flow_put put;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    uint64_t keybuf[64 / 8];
+    struct ofpbuf key;
+
+    printf("test_flow_put_stats:\n");
+
+    ofpbuf_use_stub(&key, keybuf, sizeof keybuf);
+    nl_msg_put_u32(&key, OVS_KEY_ATTR_IN_PORT, 1);
+
+    /* Missing echo -> error (not success-with-zeros). */
+    mock_reset_content(m);
+    m->flow_reply = FR_EMPTYECHO;
+    memset(&stats, 0xab, sizeof stats);
+    memset(&put, 0, sizeof put);
+    put.flags = DPIF_FP_CREATE;
+    put.key = key.data;
+    put.key_len = key.size;
+    put.stats = &stats;
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_PUT;
+    op.flow_put = put;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+    CHECK(op.error == EINVAL);
+
+    /* Good echo -> stats populated. */
+    mock_reset_content(m);
+    m->flow_reply = FR_ECHO;
+    build_flow_record(&m->flow_echo, 1, true);
+    memset(&stats, 0, sizeof stats);
+    memset(&put, 0, sizeof put);
+    put.flags = DPIF_FP_CREATE;
+    put.key = key.data;
+    put.key_len = key.size;
+    put.stats = &stats;
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_PUT;
+    op.flow_put = put;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+    CHECK(op.error == 0);
+    CHECK(stats.n_packets == 5 && stats.n_bytes == 500);
+
+    ofpbuf_uninit(&key);
+}
+
+/* Regression (audit, operate signature): the class 'operate' is the 3-arg
+ * contract; dpif_operate resolves offload before dispatch.  Drive a multi-op
+ * batch through the public path to exercise it end to end. */
+static void
+test_operate_batch(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_put put;
+    struct dpif_op op[2];
+    struct dpif_op *ops[2];
+    uint64_t keybuf[64 / 8];
+    struct ofpbuf key;
+    int i;
+
+    printf("test_operate_batch:\n");
+    mock_reset_content(m);
+
+    ofpbuf_use_stub(&key, keybuf, sizeof keybuf);
+    nl_msg_put_u32(&key, OVS_KEY_ATTR_IN_PORT, 1);
+
+    for (i = 0; i < 2; i++) {
+        memset(&put, 0, sizeof put);
+        put.flags = DPIF_FP_CREATE;
+        put.key = key.data;
+        put.key_len = key.size;
+        memset(&op[i], 0, sizeof op[i]);
+        op[i].type = DPIF_OP_FLOW_PUT;
+        op[i].flow_put = put;
+        ops[i] = &op[i];
+    }
+    dpif_operate(dpif, ops, 2, DPIF_OFFLOAD_NEVER);
+    CHECK(op[0].error == 0);
+    CHECK(op[1].error == 0);
+
+    ofpbuf_uninit(&key);
 }
 
 int
 main(int argc, char *argv[])
 {
     static struct mock_kernel mock;
-    static const struct ovsext_transport mock_transport = {
-        .open = mock_open,
-        .ioctl = mock_ioctl,
-        .close = mock_close,
-        .aux = &mock,
-    };
+    static struct ovsext_transport mock_transport;
     struct dpif *dpif;
     int error;
 
@@ -273,6 +878,11 @@ main(int argc, char *argv[])
     vlog_set_levels(NULL, VLF_ANY_DESTINATION, VLL_WARN);
 
     memset(&mock, 0, sizeof mock);
+    mock_transport.open = mock_open;
+    mock_transport.ioctl = mock_ioctl;
+    mock_transport.close = mock_close;
+    mock_transport.aux = &mock;
+    mock_reset_content(&mock);
     ovsext_set_transport(&mock_transport);
 
     error = dpif_open("ovs-system", "system", &dpif);
@@ -282,10 +892,23 @@ main(int argc, char *argv[])
     }
     printf("dpif_open ok (%s)\n", dpif_name(dpif));
 
-    replay_bringup(dpif);
+    test_bringup(dpif);
+    test_recv_large_upcall(dpif, &mock);
+    test_flow_dump_multi_record(dpif, &mock);
+    test_per_dump_channel(dpif, &mock);
+    test_flow_dump_deferred_error(dpif, &mock);
+    test_flow_get_hit(dpif, &mock);
+    test_flow_get_miss_vs_malformed(dpif, &mock);
+    test_flow_put_stats(dpif, &mock);
+    test_operate_batch(dpif, &mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);
+
+    if (failures) {
+        printf("test-dpif-windows: %d FAILURE(S)\n", failures);
+        return 1;
+    }
     printf("test-dpif-windows: OK\n");
     return 0;
 }

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -13,7 +13,7 @@
  * no VM are involved, so the provider's userspace marshalling can be exercised
  * (and ASAN-checked: configure with -DOVS_ASAN=ON) on a dev box.
  *
- * The mock reproduces the kernel quirks that hid real bugs:
+ * The mock reproduces the kernel quirks that the marshalling must cope with:
  *   - READ copies the dequeued message TRUNCATED to the caller's output length
  *     (so an undersized recv buffer drops the trailing attribute);
  *   - the dump cursor is PER FILE HANDLE (so a dump must use its own handle);
@@ -21,9 +21,7 @@
  *     READ, ended by a zero-length read (no NLMSG_DONE).
  *
  * Each test programs the mock's dump/packet/transact content, drives the
- * provider through the public dpif API, and asserts the contract.  The tests
- * regression-guard the divergences fixed in commits f18d4e34 (recv truncation)
- * and b7d08a2f (the dpif-netlink contract audit). */
+ * provider through the public dpif API, and asserts the contract. */
 
 #include <config.h>
 
@@ -515,11 +513,10 @@ test_bringup(struct dpif *dpif)
     CHECK(dpif_recv_set(dpif, true) == 0);
 }
 
-/* Regression (commit f18d4e34): a full-frame upcall larger than the caller's
- * recv stub must arrive whole.  The provider reads into its own 64 kB buffer
- * and grows the caller's ofpbuf; reading straight into the small stub would let
- * the mock's truncate-to-output-length drop the trailing PACKET attribute and
- * fail the parse, exactly as it dropped DHCP/controller upcalls on eryph. */
+/* A full-frame upcall larger than the caller's recv stub must arrive whole: the
+ * provider reads into its own 64 kB buffer and grows the caller's ofpbuf.
+ * Reading straight into the small stub lets the kernel's truncate-to-output-
+ * length drop the trailing PACKET attribute and fail the parse. */
 static void
 test_recv_large_upcall(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -543,8 +540,8 @@ test_recv_large_upcall(struct dpif *dpif, struct mock_kernel *m)
     CHECK(upcall.type == DPIF_UC_ACTION);
     CHECK(dp_packet_size(&upcall.packet) == frame_len);
 
-    /* Regression (audit #11): pid must be explicitly cleared even though the
-     * caller's upcall was not zero-initialized. */
+    /* pid must be explicitly cleared even though the caller's upcall is not
+     * zero-initialized. */
     CHECK(upcall.pid == 0);
 
     /* Queue is now drained. */
@@ -583,10 +580,10 @@ test_recv_multi_dp_filter(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&buf);
 }
 
-/* Regression (audit, flow_dump_next aliasing): a batch of N dumped flows must
- * each stay valid and distinct.  The transport reuses one buffer per record, so
- * a naive loop that kept decoded pointers would return N aliases of the last
- * record.  Program three flows with distinct keys and check they differ. */
+/* A batch of N dumped flows must each stay valid and distinct.  The transport
+ * reuses one buffer per record, so a loop that kept decoded pointers would
+ * return N aliases of the last record.  Program three flows with distinct keys
+ * and check they differ. */
 static void
 test_flow_dump_multi_record(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -634,11 +631,10 @@ test_flow_dump_multi_record(struct dpif *dpif, struct mock_kernel *m)
     }
 }
 
-/* Regression (audit #3): each dump must run on its own kernel handle, because
- * the dump cursor is per handle.  Sharing the dpif's channel would race
- * concurrent transactions and parallel revalidator dumps.  Observe that a flow
- * dump opens a second handle (peak concurrency rises above the lone main
- * channel). */
+/* Each dump must run on its own kernel handle, because the dump cursor is per
+ * handle.  Sharing the dpif's channel would race concurrent transactions and
+ * parallel revalidator dumps.  Observe that a flow dump opens a second handle
+ * (peak concurrency rises above the lone main channel). */
 static void
 test_per_dump_channel(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -668,8 +664,8 @@ test_per_dump_channel(struct dpif *dpif, struct mock_kernel *m)
     CHECK(dpif_flow_dump_destroy(dump) == 0);
 }
 
-/* Regression (audit #6): a malformed record encountered mid-dump is reported by
- * flow_dump_destroy (the dump interface defers all error reporting to it). */
+/* A malformed record encountered mid-dump is reported by flow_dump_destroy (the
+ * dump interface defers all error reporting to it). */
 static void
 test_flow_dump_deferred_error(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -723,11 +719,11 @@ test_flow_dump_open_failure(struct dpif *dpif, struct mock_kernel *m)
     CHECK(dpif_flow_flush(dpif) == 0);
 }
 
-/* Regression (audit #7/#10): FLOW_GET copies the reply's key/mask/actions into
- * the caller's buffer.  All ofpbuf_put()s must happen before the pointers are
- * captured (a later put can realloc and move the base) and the copy must be
- * unconditional.  A rich flow plus a tiny output buffer forces a realloc; ASAN
- * catches a dangling read, and the field checks catch a wrong/missing copy. */
+/* FLOW_GET copies the reply's key/mask/actions into the caller's buffer.  All
+ * ofpbuf_put()s must happen before the pointers are captured (a later put can
+ * realloc and move the base) and the copy must be unconditional.  A rich flow
+ * plus a tiny output buffer forces a realloc; ASAN catches a dangling read, and
+ * the field checks catch a wrong/missing copy. */
 static void
 test_flow_get_hit(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -839,9 +835,9 @@ test_flow_get_null_buffer(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&reqkey);
 }
 
-/* Regression (audit #9): a genuine miss is the in-band NLMSG_ERROR -> ENOENT; a
- * non-NULL reply that fails to decode is a protocol error (EINVAL), not a miss
- * reported as ENOENT. */
+/* A genuine miss is the in-band NLMSG_ERROR -> ENOENT; a non-NULL reply that
+ * fails to decode is a protocol error (EINVAL), not a miss reported as
+ * ENOENT. */
 static void
 test_flow_get_miss_vs_malformed(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -884,9 +880,8 @@ test_flow_get_miss_vs_malformed(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&reqkey);
 }
 
-/* Regression (audit #8): a stats-requested FLOW_PUT must surface a bad/missing
- * echo as an error, not report success with zeroed stats.  A good echo must
- * populate the stats. */
+/* A stats-requested FLOW_PUT must surface a bad/missing echo as an error, not
+ * report success with zeroed stats.  A good echo must populate the stats. */
 static void
 test_flow_put_stats(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -939,9 +934,8 @@ test_flow_put_stats(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
-/* Regression (audit #8): the FLOW_DEL stats path is identical to FLOW_PUT and
- * was fixed in the same commit -- a bad/missing echo must surface as an error,
- * and a good echo must populate the stats. */
+/* The FLOW_DEL stats path mirrors FLOW_PUT: a bad/missing echo must surface as
+ * an error, and a good echo must populate the stats. */
 static void
 test_flow_del_stats(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -992,9 +986,9 @@ test_flow_del_stats(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
-/* Regression (audit, operate signature): the class 'operate' is the 3-arg
- * contract; dpif_operate resolves offload before dispatch.  Drive a multi-op
- * batch through the public path to exercise it end to end. */
+/* The class 'operate' is the 3-arg contract; dpif_operate resolves offload
+ * before dispatch.  Drive a multi-op batch through the public path to exercise
+ * it end to end. */
 static void
 test_operate_batch(struct dpif *dpif, struct mock_kernel *m)
 {


### PR DESCRIPTION
The native Windows dpif provider (`lib/dpif-windows.c` + `lib/ovsext-channel.c`) was ported from `dpif-netlink` by shape and shipped several unflagged divergences from the dpif contract. This branch fixes them and adds a regression-test harness.

- **recv truncation (the headline bug):** `ovsext_recv` read each upcall straight into the caller's 512-byte stub. The driver truncates a dequeued message to the output length, so any upcall larger than the stub — a full frame plus its flow key, i.e. DHCP and other `controller()`/`userspace()` packet-ins — silently lost its trailing `OVS_PACKET_ATTR_PACKET`, failed the policy parse, and was dropped. OVN's DHCP/ARP/ND responders never fired and VMs got no network. Now reads into a 64 kB buffer and grows the caller's ofpbuf, as the old `nl_sock_recv__` `_WIN32` path did.
- **contract divergences** (systematic comparison vs `dpif-netlink` / `dpif-provider.h`): `operate()` 3-arg signature; flow-dump batch aliasing; per-dump channel/handle isolation; FLOW_GET realloc-dangle, key NULL-guard and null-buffer handling; FLOW_PUT/DEL stats error propagation; deferred dump decode error; `upcall->pid` init; lost-handle abort/restart.
- **tests:** `tests/test-dpif-windows.c` drives the real provider against an in-process mock that reproduces the ovsext IOCTL / per-handle dump cursor / truncating-read quirks; configure `-DOVS_ASAN=ON` for AddressSanitizer. Every fix is regression-guarded and was confirmed to fail when its fix is reverted. Real ICMPv6 forwarding, including >1400-byte frames, was validated end-to-end on a live kernel datapath.

The vport-change notification gap (`port_poll`) is a separate, documented follow-up and is orthogonal to these fixes.