### PR TITLE
compiler: drop Windows-deprecation build warning

### DIFF
--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -2261,8 +2261,7 @@ OvsCreateNlMsgFromCtLimit(POVS_MESSAGE msgIn,
         return STATUS_INVALID_BUFFER_SIZE;
     }
 
-    if (genlMsgHdr->cmd == OVS_CT_LIMIT_CMD_GET && numAttrs) {
-        POVS_CT_ZONE_LIMIT zoneLimitAttr = (POVS_CT_ZONE_LIMIT) attr;
+    if (genlMsgHdr->cmd == OVS_CT_LIMIT_CMD_GET) {
         UINT32 offset = NlMsgStartNested(&nlBuffer, OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
         if (!offset) {
             /* Starting the nested attribute failed. */
@@ -2270,22 +2269,55 @@ OvsCreateNlMsgFromCtLimit(POVS_MESSAGE msgIn,
             goto done;
         }
 
-        /* Insert OVS_CT_ZONE_LIMIT attributes.*/
-        for (UINT32 i = 0; i < numAttrs; i++) {
-            if (zoneLimitAttr) {
-                zoneLimitAttr->limit = zoneInfo[zoneLimitAttr->zone_id].limit;
-                zoneLimitAttr->count = zoneInfo[zoneLimitAttr->zone_id].entries;
-                if (zoneLimitAttr->zone_id == -1) {
-                    zoneLimitAttr->limit = defaultCtLimit;
+        if (numAttrs) {
+            /* Echo back the limit and live count of each requested zone. */
+            POVS_CT_ZONE_LIMIT zoneLimitAttr = (POVS_CT_ZONE_LIMIT) attr;
+            for (UINT32 i = 0; i < numAttrs; i++) {
+                if (zoneLimitAttr) {
+                    if (zoneLimitAttr->zone_id == -1) {
+                        /* The default zone has no zoneInfo[] slot; never index
+                         * the array with the -1 sentinel. */
+                        zoneLimitAttr->limit = defaultCtLimit;
+                        zoneLimitAttr->count = 0;
+                    } else {
+                        UINT16 zone = (UINT16)zoneLimitAttr->zone_id;
+                        zoneLimitAttr->limit = zoneInfo[zone].limit;
+                        zoneLimitAttr->count = zoneInfo[zone].entries;
+                    }
+                    NlMsgPutTail(&nlBuffer, (const PCHAR)zoneLimitAttr,
+                                 sizeof(OVS_CT_ZONE_LIMIT));
+                } else {
+                    status = STATUS_INVALID_PARAMETER;
+                    break;
                 }
-                NlMsgPutTail(&nlBuffer, (const PCHAR)zoneLimitAttr,
-                             sizeof(OVS_CT_ZONE_LIMIT));
-            } else {
-                status = STATUS_INVALID_PARAMETER;
-                break;
+                zoneLimitAttr = (POVS_CT_ZONE_LIMIT)((PCHAR) zoneLimitAttr +
+                                    sizeof(OVS_CT_ZONE_LIMIT));
             }
-            zoneLimitAttr = (POVS_CT_ZONE_LIMIT)((PCHAR) zoneLimitAttr +
-                                sizeof(OVS_CT_ZONE_LIMIT));
+        } else {
+            /* No zone was named in the request: enumerate the default zone plus
+             * every zone whose limit was explicitly set (i.e. differs from the
+             * default), so a bare ct-get-limits lists all configured zones
+             * instead of returning an empty, attribute-less reply. */
+            OVS_CT_ZONE_LIMIT zoneLimit;
+            zoneLimit.zone_id = -1;
+            zoneLimit.limit = defaultCtLimit;
+            zoneLimit.count = 0;
+            if (NlMsgPutTail(&nlBuffer, (const PCHAR)&zoneLimit,
+                             sizeof zoneLimit)) {
+                for (UINT32 zone = 0; zone < (UINT32)CT_MAX_ZONE; zone++) {
+                    if (zoneInfo[zone].limit == defaultCtLimit) {
+                        continue;
+                    }
+                    zoneLimit.zone_id = (int)zone;
+                    zoneLimit.limit = zoneInfo[zone].limit;
+                    zoneLimit.count = zoneInfo[zone].entries;
+                    if (!NlMsgPutTail(&nlBuffer, (const PCHAR)&zoneLimit,
+                                      sizeof zoneLimit)) {
+                        /* Reply buffer is full; return the zones that fit. */
+                        break;
+                    }
+                }
+            }
         }
         NlMsgEndNested(&nlBuffer, offset);
     }

--- a/include/openvswitch/compiler.h
+++ b/include/openvswitch/compiler.h
@@ -283,10 +283,6 @@
     ((size_t)((char *)&(((type *)0)->member) - (char *)0))
 #endif
 
-#if _MSC_VER
-#pragma message ("warning: Windows support is deprecated.")
-#endif
-
 /* Build assertions.
  *
  * Use BUILD_ASSERT_DECL as a declaration or a statement, or BUILD_ASSERT as

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -22,10 +22,13 @@
  * the fixed Windows genl family IDs (OVS_WIN_NL_*_FAMILY_ID) in place of the
  * runtime-resolved Linux genl families.
  *
- * Operations that dpif-netlink itself stubs out under '#ifdef _WIN32' (the
- * conntrack/meter/bond/timeout-policy management members) are simply absent
- * from this class' initializer, exactly as the corresponding members default
- * to NULL.  Upcalls use a single handler, as Windows always has.
+ * Conntrack zone-limit management (ct_set/get/del_limits, ct_get_features) is
+ * wired against the kernel's OVS_CT_LIMIT genl family.  The conntrack
+ * dump/flush members ride the ctnetlink (NETLINK_NETFILTER) transport in
+ * lib/netlink-conntrack.c, which is not built on Windows, so they stay absent
+ * along with the meter, bond and timeout-policy management members; the
+ * corresponding class members default to NULL.  Upcalls use a single handler,
+ * as Windows always has.
  *
  * See datapath-windows/NATIVE-DPIF-EXPERIMENT.md for the full spec. */
 
@@ -37,6 +40,7 @@
 #include <stdio.h>              /* EOF */
 #include <net/if.h>             /* IFNAMSIZ */
 
+#include "ct-dpif.h"
 #include "dpif-provider.h"
 #include "odp-netlink.h"        /* struct ovs_header, OVS_*_ATTR_*. */
 #include "ovsext-channel.h"
@@ -2228,6 +2232,177 @@ dpif_windows_recv_purge(struct dpif *dpif_)
 }
 
 /* ====================================================================
+ * Conntrack zone limits (mirrors dpif-netlink's ct_*_limits).
+ *
+ * The ovsext kernel serves the OVS_CT_LIMIT genl family at the fixed id
+ * OVS_WIN_NL_CTLIMIT_FAMILY_ID, so there is no runtime family lookup: the
+ * family is always present and a zone-limit request round-trips through the
+ * ordinary transaction channel.  A zone_id of OVS_ZONE_LIMIT_DEFAULT_ZONE
+ * carries the default (all-zones) limit.
+ * ==================================================================== */
+
+/* Parses a CT_LIMIT reply (struct ovs_header + a nested array of struct
+ * ovs_zone_limit) into 'zone_limits' as ct_dpif_zone_limit nodes. */
+static int
+dpif_windows_ct_limits_from_ofpbuf(const struct ofpbuf *buf,
+                                   struct ovs_list *zone_limits)
+{
+    static const struct nl_policy ovs_ct_limit_policy[] = {
+        [OVS_CT_LIMIT_ATTR_ZONE_LIMIT] = { .type = NL_A_NESTED,
+                                           .optional = true },
+    };
+
+    struct ofpbuf b = ofpbuf_const_initializer(buf->data, buf->size);
+    struct nlmsghdr *nlmsg = ofpbuf_try_pull(&b, sizeof *nlmsg);
+    struct genlmsghdr *genl = ofpbuf_try_pull(&b, sizeof *genl);
+    struct ovs_header *ovs_header = ofpbuf_try_pull(&b, sizeof *ovs_header);
+
+    struct nlattr *attr[ARRAY_SIZE(ovs_ct_limit_policy)];
+    if (!nlmsg || !genl || !ovs_header
+        || nlmsg->nlmsg_type != OVS_WIN_NL_CTLIMIT_FAMILY_ID
+        || !nl_policy_parse(&b, 0, ovs_ct_limit_policy, attr,
+                            ARRAY_SIZE(ovs_ct_limit_policy))) {
+        return EINVAL;
+    }
+
+    if (!attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]) {
+        return EINVAL;
+    }
+
+    int rem = NLA_ALIGN(nl_attr_get_size(attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]));
+    const struct ovs_zone_limit *zone_limit =
+        nl_attr_get(attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]);
+
+    while (rem >= sizeof *zone_limit) {
+        if (zone_limit->zone_id >= OVS_ZONE_LIMIT_DEFAULT_ZONE &&
+            zone_limit->zone_id <= UINT16_MAX) {
+            ct_dpif_push_zone_limit(zone_limits, zone_limit->zone_id,
+                                    zone_limit->limit, zone_limit->count);
+        }
+        rem -= NLA_ALIGN(sizeof *zone_limit);
+        zone_limit = ALIGNED_CAST(struct ovs_zone_limit *,
+            (unsigned char *) zone_limit + NLA_ALIGN(sizeof *zone_limit));
+    }
+    return 0;
+}
+
+static int
+dpif_windows_ct_set_limits(struct dpif *dpif_,
+                           const struct ovs_list *zone_limits)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct ofpbuf *request = ofpbuf_new(1024);
+    struct ovs_header *ovs_header;
+    int error;
+
+    nl_msg_put_genlmsghdr(request, 0, OVS_WIN_NL_CTLIMIT_FAMILY_ID,
+                          NLM_F_REQUEST | NLM_F_ECHO, OVS_CT_LIMIT_CMD_SET,
+                          OVS_CT_LIMIT_VERSION);
+    ovs_header = ofpbuf_put_uninit(request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = 0;
+
+    size_t opt_offset = nl_msg_start_nested(request,
+                                            OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
+    if (!ovs_list_is_empty(zone_limits)) {
+        struct ct_dpif_zone_limit *zone_limit;
+        LIST_FOR_EACH (zone_limit, node, zone_limits) {
+            struct ovs_zone_limit req_zone_limit = {
+                .zone_id = zone_limit->zone,
+                .limit   = zone_limit->limit,
+            };
+            nl_msg_put(request, &req_zone_limit, sizeof req_zone_limit);
+        }
+    }
+    nl_msg_end_nested(request, opt_offset);
+
+    error = ovsext_transact(&dpif->channel, request, NULL);
+    ofpbuf_delete(request);
+    return error;
+}
+
+static int
+dpif_windows_ct_get_limits(struct dpif *dpif_,
+                           const struct ovs_list *zone_limits_request,
+                           struct ovs_list *zone_limits_reply)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct ofpbuf *request = ofpbuf_new(1024);
+    struct ofpbuf *reply = NULL;
+    struct ovs_header *ovs_header;
+    int error;
+
+    nl_msg_put_genlmsghdr(request, 0, OVS_WIN_NL_CTLIMIT_FAMILY_ID,
+                          NLM_F_REQUEST | NLM_F_ECHO, OVS_CT_LIMIT_CMD_GET,
+                          OVS_CT_LIMIT_VERSION);
+    ovs_header = ofpbuf_put_uninit(request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = 0;
+
+    if (!ovs_list_is_empty(zone_limits_request)) {
+        size_t opt_offset = nl_msg_start_nested(request,
+                                                OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
+        struct ct_dpif_zone_limit *zone_limit;
+        LIST_FOR_EACH (zone_limit, node, zone_limits_request) {
+            struct ovs_zone_limit req_zone_limit = {
+                .zone_id = zone_limit->zone,
+            };
+            nl_msg_put(request, &req_zone_limit, sizeof req_zone_limit);
+        }
+        nl_msg_end_nested(request, opt_offset);
+    }
+
+    error = ovsext_transact(&dpif->channel, request, &reply);
+    if (!error) {
+        error = dpif_windows_ct_limits_from_ofpbuf(reply, zone_limits_reply);
+    }
+    ofpbuf_delete(request);
+    ofpbuf_delete(reply);
+    return error;
+}
+
+static int
+dpif_windows_ct_del_limits(struct dpif *dpif_,
+                           const struct ovs_list *zone_limits)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct ofpbuf *request = ofpbuf_new(1024);
+    struct ovs_header *ovs_header;
+    int error;
+
+    nl_msg_put_genlmsghdr(request, 0, OVS_WIN_NL_CTLIMIT_FAMILY_ID,
+                          NLM_F_REQUEST | NLM_F_ECHO, OVS_CT_LIMIT_CMD_DEL,
+                          OVS_CT_LIMIT_VERSION);
+    ovs_header = ofpbuf_put_uninit(request, sizeof *ovs_header);
+    ovs_header->dp_ifindex = 0;
+
+    if (!ovs_list_is_empty(zone_limits)) {
+        size_t opt_offset = nl_msg_start_nested(request,
+                                                OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
+        struct ct_dpif_zone_limit *zone_limit;
+        LIST_FOR_EACH (zone_limit, node, zone_limits) {
+            struct ovs_zone_limit req_zone_limit = {
+                .zone_id = zone_limit->zone,
+            };
+            nl_msg_put(request, &req_zone_limit, sizeof req_zone_limit);
+        }
+        nl_msg_end_nested(request, opt_offset);
+    }
+
+    error = ovsext_transact(&dpif->channel, request, NULL);
+    ofpbuf_delete(request);
+    return error;
+}
+
+static int
+dpif_windows_ct_get_features(struct dpif *dpif_ OVS_UNUSED,
+                             enum ct_features *features)
+{
+    if (features != NULL) {
+        *features = 0;
+    }
+    return 0;
+}
+
+/* ====================================================================
  * Class.
  * ==================================================================== */
 
@@ -2264,6 +2439,10 @@ const struct dpif_class dpif_windows_class = {
     .recv_wait = dpif_windows_recv_wait,
     .recv_purge = dpif_windows_recv_purge,
     .get_datapath_version = dpif_windows_get_datapath_version,
+    .ct_set_limits = dpif_windows_ct_set_limits,
+    .ct_get_limits = dpif_windows_ct_get_limits,
+    .ct_del_limits = dpif_windows_ct_del_limits,
+    .ct_get_features = dpif_windows_ct_get_features,
 };
 
 #endif /* _WIN32 */

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -23,12 +23,16 @@
  * runtime-resolved Linux genl families.
  *
  * Conntrack zone-limit management (ct_set/get/del_limits, ct_get_features) is
- * wired against the kernel's OVS_CT_LIMIT genl family.  The conntrack
- * dump/flush members ride the ctnetlink (NETLINK_NETFILTER) transport in
- * lib/netlink-conntrack.c, which is not built on Windows, so they stay absent
- * along with the meter, bond and timeout-policy management members; the
- * corresponding class members default to NULL.  Upcalls use a single handler,
- * as Windows always has.
+ * wired against the kernel's OVS_CT_LIMIT genl family over the ordinary
+ * transaction channel.  Conntrack dump/flush are not provided here: their
+ * userspace helpers (nl_ct_*) live in lib/netlink-conntrack.c, the
+ * NETLINK_NETFILTER ctnetlink transport, which is not built on Windows -- a
+ * userspace gap, not a kernel one (the ovsext kernel does serve the ctnetlink
+ * dump/delete path).  Meter, bond and timeout-policy management are likewise
+ * absent, but only because they are not wired yet; meters in particular ride
+ * their own OVS_WIN_NL_METER_FAMILY_ID genl family the same way these CT-limit
+ * members do, independent of netlink-conntrack.c.  All those class members
+ * default to NULL.  Upcalls use a single handler, as Windows always has.
  *
  * See datapath-windows/NATIVE-DPIF-EXPERIMENT.md for the full spec. */
 

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -30,9 +30,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <crtdbg.h>
 #include <windows.h>
 
 #include "dpif.h"
+#include "ct-dpif.h"
 #include "ovsext-channel.h"
 #include "dp-packet.h"
 #include "flow.h"
@@ -119,6 +121,14 @@ struct mock_kernel {
     /* Set when a validateDpIndex control command (subscribe/pend) arrives with a
      * dp_ifindex that is not the mock datapath -- the kernel rejects these. */
     bool validate_dp_failed;
+
+    /* OVS_CT_LIMIT family state.  SET records the requested zone+limit; GET
+     * echoes ct_limit/ct_count back for the requested zone (or the default zone
+     * when the request carries none). */
+    int      ct_last_cmd;
+    int32_t  ct_zone;
+    uint32_t ct_limit;
+    uint32_t ct_count;
 };
 
 /* ---- record builders ----------------------------------------------------- */
@@ -278,6 +288,66 @@ reply_nlmsgerr(int err, void *out, DWORD out_len, DWORD *bytes)
     return TRUE;
 }
 
+/* Extracts the first 'struct ovs_zone_limit' from a CT_LIMIT request's nested
+ * OVS_CT_LIMIT_ATTR_ZONE_LIMIT array, returning false when the request carries
+ * no zone (the "all zones / default" form). */
+static bool
+ct_parse_first_zone(const void *in, DWORD in_len, struct ovs_zone_limit *zlp)
+{
+    struct ofpbuf b = ofpbuf_const_initializer(in, in_len);
+    static const struct nl_policy pol[] = {
+        [OVS_CT_LIMIT_ATTR_ZONE_LIMIT] = { .type = NL_A_NESTED,
+                                           .optional = true },
+    };
+    struct nlattr *attr[ARRAY_SIZE(pol)];
+
+    if (!ofpbuf_try_pull(&b, NLMSG_HDRLEN)
+        || !ofpbuf_try_pull(&b, GENL_HDRLEN)
+        || !ofpbuf_try_pull(&b, sizeof(struct ovs_header))
+        || !nl_policy_parse(&b, 0, pol, attr, ARRAY_SIZE(pol))
+        || !attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]
+        || nl_attr_get_size(attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]) < sizeof *zlp) {
+        return false;
+    }
+    memcpy(zlp, nl_attr_get(attr[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]), sizeof *zlp);
+    return true;
+}
+
+/* Answers an OVS_CT_LIMIT_CMD_GET: echoes one zone limit (the requested zone,
+ * or the default zone) carrying the mock's ct_limit/ct_count, exactly as the
+ * kernel's OvsCreateNlMsgFromCtLimit lays it out. */
+static BOOL
+mock_ct_limit_get(struct mock_kernel *m, const void *in, DWORD in_len,
+                  void *out, DWORD out_len, DWORD *bytes)
+{
+    struct ovs_zone_limit req;
+    int32_t zone = ct_parse_first_zone(in, in_len, &req)
+                   ? req.zone_id : OVS_ZONE_LIMIT_DEFAULT_ZONE;
+    uint64_t stub[256 / 8];
+    struct ofpbuf r;
+    struct ovs_header *oh;
+    size_t nest;
+    DWORD n;
+
+    ofpbuf_use_stub(&r, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&r, 0, OVS_WIN_NL_CTLIMIT_FAMILY_ID, 0,
+                          OVS_CT_LIMIT_CMD_GET, OVS_CT_LIMIT_VERSION);
+    oh = ofpbuf_put_uninit(&r, sizeof *oh);
+    oh->dp_ifindex = 0;
+    nest = nl_msg_start_nested(&r, OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
+    struct ovs_zone_limit zl = { .zone_id = zone, .limit = m->ct_limit,
+                                 .count = m->ct_count };
+    nl_msg_put(&r, &zl, sizeof zl);
+    nl_msg_end_nested(&r, nest);
+    nl_msg_nlmsghdr(&r)->nlmsg_len = r.size;
+
+    n = r.size < out_len ? (DWORD) r.size : out_len;
+    memcpy(out, r.data, n);
+    *bytes = n;
+    ofpbuf_uninit(&r);
+    return TRUE;
+}
+
 static BOOL
 mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
               void *out, DWORD out_len, DWORD *bytes)
@@ -291,6 +361,26 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
     }
 
     switch (nlh->nlmsg_type) {
+    case OVS_WIN_NL_CTLIMIT_FAMILY_ID: {
+        const struct genlmsghdr *genl = ALIGNED_CAST(const struct genlmsghdr *,
+                                            (const char *) in + NLMSG_HDRLEN);
+        struct ovs_zone_limit req;
+
+        m->ct_last_cmd = genl->cmd;
+        if (genl->cmd == OVS_CT_LIMIT_CMD_GET) {
+            return mock_ct_limit_get(m, in, in_len, out, out_len, bytes);
+        }
+        if (ct_parse_first_zone(in, in_len, &req)) {
+            m->ct_zone = req.zone_id;
+            if (genl->cmd == OVS_CT_LIMIT_CMD_SET) {
+                m->ct_limit = req.limit;
+            } else {
+                m->ct_limit = 0;       /* DEL resets to unbounded. */
+            }
+        }
+        return TRUE;                   /* ack, empty reply */
+    }
+
     case OVS_WIN_NL_DATAPATH_FAMILY_ID:
         return record_copy(&m->dp[0], out, out_len, bytes);
 
@@ -1144,6 +1234,67 @@ test_port_poll(struct dpif *dpif, struct mock_kernel *m)
     CHECK(!m->validate_dp_failed);
 }
 
