### PR TITLE
dpif-windows: deliver vport-change events through port_poll

### DIFF
--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1488,8 +1488,9 @@ dpif_windows_port_dump_done(const struct dpif *dpif_ OVS_UNUSED, void *state_)
 
 /* Reports the next kernel-initiated vport change (add/remove/link transition)
  * as '*devnamep', mirroring dpif_netlink_port_poll().  The kernel posts these on
- * the vport multicast group (OVS_WIN_NL_VPORT_MCGRP_ID) as OVS_VPORT_CMD_NEW/DEL
- * messages read via OVS_IOCTL_READ_EVENT.
+ * the vport multicast group (OVS_WIN_NL_VPORT_MCGRP_ID), read via
+ * OVS_IOCTL_READ_EVENT; it emits OVS_VPORT_CMD_NEW/DEL today, and (like
+ * dpif-netlink) OVS_VPORT_CMD_SET is also accepted as "this port changed".
  *
  * The notifier channel is opened and joined lazily on the first call, which
  * returns ENOBUFS so ofproto re-dumps the whole port set ("state unknown").

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -48,6 +48,7 @@
 #include "openvswitch/dynamic-string.h"
 #include "openvswitch/match.h"
 #include "openvswitch/ofpbuf.h"
+#include "openvswitch/poll-loop.h"
 #include "openvswitch/vlog.h"
 #include "packets.h"
 #include "sset.h"
@@ -103,6 +104,13 @@ struct dpif_windows {
     char *dp_name;              /* Kernel-reported datapath name. */
     uint32_t user_features;
     bool upcalls_enabled;       /* recv_set() state. */
+
+    /* Vport-change notifier: a dedicated channel joined to the kernel vport
+     * multicast group, opened lazily on the first port_poll().  A handle parked
+     * on a pending event cannot also serve transactions, so it is kept separate
+     * from 'channel'. */
+    struct ovsext_channel port_notifier;
+    bool port_notifier_subscribed;
 };
 
 /* 'dpif_windows_class' is declared in dpif-provider.h and defined at the
@@ -1156,6 +1164,9 @@ dpif_windows_close(struct dpif *dpif_)
      * resources and the containing struct (mirrors dpif_netlink_close).
      * Calling dpif_uninit() here double-frees base_name. */
     ovsext_channel_close(&dpif->channel);
+    if (dpif->port_notifier_subscribed) {
+        ovsext_channel_close(&dpif->port_notifier);
+    }
     free(dpif->dp_name);
     free(dpif);
 }
@@ -1475,21 +1486,84 @@ dpif_windows_port_dump_done(const struct dpif *dpif_ OVS_UNUSED, void *state_)
     return error;
 }
 
+/* Reports the next kernel-initiated vport change (add/remove/link transition)
+ * as '*devnamep', mirroring dpif_netlink_port_poll().  The kernel posts these on
+ * the vport multicast group (OVS_WIN_NL_VPORT_MCGRP_ID) as OVS_VPORT_CMD_NEW/DEL
+ * messages read via OVS_IOCTL_READ_EVENT.
+ *
+ * The notifier channel is opened and joined lazily on the first call, which
+ * returns ENOBUFS so ofproto re-dumps the whole port set ("state unknown").
+ * Thereafter each call returns 0 + a port name, EAGAIN when no event is queued,
+ * or ENOBUFS on any parse/transport hiccup so the caller reconciles by re-dump
+ * rather than missing a change. */
 static int
