### PR TITLE
ovsext-channel: treat NLMSG_DONE as flow-dump end-of-dump

### DIFF
--- a/lib/ovsext-channel.c
+++ b/lib/ovsext-channel.c
@@ -258,9 +258,12 @@ ovsext_send(struct ovsext_channel *ch, const struct ofpbuf *msg)
  * The ovsext driver implements a dump the same way the Linux kernel does over
  * a netlink socket: an OVS_IOCTL_WRITE carrying the NLM_F_DUMP request arms a
  * per-handle dump cursor (OvsSetupDumpStart), then each OVS_IOCTL_READ returns
- * the next single record.  A zero-length read marks end-of-dump; the driver
- * does not send an NLMSG_DONE (see OvsGetVportDumpNext in
- * datapath-windows/ovsext/Vport.c).  This mirrors nl_dump_start/nl_dump_next. */
+ * the next single record.  End-of-dump is signalled in one of two ways
+ * depending on the family: the vport and datapath dumps return a zero-length
+ * read (OvsGetVportDumpNext), while the flow dump returns a final NLMSG_DONE
+ * record (see _FlowNlDumpCmdHandler in datapath-windows/ovsext/Flow.c).
+ * ovsext_dump_next() treats both as the end.  This mirrors
+ * nl_dump_start/nl_dump_next. */
 void
 ovsext_dump_start(struct ovsext_dump *dump, struct ovsext_channel *ch,
                   const struct ofpbuf *request)
