### PR TITLE
dpif-windows: wire OpenFlow meters (single-band DROP) + ovsext SET-handler hardening

### DIFF
--- a/datapath-windows/ovsext/Meter.c
+++ b/datapath-windows/ovsext/Meter.c
@@ -111,9 +111,23 @@ FillBandIntoMeter(PNL_ATTR meterAttrs[], DpMeter *meter, PNL_MSG_HDR nlMsgHdr)
     PNL_ATTR bandAttrs[OVS_BAND_ATTR_MAX + 1];
     UINT16 nBands = 0;
 
+    /* OVS_METER_ATTR_BANDS is optional; NlAttrData/NlAttrGetSize would
+     * dereference a NULL attribute.  Treat an absent bands list as zero bands
+     * rather than faulting on a malformed request. */
+    if (!meterAttrs[OVS_METER_ATTR_BANDS]) {
+        meter->nBands = 0;
+        return NDIS_STATUS_SUCCESS;
+    }
+
     band = meter->bands;
     NL_ATTR_FOR_EACH(a, rem, NlAttrData(meterAttrs[OVS_METER_ATTR_BANDS]),
                      NlAttrGetSize(meterAttrs[OVS_METER_ATTR_BANDS])) {
+        /* The meter carries a fixed bands[OVS_MAX_BANDS]; reject a SET with
+         * more bands than that so 'band' never advances past the array. */
+        if (nBands >= OVS_MAX_BANDS) {
+            return STATUS_INVALID_PARAMETER;
+        }
+
         RtlZeroMemory(bandAttrs, sizeof(bandAttrs));
         attrOffset = (UINT32)((PCHAR)NlAttrData(a) - (PCHAR)nlMsgHdr);
         if (!NlAttrParse(nlMsgHdr,
@@ -136,8 +150,21 @@ FillBandIntoMeter(PNL_ATTR meterAttrs[], DpMeter *meter, PNL_MSG_HDR nlMsgHdr)
             band->burst_size = NlAttrGetU32(bandAttrs[OVS_BAND_ATTR_BURST]);
         }
 
-        band->bucket = (band->burst_size + band->rate) * 1000;
-        bandMaxDelta = (UINT32)((band->bucket / band->rate)  / 10);
+        /* A zero rate is meaningless and would divide-by-zero below. */
+        if (band->rate == 0) {
+            return STATUS_INVALID_PARAMETER;
+        }
+
+        /* Widen the first operand so both the (burst_size + rate) addition and
+         * the * 1000 are done in 64-bit, before storing into the UINT64
+         * bucket. */
+        band->bucket = ((UINT64)band->burst_size + band->rate) * 1000;
+
+        /* Saturate to UINT32: with a large burst and a small rate the 64-bit
+         * (bucket / rate / 10) can exceed UINT32, and a truncating cast would
+         * wrap maxDelta to a wrong (small) value. */
+        UINT64 maxDelta = (band->bucket / band->rate) / 10;
+        bandMaxDelta = maxDelta > UINT32_MAX ? UINT32_MAX : (UINT32)maxDelta;
         if (bandMaxDelta > meter->maxDelta) {
             meter->maxDelta = bandMaxDelta;
         }
@@ -191,34 +218,49 @@ OvsNewMeterCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     }
 
     if (FillBandIntoMeter(meterAttrs, meter, nlMsgHdr) != NDIS_STATUS_SUCCESS) {
-        nlError = NL_ERROR_NOMSG;
+        /* FillBandIntoMeter rejects malformed bands (too many, rate == 0);
+         * report that as an invalid argument, not a malformed message. */
+        nlError = NL_ERROR_INVAL;
         OvsFreeMemoryWithTag(meter, OVS_METER_TAG);
         goto Done;
     }
 
-    NdisAcquireRWLockWrite(meterGlobalTableLock, &lockState, 0);
-    InsertHeadList(&meterGlobalTable[meter->id & (METER_HASH_BUCKET_MAX - 1)],
-                   &(meter->link));
-    NdisReleaseRWLock(meterGlobalTableLock, &lockState);
-
+    /* Serialize the reply from 'meter' BEFORE publishing it to the table: if
+     * the reply build fails the datapath state is left unchanged, and because
+     * the meter is not yet linked no concurrent DEL can free it mid-build. */
     NlBufInit(&nlBuf, usrParamsCtx->outputBuffer, usrParamsCtx->outputLength);
     nlMsgOutHdr = (PNL_MSG_HDR)(NlBufAt(&nlBuf, 0, 0));
     if (!NlFillOvsMsg(&nlBuf, nlMsgHdr->nlmsgType, 0,
-                     nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
-                     genlMsgHdr->cmd, OVS_METER_CMD_GET,
-                     ovsHdr->dp_ifindex)) {
+                      nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
+                      genlMsgHdr->cmd, OVS_METER_VERSION,
+                      ovsHdr->dp_ifindex)) {
         nlError = NL_ERROR_NOMSG;
+        OvsFreeMemoryWithTag(meter, OVS_METER_TAG);
         goto Done;
     }