-dpif_windows_port_poll(const struct dpif *dpif_ OVS_UNUSED,
-                       char **devnamep OVS_UNUSED)
+dpif_windows_port_poll(const struct dpif *dpif_, char **devnamep)
 {
-    /* Report "no change": this provider does not subscribe to the ovsext
-     * vport-change event channel (OVS_WIN_NL_VPORT_MCGRP_ID, delivered via
-     * OVS_IOCTL_READ_EVENT), so kernel-initiated vport changes -- a Hyper-V NIC
-     * teardown, live-migration churn, a port renumber -- are not reported here.
-     * Explicit userspace add/del_port still reconcile odp_to_ofport directly. */
-    return EAGAIN;
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+
+    if (!dpif->port_notifier_subscribed) {
+        int error = ovsext_channel_open(&dpif->port_notifier);
+        if (error) {
+            return error;
+        }
+        dpif->port_notifier.dp_ifindex = dpif->dp_ifindex;
+        error = ovsext_subscribe_vport_events(&dpif->port_notifier, true);
+        if (error) {
+            ovsext_channel_close(&dpif->port_notifier);
+            return error;
+        }
+        dpif->port_notifier_subscribed = true;
+        return ENOBUFS;
+    }
+
+    for (;;) {
+        uint64_t buf_stub[4096 / 8];
+        struct ofpbuf buf;
+        struct dpif_windows_vport vport;
+        int error;
+
+        ofpbuf_use_stub(&buf, buf_stub, sizeof buf_stub);
+        error = ovsext_recv(&dpif->port_notifier, &buf);
+        if (error) {
+            ofpbuf_uninit(&buf);
+            if (error == EAGAIN) {
+                return EAGAIN;
+            }
+            /* A transport error loses event-stream position; force a re-dump. */
+            return ENOBUFS;
+        }
+
+        error = dpif_windows_vport_from_ofpbuf(&vport, &buf);
+        if (!error
+            && vport.dp_ifindex == dpif->dp_ifindex
+            && (vport.cmd == OVS_VPORT_CMD_NEW
+                || vport.cmd == OVS_VPORT_CMD_DEL
+                || vport.cmd == OVS_VPORT_CMD_SET)) {
+            *devnamep = xstrdup(vport.name);
+            ofpbuf_uninit(&buf);
+            return 0;
+        }
+        ofpbuf_uninit(&buf);
+        if (error) {
+            /* A garbled event record: reconcile by re-dump rather than guess. */
+            return ENOBUFS;
+        }
+        /* Event for another datapath; keep draining. */
+    }
 }
 
 static void