+/* Conntrack zone-limit management round-trips through the OVS_CT_LIMIT genl
+ * family: SET records a per-zone limit, GET reads it back with the current
+ * count, DEL removes it, and an empty GET request targets the default zone.
+ * ct_get_features reports no extra capabilities on Windows. */
+static void
+test_ct_limits(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct ovs_list req = OVS_LIST_INITIALIZER(&req);
+    struct ovs_list reply = OVS_LIST_INITIALIZER(&reply);
+    struct ct_dpif_zone_limit *zl;
+    enum ct_features feat = 0xdead;
+
+    printf("test_ct_limits:\n");
+    m->ct_last_cmd = -1;
+    m->ct_zone = 0;
+    m->ct_limit = 0;
+    m->ct_count = 0;
+
+    /* SET zone 5 -> limit 200 reaches the kernel as CMD_SET. */
+    ct_dpif_push_zone_limit(&req, 5, 200, 0);
+    CHECK(ct_dpif_set_limits(dpif, &req) == 0);
+    CHECK(m->ct_last_cmd == OVS_CT_LIMIT_CMD_SET);
+    CHECK(m->ct_zone == 5);
+    CHECK(m->ct_limit == 200);
+    ct_dpif_free_zone_limits(&req);
+
+    /* GET zone 5 reads back the limit and the live count. */
+    m->ct_count = 7;
+    ovs_list_init(&req);
+    ct_dpif_push_zone_limit(&req, 5, 0, 0);
+    CHECK(ct_dpif_get_limits(dpif, &req, &reply) == 0);
+    CHECK(m->ct_last_cmd == OVS_CT_LIMIT_CMD_GET);
+    CHECK(!ovs_list_is_empty(&reply));
+    zl = CONTAINER_OF(ovs_list_front(&reply), struct ct_dpif_zone_limit, node);
+    CHECK(zl->zone == 5);
+    CHECK(zl->limit == 200);
+    CHECK(zl->count == 7);
+    ct_dpif_free_zone_limits(&req);
+    ct_dpif_free_zone_limits(&reply);
+
+    /* DEL zone 5 reaches the kernel as CMD_DEL. */
+    ovs_list_init(&req);
+    ct_dpif_push_zone_limit(&req, 5, 0, 0);
+    CHECK(ct_dpif_del_limits(dpif, &req) == 0);
+    CHECK(m->ct_last_cmd == OVS_CT_LIMIT_CMD_DEL);
+    CHECK(m->ct_zone == 5);
+    ct_dpif_free_zone_limits(&req);
+
+    /* An empty GET request carries no zone, so it targets the default zone. */
+    ovs_list_init(&reply);
+    CHECK(ct_dpif_get_limits(dpif, &req, &reply) == 0);
+    CHECK(!ovs_list_is_empty(&reply));
+    zl = CONTAINER_OF(ovs_list_front(&reply), struct ct_dpif_zone_limit, node);
+    CHECK(zl->zone == OVS_ZONE_LIMIT_DEFAULT_ZONE);
+    ct_dpif_free_zone_limits(&reply);
+
+    /* Windows advertises no extra conntrack features. */
+    CHECK(ct_dpif_get_features(dpif, &feat) == 0);
+    CHECK(feat == 0);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1151,6 +1302,14 @@ main(int argc, char *argv[])
     static struct ovsext_transport mock_transport;
     struct dpif *dpif;
     int error;
+
+    /* Route the Debug CRT's assert / runtime-check (/RTC1) reports to stderr
+     * instead of a modal dialog, so the test runs unattended under CTest/CI
+     * rather than blocking on an invisible message box. */
+    for (int rt = 0; rt <= _CRT_ASSERT; rt++) {
+        _CrtSetReportMode(rt, _CRTDBG_MODE_FILE);
+        _CrtSetReportFile(rt, _CRTDBG_FILE_STDERR);
+    }
 
     set_program_name(argv[0]);
     vlog_set_levels(NULL, VLF_ANY_DESTINATION, VLL_WARN);
@@ -1184,6 +1343,7 @@ main(int argc, char *argv[])
     test_flow_del_stats(dpif, &mock);
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
+    test_ct_limits(dpif, &mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -30,7 +30,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(_MSC_VER) && defined(_DEBUG)
 #include <crtdbg.h>
+#endif
 #include <windows.h>
 
 #include "dpif.h"
@@ -1303,13 +1305,17 @@ main(int argc, char *argv[])
     struct dpif *dpif;
     int error;
 
+#if defined(_MSC_VER) && defined(_DEBUG)
     /* Route the Debug CRT's assert / runtime-check (/RTC1) reports to stderr
      * instead of a modal dialog, so the test runs unattended under CTest/CI
-     * rather than blocking on an invisible message box. */
+     * rather than blocking on an invisible message box.  These APIs exist only
+     * in the MSVC Debug CRT; other toolchains/Release builds emit no such
+     * dialog. */
     for (int rt = 0; rt <= _CRT_ASSERT; rt++) {
         _CrtSetReportMode(rt, _CRTDBG_MODE_FILE);
         _CrtSetReportFile(rt, _CRTDBG_FILE_STDERR);
     }
+#endif
 
     set_program_name(argv[0]);
     vlog_set_levels(NULL, VLF_ANY_DESTINATION, VLL_WARN);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -315,16 +315,16 @@ ct_parse_first_zone(const void *in, DWORD in_len, struct ovs_zone_limit *zlp)
     return true;
 }
 
-/* Answers an OVS_CT_LIMIT_CMD_GET: echoes one zone limit (the requested zone,
- * or the default zone) carrying the mock's ct_limit/ct_count, exactly as the
- * kernel's OvsCreateNlMsgFromCtLimit lays it out. */
+/* Answers an OVS_CT_LIMIT_CMD_GET, laid out as the kernel's
+ * OvsCreateNlMsgFromCtLimit does: a request naming a zone echoes that one zone;
+ * a bare request (no zone) enumerates the default zone plus a configured zone
+ * (zone 7), exercising the multi-record parse the kernel's enumeration emits. */
 static BOOL
 mock_ct_limit_get(struct mock_kernel *m, const void *in, DWORD in_len,
                   void *out, DWORD out_len, DWORD *bytes)
 {
     struct ovs_zone_limit req;
-    int32_t zone = ct_parse_first_zone(in, in_len, &req)
-                   ? req.zone_id : OVS_ZONE_LIMIT_DEFAULT_ZONE;
+    bool have_zone = ct_parse_first_zone(in, in_len, &req);
     uint64_t stub[256 / 8];
     struct ofpbuf r;
     struct ovs_header *oh;
@@ -337,9 +337,20 @@ mock_ct_limit_get(struct mock_kernel *m, const void *in, DWORD in_len,
     oh = ofpbuf_put_uninit(&r, sizeof *oh);
     oh->dp_ifindex = 0;
     nest = nl_msg_start_nested(&r, OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
-    struct ovs_zone_limit zl = { .zone_id = zone, .limit = m->ct_limit,
-                                 .count = m->ct_count };
-    nl_msg_put(&r, &zl, sizeof zl);
+    if (have_zone) {
+        struct ovs_zone_limit zl = { .zone_id = req.zone_id,
+                                     .limit = m->ct_limit,
+                                     .count = m->ct_count };
+        nl_msg_put(&r, &zl, sizeof zl);
+    } else {
+        struct ovs_zone_limit def = {
+            .zone_id = OVS_ZONE_LIMIT_DEFAULT_ZONE, .limit = m->ct_limit,
+            .count = 0 };
+        struct ovs_zone_limit z7 = { .zone_id = 7, .limit = 77,
+                                     .count = m->ct_count };
+        nl_msg_put(&r, &def, sizeof def);
+        nl_msg_put(&r, &z7, sizeof z7);
+    }
     nl_msg_end_nested(&r, nest);
     nl_msg_nlmsghdr(&r)->nlmsg_len = r.size;
 
@@ -1284,12 +1295,27 @@ test_ct_limits(struct dpif *dpif, struct mock_kernel *m)
     CHECK(m->ct_zone == 5);
     ct_dpif_free_zone_limits(&req);
 
-    /* An empty GET request carries no zone, so it targets the default zone. */
+    /* An empty GET request lists all zones: the kernel enumerates the default
+     * zone plus each configured zone, so the reply carries several records.
+     * Exercise the multi-record parse (default first, then zone 7). */
     ovs_list_init(&reply);
     CHECK(ct_dpif_get_limits(dpif, &req, &reply) == 0);
     CHECK(!ovs_list_is_empty(&reply));
-    zl = CONTAINER_OF(ovs_list_front(&reply), struct ct_dpif_zone_limit, node);
-    CHECK(zl->zone == OVS_ZONE_LIMIT_DEFAULT_ZONE);
+    int n_zones = 0;
+    bool saw_default = false, saw_zone7 = false;
+    LIST_FOR_EACH (zl, node, &reply) {
+        n_zones++;
+        if (zl->zone == OVS_ZONE_LIMIT_DEFAULT_ZONE) {
+            saw_default = true;
+        } else if (zl->zone == 7) {
+            saw_zone7 = true;
+            CHECK(zl->limit == 77);
+            CHECK(zl->count == 7);
+        }
+    }
+    CHECK(n_zones == 2);
+    CHECK(saw_default);
+    CHECK(saw_zone7);
     ct_dpif_free_zone_limits(&reply);
 
     /* Windows advertises no extra conntrack features. */


### PR DESCRIPTION
@
Removes the `#pragma message ("warning: Windows support is deprecated.")` in `include/openvswitch/compiler.h`.

Upstream OVS deprecated and later removed Windows support, but dbosoft now maintains the Windows port independently. The per-translation-unit message is no longer accurate and only adds noise to MSVC builds.
@