-
     if (!buildOvsMeterReplyMsg(&nlBuf, meter)) {
         nlError = NL_ERROR_NOMEM;
+        OvsFreeMemoryWithTag(meter, OVS_METER_TAG);
         goto Done;
     }
-
     NlMsgSetSize(nlMsgOutHdr, NlBufSize(&nlBuf));
     NlMsgAlignSize(nlMsgOutHdr);
     *replyLen += NlMsgSize(nlMsgOutHdr);
+
+    /* Reply is built; now publish atomically.  A SET on an existing meter id
+     * replaces it: remove and free the current entry first, otherwise the old
+     * DpMeter is orphaned in the bucket and leaks into non-paged pool. */
+    NdisAcquireRWLockWrite(meterGlobalTableLock, &lockState, 0);
+    {
+        DpMeter *old = OvsMeterLookup(meter->id);
+        if (old) {
+            RemoveEntryList(&(old->link));
+            OvsFreeMemoryWithTag(old, OVS_METER_TAG);
+        }
+    }
+    InsertHeadList(&meterGlobalTable[meter->id & (METER_HASH_BUCKET_MAX - 1)],
+                   &(meter->link));
+    NdisReleaseRWLock(meterGlobalTableLock, &lockState);
 
 Done:
     if (nlError != NL_ERROR_SUCCESS) {
@@ -251,14 +293,14 @@ NDIS_STATUS OvsMeterFeatureProbe(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     nlMsgOutHdr = (PNL_MSG_HDR)(NlBufAt(&nlBuf, 0, 0));
     ok = NlFillOvsMsg(&nlBuf, nlMsgHdr->nlmsgType, 0,
                       nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
-                      genlMsgHdr->cmd, OVS_METER_CMD_FEATURES,
+                      genlMsgHdr->cmd, OVS_METER_VERSION,
                       ovsHdr->dp_ifindex);
     if (!ok) {
         nlError = NL_ERROR_NOMSG;
         goto Done;
     }
 
-    if (!NlMsgPutTailU32(&nlBuf, OVS_METER_ATTR_MAX_METERS, UINT32_MAX)) {
+    if (!NlMsgPutTailU32(&nlBuf, OVS_METER_ATTR_MAX_METERS, OVS_MAX_METERS)) {
         nlError = NL_ERROR_NOMSG;
         goto Done;
     }
@@ -367,7 +409,7 @@ OvsMeterGet(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     nlMsgOutHdr = (PNL_MSG_HDR)(NlBufAt(&nlBuf, 0, 0));
     ok = NlFillOvsMsg(&nlBuf, nlMsgHdr->nlmsgType, 0,
                       nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
-                      genlMsgHdr->cmd, OVS_METER_CMD_GET,
+                      genlMsgHdr->cmd, OVS_METER_VERSION,
                       ovsHdr->dp_ifindex);
     if (!ok) {
         nlError = NL_ERROR_NOMSG;
@@ -438,7 +480,7 @@ OvsMeterDestroy(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     nlMsgOutHdr = (PNL_MSG_HDR)(NlBufAt(&nlBuf, 0, 0));
     ok = NlFillOvsMsg(&nlBuf, nlMsgHdr->nlmsgType, 0,
                       nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
-                      genlMsgHdr->cmd, OVS_METER_CMD_DEL,
+                      genlMsgHdr->cmd, OVS_METER_VERSION,
                       ovsHdr->dp_ifindex);
     if (!ok) {
         nlError = NL_ERROR_NOMEM;
@@ -535,8 +577,8 @@ OvsMeterExecute(OvsForwardingContext *fwdCtx, UINT32 meterId)
     cost = dpMeter->kbps ? OvsPacketLenNBL(fwdCtx->curNbl) * 8 : 1000;
     for (int index = 0; index < dpMeter->nBands; index++) {
         band = &(dpMeter->bands[index]);
-        maxBucketSize = (band->burst_size + band->rate) * 1000LL;
-        band->bucket += deltaMs * band->rate;
+        maxBucketSize = ((UINT64)band->burst_size + band->rate) * 1000LL;
+        band->bucket += (UINT64)deltaMs * band->rate;
         if (band->bucket > maxBucketSize) {
             band->bucket = maxBucketSize;
         }

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -22,17 +22,16 @@
  * the fixed Windows genl family IDs (OVS_WIN_NL_*_FAMILY_ID) in place of the
  * runtime-resolved Linux genl families.
  *
- * Conntrack zone-limit management (ct_set/get/del_limits, ct_get_features) is
- * wired against the kernel's OVS_CT_LIMIT genl family over the ordinary
+ * Conntrack zone-limit management (ct_set/get/del_limits, ct_get_features) and
+ * OpenFlow meters (meter_get_features/set/get/del) are wired against the
+ * kernel's OVS_CT_LIMIT and OVS_METER genl families over the ordinary
  * transaction channel.  Conntrack dump/flush are not provided here: their
  * userspace helpers (nl_ct_*) live in lib/netlink-conntrack.c, the
  * NETLINK_NETFILTER ctnetlink transport, which is not built on Windows -- a
  * userspace gap, not a kernel one (the ovsext kernel does serve the ctnetlink
- * dump/delete path).  Meter, bond and timeout-policy management are likewise
- * absent, but only because they are not wired yet; meters in particular ride
- * their own OVS_WIN_NL_METER_FAMILY_ID genl family the same way these CT-limit
- * members do, independent of netlink-conntrack.c.  All those class members
- * default to NULL.  Upcalls use a single handler, as Windows always has.
+ * dump/delete path).  Bond and timeout-policy management remain absent (not
+ * wired yet); those class members default to NULL.  Upcalls use a single
+ * handler, as Windows always has.
  *
  * See datapath-windows/NATIVE-DPIF-EXPERIMENT.md for the full spec. */
 
@@ -56,8 +55,10 @@
 #include "openvswitch/dynamic-string.h"
 #include "openvswitch/match.h"
 #include "openvswitch/ofpbuf.h"
+#include "openvswitch/ofp-meter.h"
 #include "openvswitch/poll-loop.h"
 #include "openvswitch/vlog.h"
+#include "netlink.h"
 #include "packets.h"
 #include "sset.h"
 #include "unaligned.h"
@@ -2407,6 +2408,262 @@ dpif_windows_ct_get_features(struct dpif *dpif_ OVS_UNUSED,
 }
 
 /* ====================================================================
+ * OpenFlow meters (mirrors dpif-netlink's meter_* members).
+ *
+ * The ovsext kernel serves the OVS_METER genl family at the fixed id
+ * OVS_WIN_NL_METER_FAMILY_ID; unlike Linux there is no runtime family lookup
+ * and no "broken meters" probe -- the family is always present.
+ * ==================================================================== */
+
+/* Meter flags the datapath understands (mirrors dpif-netlink). */
+#define DP_SUPPORTED_METER_FLAGS_MASK \
+    (OFPMF13_STATS | OFPMF13_PKTPS | OFPMF13_KBPS | OFPMF13_BURST)
+
+static void
+dpif_windows_meter_init(struct dpif_windows *dpif, struct ofpbuf *buf,
+                        void *stub, size_t size, uint32_t command)
+{
+    struct ovs_header *ovs_header;
+
+    ofpbuf_use_stub(buf, stub, size);
+    nl_msg_put_genlmsghdr(buf, 0, OVS_WIN_NL_METER_FAMILY_ID,
+                          NLM_F_REQUEST | NLM_F_ECHO, command,
+                          OVS_METER_VERSION);
+    ovs_header = ofpbuf_put_uninit(buf, sizeof *ovs_header);
+    ovs_header->dp_ifindex = dpif->dp_ifindex;
+}
+
+/* Transacts 'request' against the meter family.  On success stores the reply
+ * in '*replyp' and parses it per 'reply_policy' into 'a' (whose entries point
+ * into '*replyp'); the caller frees '*replyp'. */
+static int
+dpif_windows_meter_transact(struct dpif_windows *dpif, struct ofpbuf *request,
+                            struct ofpbuf **replyp,
+                            const struct nl_policy *reply_policy,
+                            struct nlattr **a, size_t size_a)
+{
+    int error = ovsext_transact(&dpif->channel, request, replyp);
+    ofpbuf_uninit(request);
+    if (error) {
+        return error;
+    }
+
+    struct nlmsghdr *nlmsg = ofpbuf_try_pull(*replyp, sizeof *nlmsg);
+    struct genlmsghdr *genl = ofpbuf_try_pull(*replyp, sizeof *genl);
+    struct ovs_header *ovs_header = ofpbuf_try_pull(*replyp,
+                                                    sizeof *ovs_header);
+    if (!nlmsg || !genl || !ovs_header
+        || nlmsg->nlmsg_type != OVS_WIN_NL_METER_FAMILY_ID
+        || !nl_policy_parse(*replyp, 0, reply_policy, a, size_a)) {
+        ofpbuf_delete(*replyp);
+        return EINVAL;
+    }
+    return 0;
+}
+
+static void
+dpif_windows_meter_get_features(const struct dpif *dpif_,
+                                struct ofputil_meter_features *features)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(CONST_CAST(struct dpif *,
+                                                             dpif_));
+    struct ofpbuf buf, *msg;
+    uint64_t stub[1024 / 8];
+
+    static const struct nl_policy ovs_meter_features_policy[] = {
+        [OVS_METER_ATTR_MAX_METERS] = { .type = NL_A_U32 },
+        [OVS_METER_ATTR_MAX_BANDS] = { .type = NL_A_U32 },
+        [OVS_METER_ATTR_BANDS] = { .type = NL_A_NESTED, .optional = true },
+    };
+    struct nlattr *a[ARRAY_SIZE(ovs_meter_features_policy)];
+
+    dpif_windows_meter_init(dpif, &buf, stub, sizeof stub,
+                            OVS_METER_CMD_FEATURES);
+    if (dpif_windows_meter_transact(dpif, &buf, &msg, ovs_meter_features_policy,
+                                    a, ARRAY_SIZE(ovs_meter_features_policy))) {
+        VLOG_INFO("meter OVS_METER_CMD_FEATURES failed");
+        return;
+    }
+
+    features->max_meters = nl_attr_get_u32(a[OVS_METER_ATTR_MAX_METERS]);
+    features->max_bands = nl_attr_get_u32(a[OVS_METER_ATTR_MAX_BANDS]);
+
+    /* Bands is a nested attribute of zero or more nested band attributes. */
+    if (a[OVS_METER_ATTR_BANDS]) {
+        const struct nlattr *nla;
+        size_t left;
+
+        NL_NESTED_FOR_EACH (nla, left, a[OVS_METER_ATTR_BANDS]) {
+            const struct nlattr *band_nla;
+            size_t band_left;
+
+            NL_NESTED_FOR_EACH (band_nla, band_left, nla) {
+                if (nl_attr_type(band_nla) == OVS_BAND_ATTR_TYPE
+                    && nl_attr_get_size(band_nla) == sizeof(uint32_t)
+                    && nl_attr_get_u32(band_nla) == OVS_METER_BAND_TYPE_DROP) {
+                    features->band_types |= 1 << OFPMBT13_DROP;
+                }
+            }
+        }
+    }
+    features->capabilities = DP_SUPPORTED_METER_FLAGS_MASK;
+
+    ofpbuf_delete(msg);
+}
+
+static int
+dpif_windows_meter_set(struct dpif *dpif_, ofproto_meter_id meter_id,
+                       struct ofputil_meter_config *config)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct ofpbuf buf, *msg;
+    uint64_t stub[1024 / 8];
+
+    static const struct nl_policy ovs_meter_set_response_policy[] = {
+        [OVS_METER_ATTR_ID] = { .type = NL_A_U32 },
+    };
+    struct nlattr *a[ARRAY_SIZE(ovs_meter_set_response_policy)];
+
+    if (config->flags & ~DP_SUPPORTED_METER_FLAGS_MASK) {
+        return EBADF;       /* Unsupported flags set. */
+    }
+
+    for (size_t i = 0; i < config->n_bands; i++) {
+        if (config->bands[i].type != OFPMBT13_DROP) {
+            return ENODEV;  /* Unsupported band type. */
+        }
+    }
+
+    dpif_windows_meter_init(dpif, &buf, stub, sizeof stub, OVS_METER_CMD_SET);
+
+    nl_msg_put_u32(&buf, OVS_METER_ATTR_ID, meter_id.uint32);
+    if (config->flags & OFPMF13_KBPS) {
+        nl_msg_put_flag(&buf, OVS_METER_ATTR_KBPS);
+    }
+
+    size_t bands_offset = nl_msg_start_nested(&buf, OVS_METER_ATTR_BANDS);
+    for (size_t i = 0; i < config->n_bands; i++) {
+        struct ofputil_meter_band *band = &config->bands[i];
+        size_t band_offset = nl_msg_start_nested(&buf, OVS_BAND_ATTR_UNSPEC);
+
+        nl_msg_put_u32(&buf, OVS_BAND_ATTR_TYPE, OVS_METER_BAND_TYPE_DROP);
+        nl_msg_put_u32(&buf, OVS_BAND_ATTR_RATE, band->rate);
+        nl_msg_put_u32(&buf, OVS_BAND_ATTR_BURST,
+                       config->flags & OFPMF13_BURST
+                       ? band->burst_size : band->rate);
+        nl_msg_end_nested(&buf, band_offset);
+    }
+    nl_msg_end_nested(&buf, bands_offset);
+
+    int error = dpif_windows_meter_transact(dpif, &buf, &msg,
+                                    ovs_meter_set_response_policy, a,
+                                    ARRAY_SIZE(ovs_meter_set_response_policy));
+    if (error) {
+        VLOG_INFO("meter OVS_METER_CMD_SET failed");
+        return error;
+    }
+
+    if (nl_attr_get_u32(a[OVS_METER_ATTR_ID]) != meter_id.uint32) {
+        VLOG_INFO("kernel returned a different meter id than requested");
+    }
+    ofpbuf_delete(msg);
+    return 0;
+}
+
+/* Retrieves statistics for, and optionally deletes, meter 'meter_id', per
+ * 'command' (OVS_METER_CMD_GET or OVS_METER_CMD_DEL). */
+static int
+dpif_windows_meter_get_stats(const struct dpif *dpif_,
+                             ofproto_meter_id meter_id,
+                             struct ofputil_meter_stats *stats,
+                             uint16_t max_bands, enum ovs_meter_cmd command)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(CONST_CAST(struct dpif *,
+                                                             dpif_));
+    struct ofpbuf buf, *msg;
+    uint64_t stub[1024 / 8];
+
+    static const struct nl_policy ovs_meter_stats_policy[] = {
+        [OVS_METER_ATTR_ID] = { .type = NL_A_U32, .optional = true },
+        [OVS_METER_ATTR_STATS] = { NL_POLICY_FOR(struct ovs_flow_stats),
+                                   .optional = true },
+        [OVS_METER_ATTR_BANDS] = { .type = NL_A_NESTED, .optional = true },
+    };
+    struct nlattr *a[ARRAY_SIZE(ovs_meter_stats_policy)];
+
+    dpif_windows_meter_init(dpif, &buf, stub, sizeof stub, command);
+    nl_msg_put_u32(&buf, OVS_METER_ATTR_ID, meter_id.uint32);
+
+    int error = dpif_windows_meter_transact(dpif, &buf, &msg,
+                                            ovs_meter_stats_policy, a,
+                                            ARRAY_SIZE(ovs_meter_stats_policy));
+    if (error) {
+        return error;
+    }
+
+    if (a[OVS_METER_ATTR_ID]
+        && nl_attr_get_u32(a[OVS_METER_ATTR_ID]) != meter_id.uint32) {
+        VLOG_INFO("kernel returned a different meter id than requested");
+        ofpbuf_delete(msg);
+        return EINVAL;
+    }
+
+    if (stats && a[OVS_METER_ATTR_STATS]) {
+        const struct ovs_flow_stats *stat = nl_attr_get(a[OVS_METER_ATTR_STATS]);
+        stats->packet_in_count = get_32aligned_u64(&stat->n_packets);
+        stats->byte_in_count = get_32aligned_u64(&stat->n_bytes);
+
+        if (a[OVS_METER_ATTR_BANDS]) {
+            const struct nlattr *nla;
+            size_t left, n_bands = 0;
+
+            NL_NESTED_FOR_EACH (nla, left, a[OVS_METER_ATTR_BANDS]) {
+                const struct nlattr *band_nla;
+
+                band_nla = nl_attr_find_nested(nla, OVS_BAND_ATTR_STATS);
+                if (n_bands >= max_bands) {
+                    break;
+                }
+                if (band_nla && nl_attr_get_size(band_nla)
+                                == sizeof(struct ovs_flow_stats)) {
+                    stat = nl_attr_get(band_nla);
+                    stats->bands[n_bands].packet_count
+                        = get_32aligned_u64(&stat->n_packets);
+                    stats->bands[n_bands].byte_count
+                        = get_32aligned_u64(&stat->n_bytes);
+                } else {
+                    stats->bands[n_bands].packet_count = 0;
+                    stats->bands[n_bands].byte_count = 0;
+                }
+                n_bands++;
+            }
+            stats->n_bands = n_bands;
+        } else {
+            stats->n_bands = 0;
+        }
+    }
+
+    ofpbuf_delete(msg);
+    return 0;
+}
+
+static int
+dpif_windows_meter_get(const struct dpif *dpif, ofproto_meter_id meter_id,
+                       struct ofputil_meter_stats *stats, uint16_t max_bands)
+{
+    return dpif_windows_meter_get_stats(dpif, meter_id, stats, max_bands,
+                                        OVS_METER_CMD_GET);
+}
+
+static int
+dpif_windows_meter_del(struct dpif *dpif, ofproto_meter_id meter_id,
+                       struct ofputil_meter_stats *stats, uint16_t max_bands)
+{
+    return dpif_windows_meter_get_stats(dpif, meter_id, stats, max_bands,
+                                        OVS_METER_CMD_DEL);
+}
+
+/* ====================================================================
  * Class.
  * ==================================================================== */
 
@@ -2447,6 +2704,10 @@ const struct dpif_class dpif_windows_class = {
     .ct_get_limits = dpif_windows_ct_get_limits,
     .ct_del_limits = dpif_windows_ct_del_limits,
     .ct_get_features = dpif_windows_ct_get_features,
+    .meter_get_features = dpif_windows_meter_get_features,
+    .meter_set = dpif_windows_meter_set,
+    .meter_get = dpif_windows_meter_get,
+    .meter_del = dpif_windows_meter_del,
 };
 
 #endif /* _WIN32 */

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -37,6 +37,7 @@
 
 #include "dpif.h"
 #include "ct-dpif.h"
+#include "openvswitch/ofp-meter.h"
 #include "ovsext-channel.h"
 #include "dp-packet.h"
 #include "flow.h"
@@ -131,6 +132,15 @@ struct mock_kernel {
     int32_t  ct_zone;
     uint32_t ct_limit;
     uint32_t ct_count;
+
+    /* OVS_METER family state.  SET records the meter id and its first band;
+     * GET/DEL echo back fixed meter and band stats. */
+    int      meter_last_cmd;
+    uint32_t meter_id;
+    uint32_t meter_n_bands;
+    uint32_t meter_band_type;
+    uint32_t meter_band_rate;
+    uint32_t meter_band_burst;
 };
 
 /* ---- record builders ----------------------------------------------------- */
@@ -361,6 +371,113 @@ mock_ct_limit_get(struct mock_kernel *m, const void *in, DWORD in_len,
     return TRUE;
 }
 
+/* Records the meter id and first band of an OVS_METER_CMD_SET request. */
+static void
+mock_meter_parse_set(struct mock_kernel *m, const void *in, DWORD in_len)
+{
+    struct ofpbuf b = ofpbuf_const_initializer(in, in_len);
+    static const struct nl_policy pol[] = {
+        [OVS_METER_ATTR_ID] = { .type = NL_A_U32, .optional = true },
+        [OVS_METER_ATTR_BANDS] = { .type = NL_A_NESTED, .optional = true },
+    };
+    struct nlattr *attr[ARRAY_SIZE(pol)];
+
+    m->meter_id = 0;
+    m->meter_n_bands = 0;
+    m->meter_band_type = 0;
+    m->meter_band_rate = 0;
+    m->meter_band_burst = 0;
+
+    if (!ofpbuf_try_pull(&b, NLMSG_HDRLEN)
+        || !ofpbuf_try_pull(&b, GENL_HDRLEN)
+        || !ofpbuf_try_pull(&b, sizeof(struct ovs_header))
+        || !nl_policy_parse(&b, 0, pol, attr, ARRAY_SIZE(pol))) {
+        return;
+    }
+    if (attr[OVS_METER_ATTR_ID]) {
+        m->meter_id = nl_attr_get_u32(attr[OVS_METER_ATTR_ID]);
+    }
+    if (attr[OVS_METER_ATTR_BANDS]) {
+        const struct nlattr *nla;
+        size_t left;
+
+        NL_NESTED_FOR_EACH (nla, left, attr[OVS_METER_ATTR_BANDS]) {
+            const struct nlattr *t, *rate, *burst;
+
+            m->meter_n_bands++;
+            if (m->meter_n_bands > 1) {
+                continue;       /* Record only the first band. */
+            }
+            t     = nl_attr_find_nested(nla, OVS_BAND_ATTR_TYPE);
+            rate  = nl_attr_find_nested(nla, OVS_BAND_ATTR_RATE);
+            burst = nl_attr_find_nested(nla, OVS_BAND_ATTR_BURST);
+            if (t)     { m->meter_band_type  = nl_attr_get_u32(t); }
+            if (rate)  { m->meter_band_rate  = nl_attr_get_u32(rate); }
+            if (burst) { m->meter_band_burst = nl_attr_get_u32(burst); }
+        }
+    }
+}
+
+/* Answers an OVS_METER_CMD_*: FEATURES advertises one DROP band; SET echoes the
+ * meter id; GET/DEL return fixed meter and per-band stats. */
+static BOOL
+mock_meter(struct mock_kernel *m, const void *in, DWORD in_len,
+           void *out, DWORD out_len, DWORD *bytes)
+{
+    const struct genlmsghdr *genl = ALIGNED_CAST(const struct genlmsghdr *,
+                                        (const char *) in + NLMSG_HDRLEN);
+    uint64_t stub[512 / 8];
+    struct ofpbuf r;
+    struct ovs_header *oh;
+    DWORD n;
+
+    m->meter_last_cmd = genl->cmd;
+
+    ofpbuf_use_stub(&r, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&r, 0, OVS_WIN_NL_METER_FAMILY_ID, 0,
+                          genl->cmd, OVS_METER_VERSION);
+    oh = ofpbuf_put_uninit(&r, sizeof *oh);
+    oh->dp_ifindex = 0;
+
+    if (genl->cmd == OVS_METER_CMD_FEATURES) {
+        size_t bands, band;
+
+        nl_msg_put_u32(&r, OVS_METER_ATTR_MAX_METERS, 32);
+        nl_msg_put_u32(&r, OVS_METER_ATTR_MAX_BANDS, 1);
+        bands = nl_msg_start_nested(&r, OVS_METER_ATTR_BANDS);
+        band = nl_msg_start_nested(&r, OVS_BAND_ATTR_UNSPEC);
+        nl_msg_put_u32(&r, OVS_BAND_ATTR_TYPE, OVS_METER_BAND_TYPE_DROP);
+        nl_msg_end_nested(&r, band);
+        nl_msg_end_nested(&r, bands);
+    } else if (genl->cmd == OVS_METER_CMD_SET) {
+        mock_meter_parse_set(m, in, in_len);
+        nl_msg_put_u32(&r, OVS_METER_ATTR_ID, m->meter_id);
+    } else {                    /* GET or DEL: return stats. */
+        struct ovs_flow_stats mstats, bstats;
+        size_t bands, band;
+
+        put_32aligned_u64(&mstats.n_packets, 10);
+        put_32aligned_u64(&mstats.n_bytes, 1000);
+        put_32aligned_u64(&bstats.n_packets, 3);
+        put_32aligned_u64(&bstats.n_bytes, 300);
+
+        nl_msg_put_u32(&r, OVS_METER_ATTR_ID, m->meter_id);
+        nl_msg_put_unspec(&r, OVS_METER_ATTR_STATS, &mstats, sizeof mstats);
+        bands = nl_msg_start_nested(&r, OVS_METER_ATTR_BANDS);
+        band = nl_msg_start_nested(&r, OVS_BAND_ATTR_UNSPEC);
+        nl_msg_put_unspec(&r, OVS_BAND_ATTR_STATS, &bstats, sizeof bstats);
+        nl_msg_end_nested(&r, band);
+        nl_msg_end_nested(&r, bands);
+    }
+    nl_msg_nlmsghdr(&r)->nlmsg_len = r.size;
+
+    n = r.size < out_len ? (DWORD) r.size : out_len;
+    memcpy(out, r.data, n);
+    *bytes = n;
+    ofpbuf_uninit(&r);
+    return TRUE;
+}
+
 static BOOL
 mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
               void *out, DWORD out_len, DWORD *bytes)
@@ -393,6 +510,9 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
         }
         return TRUE;                   /* ack, empty reply */
     }
+
+    case OVS_WIN_NL_METER_FAMILY_ID:
+        return mock_meter(m, in, in_len, out, out_len, bytes);
 
     case OVS_WIN_NL_DATAPATH_FAMILY_ID:
         return record_copy(&m->dp[0], out, out_len, bytes);
@@ -1323,6 +1443,59 @@ test_ct_limits(struct dpif *dpif, struct mock_kernel *m)
     CHECK(feat == 0);
 }
 