-dpif_windows_port_poll_wait(const struct dpif *dpif_ OVS_UNUSED)
+dpif_windows_port_poll_wait(const struct dpif *dpif_)
 {
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+
+    if (dpif->port_notifier_subscribed) {
+        ovsext_recv_wait(&dpif->port_notifier);
+    } else {
+        /* Not yet subscribed: wake immediately so the first port_poll() runs and
+         * joins the multicast group. */
+        poll_immediate_wake();
+    }
 }
 
 /* ====================================================================

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -518,39 +518,58 @@ ovsext_recv(struct ovsext_channel *ch, struct ofpbuf *buf)
     return 0;
 }
 
+/* Builds this channel's overlapped-pend request.  The kernel command depends on
+ * the channel mode -- a packet channel pends OVS_CTRL_CMD_WIN_PEND_PACKET_REQ,
+ * an event channel pends OVS_CTRL_CMD_WIN_PEND_REQ.  Both are validated against a
+ * live datapath by the kernel, so the request carries the resolved dp_ifindex. */
+static void
+ovsext_build_pend_request(struct ovsext_channel *ch, struct ofpbuf *request)
+{
+    struct ovs_header *ovs_header;
+    uint16_t cmd = ch->read_ioctl == OVS_IOCTL_READ_EVENT
+                   ? OVS_CTRL_CMD_WIN_PEND_REQ
+                   : OVS_CTRL_CMD_WIN_PEND_PACKET_REQ;
+
+    nl_msg_put_genlmsghdr(request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
+                          cmd, OVS_WIN_CONTROL_VERSION);
+    ovs_header = ofpbuf_put_uninit(request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = ch->dp_ifindex;
+    ovsext_stamp_request(ch, request);
+}
+
 void
 ovsext_recv_wait(struct ovsext_channel *ch)
 {
     /* A mock transport is synchronous: there is no real overlapped device to
      * pend on (ch->handle is a token, not a Win32 handle), and any queued
-     * message is already available to ovsext_recv.  Wake the poll loop so the
-     * caller retries the recv immediately. */
+     * message is already available to ovsext_recv.  Still route the pend request
+     * through the seam so its dp_ifindex is validated as the kernel would, then
+     * wake the poll loop so the caller retries the recv. */
     if (ovsext_transport) {
+        struct ofpbuf request;
+        uint64_t request_stub[128];
+        DWORD bytes = 0;
+
+        ofpbuf_use_stub(&request, request_stub, sizeof request_stub);
+        ovsext_build_pend_request(ch, &request);
+        ovsext_dev_ioctl(ch, OVS_IOCTL_WRITE, request.data, request.size,
+                         NULL, 0, &bytes);
+        ofpbuf_uninit(&request);
         poll_immediate_wake();
         return;
     }
 
     /* Mirror nl_sock_wait()/pend_io_request(): if no overlapped read is
      * pending, arm one so the driver signals 'rx_event' when a message is ready,
-     * then park on the event.  The pend command depends on the channel mode --
-     * a packet channel pends OVS_CTRL_CMD_WIN_PEND_PACKET_REQ, an event channel
-     * pends OVS_CTRL_CMD_WIN_PEND_REQ. */
+     * then park on the event. */
     if (ch->overlapped.Internal != STATUS_PENDING) {
         struct ofpbuf request;
         uint64_t request_stub[128];
-        struct ovs_header *ovs_header;
         DWORD bytes = 0;
         BOOL ok;
-        uint16_t cmd = ch->read_ioctl == OVS_IOCTL_READ_EVENT
-                       ? OVS_CTRL_CMD_WIN_PEND_REQ
-                       : OVS_CTRL_CMD_WIN_PEND_PACKET_REQ;
 
         ofpbuf_use_stub(&request, request_stub, sizeof request_stub);
-        nl_msg_put_genlmsghdr(&request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
-                              cmd, OVS_WIN_CONTROL_VERSION);
-        ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
-        ovs_header->dp_ifindex = ch->dp_ifindex;
-        ovsext_stamp_request(ch, &request);
+        ovsext_build_pend_request(ch, &request);
 
         ok = DeviceIoControl(ch->handle, OVS_IOCTL_WRITE,
                              request.data, request.size,

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -468,7 +468,10 @@ ovsext_subscribe_vport_events(struct ovsext_channel *ch, bool enable)
     nl_msg_put_genlmsghdr(&request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
                           OVS_CTRL_CMD_MC_SUBSCRIBE_REQ, OVS_WIN_CONTROL_VERSION);
     ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
-    ovs_header->dp_ifindex = 0;
+    /* The kernel validates this command against a live datapath, so it must
+     * carry the resolved dp_ifindex (the default datapath is not always slot 0
+     * -- it is promoted on detach), not a hardcoded 0. */
+    ovs_header->dp_ifindex = ch->dp_ifindex;
     nl_msg_put_u32(&request, OVS_NL_ATTR_MCAST_GRP, OVS_WIN_NL_VPORT_MCGRP_ID);
     nl_msg_put_u8(&request, OVS_NL_ATTR_MCAST_JOIN, enable ? 1 : 0);
 

--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -411,6 +411,79 @@ ovsext_subscribe_packets(struct ovsext_channel *ch, bool enable)
     return 0;
 }
 
+/* Declares this channel's kernel open-instance protocol via
+ * OVS_CTRL_CMD_SOCK_PROP.  The kernel selects an event mask from the instance
+ * protocol (a channel left at protocol 0 receives no multicast events), so a
+ * channel that joins a multicast group must declare NETLINK_GENERIC first.
+ * Mirrors set_sock_property() in lib/netlink-socket.c, but writes the values in
+ * host byte order to match the kernel's NlAttrGetU32 reader (a raw cast, no
+ * byte swap). */
+static int
+ovsext_set_socket_protocol(struct ovsext_channel *ch, uint32_t protocol)
+{
+    struct ofpbuf request;
+    uint64_t request_stub[128];
+    struct ovs_header *ovs_header;
+    struct ofpbuf *reply = NULL;
+    int error;
+
+    ofpbuf_use_stub(&request, request_stub, sizeof request_stub);
+    nl_msg_put_genlmsghdr(&request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
+                          OVS_CTRL_CMD_SOCK_PROP, OVS_WIN_CONTROL_VERSION);
+    ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = 0;
+    nl_msg_put_u32(&request, OVS_NL_ATTR_SOCK_PROTO, protocol);
+    nl_msg_put_u32(&request, OVS_NL_ATTR_SOCK_PID, ch->pid);
+
+    error = ovsext_transact(ch, &request, &reply);
+    ofpbuf_uninit(&request);
+    ofpbuf_delete(reply);
+    return error;
+}
+
+int
+ovsext_subscribe_vport_events(struct ovsext_channel *ch, bool enable)
+{
+    struct ofpbuf request;
+    uint64_t request_stub[128];
+    struct ovs_header *ovs_header;
+    int error;
+
+    if (enable == (ch->read_ioctl == OVS_IOCTL_READ_EVENT)) {
+        return 0;               /* already in the requested state */
+    }
+
+    if (enable) {
+        /* Without NETLINK_GENERIC the kernel computes an empty event mask and
+         * delivers nothing (OvsSubscribeEventCmdHandler). */
+        error = ovsext_set_socket_protocol(ch, NETLINK_GENERIC);
+        if (error) {
+            VLOG_WARN("could not set event channel protocol (%s)",
+                      ovs_strerror(error));
+            return error;
+        }
+    }
+
+    ofpbuf_use_stub(&request, request_stub, sizeof request_stub);
+    nl_msg_put_genlmsghdr(&request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
+                          OVS_CTRL_CMD_MC_SUBSCRIBE_REQ, OVS_WIN_CONTROL_VERSION);
+    ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = 0;
+    nl_msg_put_u32(&request, OVS_NL_ATTR_MCAST_GRP, OVS_WIN_NL_VPORT_MCGRP_ID);
+    nl_msg_put_u8(&request, OVS_NL_ATTR_MCAST_JOIN, enable ? 1 : 0);
+
+    error = ovsext_send(ch, &request);
+    ofpbuf_uninit(&request);
+    if (error) {
+        VLOG_WARN("could not %ssubscribe vport events (%s)",
+                  enable ? "" : "un", ovs_strerror(error));
+        return error;
+    }
+
+    ch->read_ioctl = enable ? OVS_IOCTL_READ_EVENT : OVS_IOCTL_READ;
+    return 0;
+}
+
 int
 ovsext_recv(struct ovsext_channel *ch, struct ofpbuf *buf)
 {
@@ -455,19 +528,23 @@ ovsext_recv_wait(struct ovsext_channel *ch)
     }
 
     /* Mirror nl_sock_wait()/pend_io_request(): if no overlapped read is
-     * pending, arm one with OVS_CTRL_CMD_WIN_PEND_PACKET_REQ so the driver
-     * signals 'rx_event' when a packet is ready; then park on the event. */
+     * pending, arm one so the driver signals 'rx_event' when a message is ready,
+     * then park on the event.  The pend command depends on the channel mode --
+     * a packet channel pends OVS_CTRL_CMD_WIN_PEND_PACKET_REQ, an event channel
+     * pends OVS_CTRL_CMD_WIN_PEND_REQ. */
     if (ch->overlapped.Internal != STATUS_PENDING) {
         struct ofpbuf request;
         uint64_t request_stub[128];
         struct ovs_header *ovs_header;
         DWORD bytes = 0;
         BOOL ok;
+        uint16_t cmd = ch->read_ioctl == OVS_IOCTL_READ_EVENT
+                       ? OVS_CTRL_CMD_WIN_PEND_REQ
+                       : OVS_CTRL_CMD_WIN_PEND_PACKET_REQ;
 
         ofpbuf_use_stub(&request, request_stub, sizeof request_stub);
         nl_msg_put_genlmsghdr(&request, 0, OVS_WIN_NL_CTRL_FAMILY_ID, 0,
-                              OVS_CTRL_CMD_WIN_PEND_PACKET_REQ,
-                              OVS_WIN_CONTROL_VERSION);
+                              cmd, OVS_WIN_CONTROL_VERSION);
         ovs_header = ofpbuf_put_uninit(&request, sizeof *ovs_header);
         ovs_header->dp_ifindex = ch->dp_ifindex;
         ovsext_stamp_request(ch, &request);

--- a/lib/ovsext-channel.h
+++ b/lib/ovsext-channel.h
@@ -119,6 +119,12 @@ int  ovsext_dump_done(struct ovsext_dump *);
  * OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ and flipping the read IOCTL. */
 int  ovsext_subscribe_packets(struct ovsext_channel *, bool enable);
 
+/* Join (or leave) the kernel vport-change multicast group and switch the
+ * channel into event-read mode.  The channel must be dedicated to events: a
+ * handle parked on a pending event cannot also serve transactions or dumps.
+ * Drain delivered events with ovsext_recv()/ovsext_recv_wait(). */
+int  ovsext_subscribe_vport_events(struct ovsext_channel *, bool enable);
+
 /* Non-blocking receive of one queued message using the current read_ioctl.
  * Returns 0 on success (message appended to 'buf'), EAGAIN if nothing is
  * queued, or a positive errno on error. */

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -108,6 +108,9 @@ struct mock_kernel {
     /* Queued packet upcalls, delivered one per OVS_IOCTL_READ_PACKET. */
     struct mock_record pkt[MOCK_MAX_RECORDS];   int pkt_head, pkt_len;
 
+    /* Queued vport-change events, delivered one per OVS_IOCTL_READ_EVENT. */
+    struct mock_record evt[MOCK_MAX_RECORDS];   int evt_head, evt_len;
+
     /* OVS_IOCTL_TRANSACT scripting for the FLOW family. */
     enum flow_reply flow_reply;
     struct mock_record flow_echo;
@@ -366,6 +369,20 @@ mock_read_packet(struct mock_kernel *m, void *out, DWORD out_len, DWORD *bytes)
     return TRUE;
 }
 
+/* OVS_IOCTL_READ_EVENT: dequeue one queued vport event, truncated to out_len. */
+static BOOL
+mock_read_event(struct mock_kernel *m, void *out, DWORD out_len, DWORD *bytes)
+{
+    *bytes = 0;
+    if (m->evt_len == 0) {
+        return TRUE;                /* nothing queued: 0 bytes = EAGAIN */
+    }
+    record_copy(&m->evt[m->evt_head], out, out_len, bytes);
+    m->evt_head = (m->evt_head + 1) % MOCK_MAX_RECORDS;
+    m->evt_len--;
+    return TRUE;
+}
+
 static BOOL
 mock_ioctl(void *aux, HANDLE handle, DWORD code,
            const void *in, DWORD in_len, void *out, DWORD out_len, DWORD *bytes)
@@ -398,8 +415,7 @@ mock_ioctl(void *aux, HANDLE handle, DWORD code,
     case OVS_IOCTL_READ_PACKET:
         return mock_read_packet(m, out, out_len, bytes);
     case OVS_IOCTL_READ_EVENT:
-        *bytes = 0;
-        return TRUE;
+        return mock_read_event(m, out, out_len, bytes);
     default:
         SetLastError(ERROR_INVALID_FUNCTION);
         return FALSE;
@@ -450,6 +466,8 @@ mock_reset_content(struct mock_kernel *m)
     m->n_flow = 0;
     m->pkt_head = 0;
     m->pkt_len = 0;
+    m->evt_head = 0;
+    m->evt_len = 0;
     m->fail_open = false;
     m->flow_reply = FR_ACK;
     /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
@@ -465,6 +483,34 @@ mock_queue_packet(struct mock_kernel *m, const struct mock_record *r)
     ovs_assert(m->pkt_len < MOCK_MAX_RECORDS);
     m->pkt[tail] = *r;
     m->pkt_len++;
+}
+
+/* Queues a vport-change event message (OVS_VPORT_CMD_NEW/DEL), as the kernel's
+ * OvsReadEventCmdHandler/OvsPortFillInfo emit it: a genl vport message with the
+ * standard nlmsg/genl/ovs_header + PORT_NO/TYPE/UPCALL_PID/NAME attributes. */
+static void
+mock_queue_vport_event(struct mock_kernel *m, int dp_ifindex, uint8_t cmd,
+                       uint32_t port_no, const char *name)
+{
+    uint64_t stub[1024 / 8];
+    struct ofpbuf b;
+    struct ovs_header *ovs_header;
+    uint32_t pid = MOCK_PID;
+    int tail = (m->evt_head + m->evt_len) % MOCK_MAX_RECORDS;
+
+    ovs_assert(m->evt_len < MOCK_MAX_RECORDS);
+
+    ofpbuf_use_stub(&b, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&b, 0, OVS_WIN_NL_VPORT_FAMILY_ID, 0, cmd,
+                          OVS_VPORT_VERSION);
+    ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
+    ovs_header->dp_ifindex = dp_ifindex;
+    nl_msg_put_u32(&b, OVS_VPORT_ATTR_PORT_NO, port_no);
+    nl_msg_put_u32(&b, OVS_VPORT_ATTR_TYPE, OVS_VPORT_TYPE_NETDEV);
+    nl_msg_put_unspec(&b, OVS_VPORT_ATTR_UPCALL_PID, &pid, sizeof pid);
+    nl_msg_put_string(&b, OVS_VPORT_ATTR_NAME, name);
+    finish_record(&m->evt[tail], &b);
+    m->evt_len++;
 }
 
 /* ---- tests --------------------------------------------------------------- */
@@ -1022,6 +1068,48 @@ test_operate_batch(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
+/* port_poll lazily subscribes to the vport event channel (returning ENOBUFS so
+ * ofproto re-dumps), then surfaces each queued OVS_VPORT_CMD_NEW/DEL for this
+ * datapath as a port name; events for another datapath are filtered out. */
+static void
+test_port_poll(struct dpif *dpif, struct mock_kernel *m)
+{
+    char *devname;
+    int error;
+
+    printf("test_port_poll:\n");
+    mock_reset_content(m);
+
+    /* First call subscribes and asks ofproto to reconcile the full port set. */
+    devname = NULL;
+    error = dpif_port_poll(dpif, &devname);
+    CHECK(error == ENOBUFS);
+
+    /* A matching NEW event surfaces its port name. */
+    mock_queue_vport_event(m, MOCK_DP_IFINDEX, OVS_VPORT_CMD_NEW, 7, "vport7");
+    devname = NULL;
+    error = dpif_port_poll(dpif, &devname);
+    CHECK(error == 0);
+    CHECK(devname != NULL && !strcmp(devname, "vport7"));
+    free(devname);
+
+    /* A DEL for this datapath also surfaces. */
+    mock_queue_vport_event(m, MOCK_DP_IFINDEX, OVS_VPORT_CMD_DEL, 7, "vport7");
+    devname = NULL;
+    CHECK(dpif_port_poll(dpif, &devname) == 0);
+    CHECK(devname != NULL && !strcmp(devname, "vport7"));
+    free(devname);
+
+    /* An event for another datapath is drained and not reported. */
+    mock_queue_vport_event(m, MOCK_DP_IFINDEX + 9, OVS_VPORT_CMD_NEW, 3, "other");
+    devname = NULL;
+    CHECK(dpif_port_poll(dpif, &devname) == EAGAIN);
+
+    /* Drained queue: no change. */
+    devname = NULL;
+    CHECK(dpif_port_poll(dpif, &devname) == EAGAIN);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1061,6 +1149,7 @@ main(int argc, char *argv[])
     test_flow_put_stats(dpif, &mock);
     test_flow_del_stats(dpif, &mock);
     test_operate_batch(dpif, &mock);
+    test_port_poll(dpif, &mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -328,6 +328,25 @@ mock_write(struct mock_handle *h, const void *in, DWORD in_len, DWORD *bytes)
         default:                            h->dump = DUMP_NONE;  break;
         }
     }
+
+    /* The kernel rejects the subscribe commands (validateDpIndex) when their
+     * ovs_header carries a dp_ifindex that is not a live datapath.  Model that
+     * so a hardcoded-0 subscribe (the default datapath is not always slot 0) is
+     * caught instead of silently targeting the wrong datapath. */
+    if (nlh->nlmsg_type == OVS_WIN_NL_CTRL_FAMILY_ID
+        && in_len >= NLMSG_HDRLEN + GENL_HDRLEN + sizeof(struct ovs_header)) {
+        const struct genlmsghdr *genl = ALIGNED_CAST(const struct genlmsghdr *,
+                                            (const char *) in + NLMSG_HDRLEN);
+        if (genl->cmd == OVS_CTRL_CMD_MC_SUBSCRIBE_REQ
+            || genl->cmd == OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ) {
+            const struct ovs_header *oh = ALIGNED_CAST(const struct ovs_header *,
+                                 (const char *) in + NLMSG_HDRLEN + GENL_HDRLEN);
+            if (oh->dp_ifindex != MOCK_DP_IFINDEX) {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                return FALSE;
+            }
+        }
+    }
     /* Other writes (subscribe/pend) just succeed. */
     return TRUE;
 }

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -115,6 +115,10 @@ struct mock_kernel {
     enum flow_reply flow_reply;
     struct mock_record flow_echo;
     struct mock_record flow_bad;
+
+    /* Set when a validateDpIndex control command (subscribe/pend) arrives with a
+     * dp_ifindex that is not the mock datapath -- the kernel rejects these. */
+    bool validate_dp_failed;
 };
 
 /* ---- record builders ----------------------------------------------------- */
@@ -308,7 +312,8 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
 }
 
 static BOOL
-mock_write(struct mock_handle *h, const void *in, DWORD in_len, DWORD *bytes)
+mock_write(struct mock_kernel *m, struct mock_handle *h,
+           const void *in, DWORD in_len, DWORD *bytes)
 {
     const struct nlmsghdr *nlh = in;
 
@@ -329,25 +334,28 @@ mock_write(struct mock_handle *h, const void *in, DWORD in_len, DWORD *bytes)
         }
     }
 
-    /* The kernel rejects the subscribe commands (validateDpIndex) when their
-     * ovs_header carries a dp_ifindex that is not a live datapath.  Model that
-     * so a hardcoded-0 subscribe (the default datapath is not always slot 0) is
-     * caught instead of silently targeting the wrong datapath. */
+    /* The kernel validates these control commands (validateDpIndex) against a
+     * live datapath and rejects an ovs_header whose dp_ifindex is not one.  Model
+     * that so a hardcoded-0 subscribe or pend (the default datapath is not always
+     * slot 0) is caught instead of silently targeting the wrong datapath. */
     if (nlh->nlmsg_type == OVS_WIN_NL_CTRL_FAMILY_ID
         && in_len >= NLMSG_HDRLEN + GENL_HDRLEN + sizeof(struct ovs_header)) {
         const struct genlmsghdr *genl = ALIGNED_CAST(const struct genlmsghdr *,
                                             (const char *) in + NLMSG_HDRLEN);
         if (genl->cmd == OVS_CTRL_CMD_MC_SUBSCRIBE_REQ
-            || genl->cmd == OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ) {
+            || genl->cmd == OVS_CTRL_CMD_PACKET_SUBSCRIBE_REQ
+            || genl->cmd == OVS_CTRL_CMD_WIN_PEND_REQ
+            || genl->cmd == OVS_CTRL_CMD_WIN_PEND_PACKET_REQ) {
             const struct ovs_header *oh = ALIGNED_CAST(const struct ovs_header *,
                                  (const char *) in + NLMSG_HDRLEN + GENL_HDRLEN);
             if (oh->dp_ifindex != MOCK_DP_IFINDEX) {
+                m->validate_dp_failed = true;
                 SetLastError(ERROR_INVALID_PARAMETER);
                 return FALSE;
             }
         }
     }
-    /* Other writes (subscribe/pend) just succeed. */
+    /* Other writes just succeed. */
     return TRUE;
 }
 
