### PR TITLE
doc: add Windows-fork README.md and NEWS_WINDOWS

### DIFF
--- a/NEWS_WINDOWS
+++ b/NEWS_WINDOWS
@@ -1,0 +1,63 @@
+Open vSwitch for Windows - dbosoft fork
+=======================================
+
+This file records the changes that are specific to dbosoft's Windows-focused
+fork of Open vSwitch. It complements, and does not replace, the upstream
+changelog in the NEWS file: NEWS continues to track the upstream Open vSwitch
+baseline this fork is built on, while the entries below cover the Windows
+support and Windows-only fixes that dbosoft maintains on top of that baseline.
+
+Upstream removed Windows support from Open vSwitch on the main branch (after
+v3.7.0); see the "Windows" entry under "Post-v3.7.0" in NEWS. This fork
+re-establishes Windows support on top of that Windows-removed upstream main and
+continues to develop it independently.
+
+Each release section lists, in order:
+  - the upstream Open vSwitch baseline the fork is synced to, and
+  - the dbosoft Windows-specific changes layered on top.
+
+
+Unreleased (dbosoft-main)
+-------------------------
+   - Upstream baseline:
+     * Synced with upstream Open vSwitch main (post-v3.7.0, Windows removed),
+       including the DPDK 25.11.2 update, the dpif-offload UDP tunnel entropy
+       support, the ofproto-dpif STP/RSTP bundle floodable fix, the lldp
+       decode hardening fixes, and the dummy simulated hardware offload.
+   - Windows platform:
+     * Re-established Windows support on top of upstream main after Windows was
+       removed upstream: native dpif-windows datapath talking to the ovsext
+       NDIS extension over the ovsext-channel dump/transact protocol (the
+       netlink transport is no longer used on Windows), an MSYS-free CMake +
+       CTest build, and the "Build and Test (Windows)" CI workflow.
+     * VS2022 build fixes (OVS_TYPEOF via __typeof__, Winsock-to-errno
+       translation, ovsext.inf), plus dbosoft driver branding and unique
+       hardware IDs.
+     * Windows runtime fixes: process_start via CreateProcess, ovsdb-server
+       --run/--monitor, vlog log-file reopen, ovs-vsctl exit code, an ovs-pki
+       ACL shim, child exit-code propagation, and ovsdb already-open detection.
+     * Removed the per-translation-unit "Windows support is deprecated" build
+       message: the Windows port is now maintained by dbosoft.
+   - ovsext (Windows kernel datapath):
+     * Back multiple Hyper-V virtual switches from a single extension instance
+       (multi-datapath L2 forwarding).
+     * NDIS 6.60 / 6.85 dual-binary modernization so a single package targets
+       current Windows releases.
+     * Conntrack zone-limit management (OVS_CT_LIMIT family): set, get and
+       delete per-zone limits; enumerate all zone limits on a bare
+       ct-get-limits; delete reverts a zone to the default limit. Fixes an
+       out-of-bounds zoneInfo access on the enumeration path.
+   - netdev-windows:
+     * Detect member-link carrier state via the IP Helper API so bonding can
+       react to member up/down transitions.
+   - dpif-windows:
+     * Fix upcall truncation that caused full-frame controller upcalls (for
+       example DHCP) to be cut short, and resolve several divergences from the
+       dpif provider contract.
+     * Fix packet-subscribe EINVAL after a datapath detach/promote by carrying
+       the resolved dp_ifindex instead of assuming slot 0.
+     * Deliver vport-change events to userspace through port_poll by consuming
+       the ovsext vport multicast channel.
+     * Faithful mock-kernel unit-test harness (tests/test-dpif-windows.c) with
+       optional AddressSanitizer wiring, covering the recv-truncation and
+       dpif-contract fixes and multi-zone ct-get-limits enumeration.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Open vSwitch for Windows (dbosoft)
+
+[![Build and Test (Windows)](https://github.com/dbosoft/ovs/workflows/Build%20and%20Test%20(Windows)/badge.svg)](https://github.com/dbosoft/ovs/actions)
+
+## What is this fork?
+
+This repository is **dbosoft's Windows-focused fork of Open vSwitch**. It is
+**not** an official Open vSwitch release and is **not** affiliated with or
+endorsed by the upstream Open vSwitch project.
+
+Upstream Open vSwitch deprecated Windows support in v3.7 and removed it from
+the `main` branch entirely. This fork re-establishes and continues development of:
+
+- the **ovsext** NDIS forwarding extension (the Windows kernel datapath), and
+- the Windows userspace components (`ovs-vswitchd`, `ovsdb-server`, and the
+  `ovs-*` tools) together with a native, MSYS-free CMake build.
+
+The fork is based on upstream Open vSwitch `main` (after the Windows removal)
+and is periodically resynced with upstream. All non-Windows platforms (Linux,
+FreeBSD, DPDK, userspace datapath) continue to inherit upstream behaviour
+unchanged; our additions are Windows-specific. See
+[NEWS_WINDOWS](NEWS_WINDOWS) for the changes that are unique to this fork on
+top of the upstream baseline tracked in [NEWS](NEWS).
+
+If you are running Open vSwitch on Linux, FreeBSD, or with DPDK, you almost
+certainly want the upstream project at <https://github.com/openvswitch/ovs>
+instead of this fork.
+
+## What is Open vSwitch?
+
+Open vSwitch is a multilayer software switch licensed under the open source
+Apache 2 license. Its goal is to implement a production quality switch
+platform that supports standard management interfaces and opens the forwarding
+functions to programmatic extension and control.
+
+On Windows, Open vSwitch integrates with Hyper-V as an NDIS forwarding
+extension on the virtual switch, providing flow-based forwarding for virtual
+machine traffic. Open vSwitch supports, among other features:
+
+- Standard 802.1Q VLAN model with trunk and access ports
+- NIC bonding with or without LACP on the upstream switch
+- NetFlow, sFlow(R), and mirroring for increased visibility
+- QoS (Quality of Service) configuration, plus policing
+- Geneve, GRE, VXLAN, ERSPAN, GTP-U, SRv6, and Bareudp tunneling
+- OpenFlow 1.0 plus numerous extensions
+- Transactional configuration database with C and Python bindings
+
+> **Two READMEs?** The upstream `README.rst` is left untouched to keep this
+> fork's divergence from upstream minimal. This Windows-specific `README.md`
+> is added alongside it. 
+
+## What's here?
+
+The main components of this distribution are:
+
+- **ovsext**, the Windows NDIS forwarding extension implementing the kernel
+  datapath, under `datapath-windows/`.
+- `ovs-vswitchd`, a daemon that implements the switch.
+- `ovsdb-server`, a lightweight database server that `ovs-vswitchd` queries to
+  obtain its configuration.
+- `ovs-vsctl`, a utility for querying and updating the configuration of
+  `ovs-vswitchd`.
+- `ovs-appctl`, a utility that sends commands to running Open vSwitch daemons.
+- `ovs-dpctl`, a tool for configuring the switch datapath.
+
+Open vSwitch also provides some tools:
+
+- `ovs-ofctl`, a utility for querying and controlling OpenFlow switches and
+  controllers.
+- `ovs-pki`, a utility for creating and managing the public-key infrastructure
+  for OpenFlow switches.
+- `ovs-testcontroller`, a simple OpenFlow controller that may be useful for
+  testing (though not for production).
+
+## Building on Windows
+
+The Windows build uses CMake with Visual Studio 2022 (no MSYS/autotools). The
+ovsext driver is built with the Windows Driver Kit (WDK). The
+**Build and Test (Windows)** GitHub Actions workflow shows the canonical build
+and test steps.
+
+For background on Open vSwitch concepts, the upstream documentation under
+`Documentation/` remains a useful reference. **Note:** that documentation is
+inherited from upstream and is **not** maintained for this Windows fork — it
+may describe Linux-specific procedures or features that do not apply here, and
+may be stale with respect to the Windows port.
+
+## License
+
+Open vSwitch is licensed under the open source Apache 2 license. Some files may
+be marked specifically with a different license, in which case that license
+applies to the file in question.
+
+- Files under the `datapath` directory are licensed under the GNU General
+  Public License, version 2.
+- `lib/conntrack-tcp.c` is licensed under the 2-clause BSD license.
+- `lib/sflow*.[ch]` are licensed under the terms of either the Sun Industry
+  Standards Source License 1.1
+  (<http://host-sflow.sourceforge.net/sissl.html>) or the InMon sFlow License
+  (<http://www.inmon.com/technology/sflowlicense.txt>).
+
+## Contact
+
+For issues specific to this Windows fork, please use the issue tracker at
+<https://github.com/dbosoft/ovs/issues>.
+
+Upstream Open vSwitch can be reached at bugs@openvswitch.org.


### PR DESCRIPTION
Adds a Windows-focused `README.md` and a `NEWS_WINDOWS` changelog for this fork.

- `README.md` states plainly that this is dbosoft's Windows fork of Open vSwitch: not official, not affiliated with upstream, Windows only, based on upstream `main` (after upstream removed Windows support) and periodically resynced. GitHub renders `README.md` in preference to the existing `README.rst`, which is left untouched to keep fork divergence minimal.
- `NEWS_WINDOWS` records the Windows-specific changes layered on top of the upstream baseline that `NEWS` continues to track, so both are visible.

The upstream `Documentation/` tree is intentionally left as-is (stale for Windows) and the README flags it as such.