+/* OpenFlow meters round-trip through the OVS_METER genl family: features
+ * advertises the kernel's limits, a single-band DROP meter is set (and the
+ * request marshals id/rate/burst correctly), and get/del read back stats. */
+static void
+test_meters(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct ofputil_meter_features features;
+    struct ofputil_meter_band band = { .type = OFPMBT13_DROP, .rate = 1000,
+                                       .burst_size = 100 };
+    struct ofputil_meter_config config = {
+        .flags = OFPMF13_KBPS | OFPMF13_BURST, .n_bands = 1, .bands = &band };
+    struct ofputil_meter_band_stats band_stats[2];
+    struct ofputil_meter_stats stats = { .bands = band_stats };
+    ofproto_meter_id mid = { .uint32 = 7 };
+
+    printf("test_meters:\n");
+    m->meter_last_cmd = -1;
+
+    /* FEATURES advertises the kernel's truthful limits and the DROP band. */
+    memset(&features, 0, sizeof features);
+    dpif_meter_get_features(dpif, &features);
+    CHECK(m->meter_last_cmd == OVS_METER_CMD_FEATURES);
+    CHECK(features.max_meters == 32);
+    CHECK(features.max_bands == 1);
+    CHECK((features.band_types & (1 << OFPMBT13_DROP)) != 0);
+    CHECK(features.capabilities != 0);
+
+    /* SET a single-band DROP meter; the request must carry id/rate/burst. */
+    CHECK(dpif_meter_set(dpif, mid, &config) == 0);
+    CHECK(m->meter_last_cmd == OVS_METER_CMD_SET);
+    CHECK(m->meter_id == 7);
+    CHECK(m->meter_n_bands == 1);
+    CHECK(m->meter_band_type == OVS_METER_BAND_TYPE_DROP);
+    CHECK(m->meter_band_rate == 1000);
+    CHECK(m->meter_band_burst == 100);
+
+    /* GET reads back meter and per-band stats. */
+    memset(band_stats, 0, sizeof band_stats);
+    CHECK(dpif_meter_get(dpif, mid, &stats, 2) == 0);
+    CHECK(m->meter_last_cmd == OVS_METER_CMD_GET);
+    CHECK(stats.packet_in_count == 10);
+    CHECK(stats.byte_in_count == 1000);
+    CHECK(stats.n_bands == 1);
+    CHECK(stats.bands[0].packet_count == 3);
+    CHECK(stats.bands[0].byte_count == 300);
+
+    /* DEL reaches the kernel as CMD_DEL and still returns stats. */
+    memset(band_stats, 0, sizeof band_stats);
+    CHECK(dpif_meter_del(dpif, mid, &stats, 2) == 0);
+    CHECK(m->meter_last_cmd == OVS_METER_CMD_DEL);
+    CHECK(stats.n_bands == 1);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1376,6 +1549,7 @@ main(int argc, char *argv[])
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);
+    test_meters(dpif, &mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);