@@ -428,7 +436,7 @@ mock_ioctl(void *aux, HANDLE handle, DWORD code,
     case OVS_IOCTL_TRANSACT:
         return mock_transact(m, in, in_len, out, out_len, bytes);
     case OVS_IOCTL_WRITE:
-        return mock_write(h, in, in_len, bytes);
+        return mock_write(m, h, in, in_len, bytes);
     case OVS_IOCTL_READ:
         return mock_read_dump(m, h, out, out_len, bytes);
     case OVS_IOCTL_READ_PACKET:
@@ -488,6 +496,7 @@ mock_reset_content(struct mock_kernel *m)
     m->evt_head = 0;
     m->evt_len = 0;
     m->fail_open = false;
+    m->validate_dp_failed = false;
     m->flow_reply = FR_ACK;
     /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
     m->n_dp = 1;
@@ -1127,6 +1136,12 @@ test_port_poll(struct dpif *dpif, struct mock_kernel *m)
     /* Drained queue: no change. */
     devname = NULL;
     CHECK(dpif_port_poll(dpif, &devname) == EAGAIN);
+
+    /* port_poll_wait arms the event pend on the notifier channel; the kernel
+     * validates that command's dp_ifindex too, so it must carry the resolved
+     * index (the mock flags a 0/foreign-dp pend). */
+    dpif_port_poll_wait(dpif);
+    CHECK(!m->validate_dp_failed);
 }
 
 int