@@ -314,8 +317,9 @@ ovsext_dump_next(struct ovsext_dump *dump, struct ofpbuf *reply)
     }
 
     if (bytes == 0) {
-        /* End-of-dump: the driver replies with zero bytes once the cursor is
-         * exhausted (no NLMSG_DONE record is sent). */
+        /* End-of-dump for the vport/datapath dumps: the driver replies with
+         * zero bytes once the cursor is exhausted.  (The flow dump instead
+         * ends with the NLMSG_DONE record handled below.) */
         return false;
     }
     if (bytes < sizeof *nlmsg) {
@@ -328,6 +332,11 @@ ovsext_dump_next(struct ovsext_dump *dump, struct ofpbuf *reply)
     dump->buf->size = bytes;
 
     nlmsg = dump->buf->data;
+    if (nlmsg->nlmsg_type == NLMSG_DONE) {
+        /* The flow dump ends with an NLMSG_DONE record rather than a
+         * zero-length read; treat it as end-of-dump (not a flow record). */
+        return false;
+    }
     if (nlmsg->nlmsg_type == NLMSG_ERROR) {
         int nl_error = EINVAL;
         nl_msg_nlmsgerr(dump->buf, &nl_error, NULL);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -108,6 +108,8 @@ struct mock_kernel {
     struct mock_record dp[MOCK_MAX_RECORDS];    int n_dp;
     struct mock_record vport[MOCK_MAX_RECORDS]; int n_vport;
     struct mock_record flow[MOCK_MAX_RECORDS];  int n_flow;
+    bool flow_dump_done;        /* FLOW dump ends with an NLMSG_DONE record
+                                 * (as the kernel does), not a zero-length read. */
 
     /* Queued packet upcalls, delivered one per OVS_IOCTL_READ_PACKET. */
     struct mock_record pkt[MOCK_MAX_RECORDS];   int pkt_head, pkt_len;
@@ -479,6 +481,21 @@ mock_read_dump(struct mock_kernel *m, struct mock_handle *h,
     }
 
     if (h->cursor >= n) {
+        if (h->dump == DUMP_FLOW && m->flow_dump_done) {
+            /* The flow dump ends with an NLMSG_DONE record (Flow.c); emit it
+             * once, then the next read is the zero-length EOF. */
+            struct nlmsghdr *nlh = out;
+            if (out_len < NLMSG_HDRLEN) {
+                SetLastError(ERROR_INSUFFICIENT_BUFFER);
+                return FALSE;       /* leave the dump armed so a retry works */
+            }
+            h->dump = DUMP_NONE;
+            memset(out, 0, NLMSG_HDRLEN);
+            nlh->nlmsg_len = NLMSG_HDRLEN;
+            nlh->nlmsg_type = NLMSG_DONE;
+            *bytes = NLMSG_HDRLEN;
+            return TRUE;
+        }
         h->dump = DUMP_NONE;        /* exhausted: zero-length read = EOF */
         return TRUE;
     }
@@ -600,6 +617,7 @@ mock_reset_content(struct mock_kernel *m)
     m->evt_len = 0;
     m->fail_open = false;
     m->validate_dp_failed = false;
+    m->flow_dump_done = false;
     m->flow_reply = FR_ACK;
     /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
     m->n_dp = 1;
@@ -806,6 +824,53 @@ test_flow_dump_multi_record(struct dpif *dpif, struct mock_kernel *m)
         CHECK(memcmp(keys[1], keys[2], key_lens[1]) != 0);
         CHECK(memcmp(keys[0], keys[2], key_lens[0]) != 0);
     }
+}
+
+/* The flow dump terminates with an NLMSG_DONE record (unlike vport/datapath
+ * dumps, which end with a zero-length read).  The transport must treat that
+ * record as end-of-dump, not feed it back as a flow whose decode then fails and
+ * makes dpif_flow_dump_destroy report EINVAL.  Covers the zero-flow case (the
+ * lone record is the terminator) and a non-empty dump. */
+static void
+test_flow_dump_done_terminator(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_dump_types types = { .ovs_flows = true };
+    struct dpif_flow_dump *dump;
+    struct dpif_flow_dump_thread *thread;
+    struct dpif_flow batch[8];
+    int total, n;
+
+    printf("test_flow_dump_done_terminator:\n");
+
+    /* Zero flows: the only record read is the NLMSG_DONE terminator. */
+    mock_reset_content(m);
+    m->flow_dump_done = true;
+    m->n_flow = 0;
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+    total = 0;
+    while ((n = dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch))) > 0) {
+        total += n;
+    }
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(total == 0);
+    CHECK(dpif_flow_dump_destroy(dump) == 0);   /* NLMSG_DONE is not an error */
+
+    /* Two flows followed by the NLMSG_DONE terminator. */
+    mock_reset_content(m);
+    m->flow_dump_done = true;
+    m->n_flow = 2;
+    build_flow_record(&m->flow[0], 100, false);
+    build_flow_record(&m->flow[1], 200, false);
+    dump = dpif_flow_dump_create(dpif, false, &types);
+    thread = dpif_flow_dump_thread_create(dump);
+    total = 0;
+    while ((n = dpif_flow_dump_next(thread, batch, ARRAY_SIZE(batch))) > 0) {
+        total += n;
+    }
+    dpif_flow_dump_thread_destroy(thread);
+    CHECK(total == 2);
+    CHECK(dpif_flow_dump_destroy(dump) == 0);
 }
 
 /* Each dump must run on its own kernel handle, because the dump cursor is per
@@ -1365,6 +1430,7 @@ main(int argc, char *argv[])
     test_recv_large_upcall(dpif, &mock);
     test_recv_multi_dp_filter(dpif, &mock);
     test_flow_dump_multi_record(dpif, &mock);
+    test_flow_dump_done_terminator(dpif, &mock);
     test_per_dump_channel(dpif, &mock);
     test_flow_dump_deferred_error(dpif, &mock);
     test_flow_dump_open_failure(dpif, &mock);


### PR DESCRIPTION
Fixes a continuous `dpif(revalidatorN)|WARN|system@ovs-system: flow_dump_destroy failed (Invalid argument)` — logged on every revalidator flow dump (~1/sec), even with zero installed flows.

**Cause.** The ovsext flow dump terminates with an `NLMSG_DONE` record, whereas the vport and datapath dumps end with a zero-length read. `ovsext_dump_next()` only handled the zero-length EOF (and `NLMSG_ERROR`), so it handed the `NLMSG_DONE` terminator back as if it were a flow record. `dpif_windows_flow_from_ofpbuf` then rejected its `nlmsg_type` and stashed `EINVAL` in the dump status, which `dpif_flow_dump_destroy` surfaced as the warning. With zero flows the only record read is the terminator, so it fired on every dump regardless of flow count. The flows themselves arrive before the terminator and decode fine, so the symptom was log spam (which also masks genuine dump failures), not lost flows.

**Fix.** Recognise `NLMSG_DONE` as end-of-dump in `ovsext_dump_next()` (as `nl_dump_next` does), so the terminator is consumed rather than decoded. Userspace-only; the kernel is unchanged, so it works against already-installed drivers.

**Testing.**
- New `test_flow_dump_done_terminator` (mock-kernel unit test) drives a flow dump that ends with an `NLMSG_DONE` record, for both the zero-flow and non-empty cases, and asserts `dpif_flow_dump_destroy` returns 0. Verified to fail without the fix and pass with it; green with and without AddressSanitizer.
- Live: on a `system@ovs-system` datapath, the revalidator ran with zero installed flows and logged the warning zero times over 9 s (previously ~1/sec).