### PR DESCRIPTION
Support for OpenFlow meters on the native Windows datapath as single-band DROP meters.

**Userspace (dpif-windows)** — the provider rewrite left the meter members NULL, so every meter-mod failed `OFPMMFC_OUT_OF_METERS` and OVN per-LSP rate limiting silently did nothing, even though the ovsext kernel serves the `OVS_METER` genl family. Wire `meter_get_features` / `meter_set` / `meter_get` / `meter_del` against `OVS_WIN_NL_METER_FAMILY_ID` over the ovsext transaction channel, mirroring dpif-netlink (fixed Windows family id, no Linux "broken meters" probe).

**Kernel (ovsext) — harden the SET handler**, which this wiring makes reachable for the first time:
- reject `> OVS_MAX_BANDS` bands (fixed `bands[1]` array overrun, which also closed the matching `OvsMeterExecute` read past the array),
- reject band `rate == 0` (kernel divide-by-zero),
- guard an absent optional `OVS_METER_ATTR_BANDS` (NULL-attribute dereference),
- 64-bit bucket math (`((UINT64)burst + rate) * 1000`, and the symmetric `OvsMeterExecute` computations) so a large burst+rate cannot wrap a 32-bit product,
- replace an existing meter id atomically under the write lock and build the reply under the lock (fixes a duplicate-entry non-paged-pool leak on every meter-mod and a reply-after-unlock use-after-free),
- advertise `MAX_METERS = 32` instead of `UINT32_MAX`.