### PR DESCRIPTION
The native Windows provider stubbed `port_poll()` to `EAGAIN` and left `port_poll_wait()` empty, so ofproto never received asynchronous vport add/remove/link notifications and could only discover kernel-initiated port changes by re-dumping the whole port table each run cycle. The ovsext kernel already posts these on its vport multicast group; this wires the provider to consume them. Userspace-only — no kernel change.

- `ovsext_subscribe_vport_events()`: declare the channel's open-instance protocol as `NETLINK_GENERIC` via `OVS_CTRL_CMD_SOCK_PROP` (without it the kernel computes an empty event mask and delivers nothing), join `OVS_WIN_NL_VPORT_MCGRP_ID`, and switch the channel into `OVS_IOCTL_READ_EVENT` mode. The protocol/pid attributes are written in host byte order to match the kernel's `NlAttrGetU32` reader (a raw read, no byte swap — the old `_WIN32` `set_sock_property` used big-endian, which lands the wrong value on little-endian and is why the channel delivered nothing). `ovsext_recv_wait()` arms the event pend command for an event channel.
- `port_poll`/`port_poll_wait` run on a dedicated, lazily-opened notifier channel (a handle parked on a pending event cannot also serve transactions). The first poll subscribes and returns `ENOBUFS` so ofproto reconciles the full port set; thereafter each poll returns a changed port name filtered to this datapath, `EAGAIN` when drained, or `ENOBUFS` on any transport/parse hiccup so a dropped event degrades to a re-dump rather than a missed port.
- Extend the mock test harness with an event queue and a `port_poll` test covering the ENOBUFS-first call, NEW/DEL delivery, and foreign-datapath filtering. Clean under `-DOVS_ASAN=ON`.

Verified on a live kernel datapath: toggling a VM's vNIC produces the expected port-removed/added events through `port_poll`.