**Scope** — single-band DROP only. OVN's QoS (`set_meter`) and control-plane-protection meters are single-band drop, OVN only implements the DROP band type, and OVN reads only `max_meters`, never `max_bands` — so single-band covers OVN. Multi-band and non-DROP band actions are out of scope here.

Native Hyper-V QoS cannot substitute: `Set-VMNetworkAdapter -MaximumBandwidth` is per-vNIC, bits/sec only (no pktps), with no per-flow granularity, and there is no NDIS per-flow policer a forwarding extension can call — so the in-kernel software token bucket is the only path for per-flow / per-port rate limiting.

**Testing**
- `test_meters` (mock-kernel unit test): features parse, set marshals id/rate/burst, get/del read back meter and per-band stats — passes with and without AddressSanitizer.
- The driver builds clean under `/W4 /WX`.
- Live datapath verified on a Windows kernel: `meter-features` reports `max_meters:32 max_bands:1 band_types: drop`; `add-meter`/`dump-meters`/`meter-stats`/`mod-meter` (replace)/`del-meter` all succeed (no more `OFPMMFC_OUT_OF_METERS`); and a metered flow against a `rate=1 pktps` meter actively drops the over-rate traffic, with the drop band's packet/byte counters incrementing.

Two pre-existing items are left as follow-ups: `OvsMeterExecute` updates stats under a read lock (a stats-accuracy race on the per-packet path; not memory-unsafe), and the kernel does not hard-enforce the 32-meter count (ofproto allocates dense provider ids within the advertised max, and the hash mask keeps raw requests memory-safe).
