### PR TITLE
dpif-windows: negotiate datapath features and report megaflow stats

### DIFF
--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -1290,6 +1290,11 @@ OvsGetPidHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
  * userspace.
  * --------------------------------------------------------------------------
  */
+/* Datapath features ovsext honours in the OVS_DP_F_* handshake.  Windows has
+ * no TC offload and per-CPU upcall dispatch is not implemented, so only the
+ * unaligned-attribute and per-vport-PID features are supported. */
+#define OVSEXT_SUPPORTED_DP_FEATURES (OVS_DP_F_UNALIGNED | OVS_DP_F_VPORT_PIDS)
+
 static NTSTATUS
 OvsDpFillInfo(POVS_SWITCH_CONTEXT ovsSwitchContext,
               POVS_MESSAGE msgIn,
@@ -1329,6 +1334,25 @@ OvsDpFillInfo(POVS_SWITCH_CONTEXT ovsSwitchContext,
         dpStats.n_flows = datapath->nFlows;
         writeOk = NlMsgPutTailUnspec(nlBuf, OVS_DP_ATTR_STATS,
                                      (PCHAR)&dpStats, sizeof dpStats);
+    }
+    if (writeOk) {
+        /* ovsext keeps a linear flow table rather than a tuple-space
+         * classifier, so it has no real megaflow masks.  Report the table as a
+         * single implicit mask so that dpif_get_dp_stats() takes its populated
+         * branch instead of the UINT32_MAX "no megaflow stats" sentinel, giving
+         * ovs-dpctl a sensible masks line. */
+        struct ovs_dp_megaflow_stats dpMegaflowStats;
+
+        RtlZeroMemory(&dpMegaflowStats, sizeof dpMegaflowStats);
+        dpMegaflowStats.n_masks = 1;
+        dpMegaflowStats.n_mask_hit = datapath->hits;
+        writeOk = NlMsgPutTailUnspec(nlBuf, OVS_DP_ATTR_MEGAFLOW_STATS,
+                                     (PCHAR)&dpMegaflowStats,
+                                     sizeof dpMegaflowStats);
+    }
+    if (writeOk) {
+        writeOk = NlMsgPutTailU32(nlBuf, OVS_DP_ATTR_USER_FEATURES,
+                                  datapath->userFeatures);
     }
     nlMsg = (PNL_MSG_HDR)NlBufAt(nlBuf, 0, 0);
     nlMsg->nlmsgLen = NlBufSize(nlBuf);
@@ -1590,13 +1614,6 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                         dpAttrs, ARRAY_SIZE(dpAttrs))) {
             return STATUS_INVALID_PARAMETER;
         }
-
-        /*
-        * XXX: Not clear at this stage if there's any role for the
-        * OVS_DP_ATTR_UPCALL_PID and OVS_DP_ATTR_USER_FEATURES attributes passed
-        * from userspace.
-        */
-
     } else {
         RtlZeroMemory(dpAttrs, sizeof dpAttrs);
     }
@@ -1631,6 +1648,21 @@ HandleDpTransactionCommon(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     if (usrParamsCtx->ovsMsg->genlMsg.cmd == OVS_DP_CMD_NEW) {
         nlError = NL_ERROR_EXIST;
         goto cleanup;
+    }
+
+    /* Honour the OVS_DP_F_* handshake: store the requested feature mask after
+     * rejecting any bit ovsext does not implement, mirroring the Linux
+     * "request bit must come back set" contract.  Only OVS_DP_CMD_SET carries a
+     * meaningful request; the value is echoed back by OvsDpFillInfo. */
+    if (usrParamsCtx->ovsMsg->genlMsg.cmd == OVS_DP_CMD_SET &&
+        dpAttrs[OVS_DP_ATTR_USER_FEATURES] != NULL) {
+        UINT32 userFeatures = NlAttrGetU32(dpAttrs[OVS_DP_ATTR_USER_FEATURES]);
+
+        if (userFeatures & ~OVSEXT_SUPPORTED_DP_FEATURES) {
+            nlError = NL_ERROR_NOTSUPP;
+            goto cleanup;
+        }
+        switchContext->datapath.userFeatures = userFeatures;
     }
 
     status = OvsDpFillInfo(switchContext, msgIn, &nlBuf);

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -62,6 +62,9 @@ typedef struct _OVS_DATAPATH
    UINT64                  misses;          // Number of flow table misses.
    UINT64                  lost;            // Number of dropped misses.
 
+   /* OVS_DP_F_* feature mask negotiated with userspace. */
+   UINT32                  userFeatures;
+
    /* Used to protect the flows in the flowtable. */
    PNDIS_RW_LOCK_EX        lock;
 } OVS_DATAPATH, *POVS_DATAPATH;

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1088,6 +1088,9 @@ dpif_windows_register_all_switch_types(void)
     }
 }
 
+static int dpif_windows_set_features(struct dpif *dpif_,
+                                     uint32_t new_features);
+
 static int
 dpif_windows_open(const struct dpif_class *class, const char *name,
                   bool create, struct dpif **dpifp)
@@ -1159,6 +1162,14 @@ dpif_windows_open(const struct dpif_class *class, const char *name,
     dpif->channel.dp_ifindex = dp.dp_ifindex;
     ofpbuf_delete(buf);
 
+    /* The datapath is owned by the driver, so it is resolved with GET rather
+     * than created with NEW; the feature mask is therefore not carried on the
+     * open transaction.  Negotiate it now with an explicit SET.  Best-effort:
+     * an older kernel that does not echo the features leaves user_features 0,
+     * which is harmless (callers simply see the features as unsupported). */
+    dpif_windows_set_features(&dpif->dpif,
+                              OVS_DP_F_UNALIGNED | OVS_DP_F_VPORT_PIDS);
+
     *dpifp = &dpif->dpif;
     return 0;
 }
@@ -1223,6 +1234,43 @@ dpif_windows_get_stats(const struct dpif *dpif_, struct dpif_dp_stats *stats)
         ofpbuf_delete(buf);
     }
     return error;
+}
+
+/* Requests 'new_features' from the kernel via OVS_DP_CMD_SET, mirroring
+ * dpif_netlink_set_features().  The kernel echoes back the mask it accepted
+ * (rejecting any unsupported bit), which is cached in 'dpif->user_features';
+ * returns EOPNOTSUPP if a requested bit did not come back set. */
+static int
+dpif_windows_set_features(struct dpif *dpif_, uint32_t new_features)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct dpif_windows_dp request, reply;
+    struct ofpbuf *buf;
+    int error;
+
+    dpif_windows_dp_init(&request);
+    request.cmd = OVS_DP_CMD_SET;
+    request.name = OVS_WINDOWS_KERNEL_DP_NAME;
+    request.dp_ifindex = dpif->dp_ifindex;
+    request.user_features = dpif->user_features | new_features;
+
+    error = dpif_windows_dp_transact(dpif, &request, &reply, &buf);
+    if (!error) {
+        dpif->user_features = reply.user_features;
+        ofpbuf_delete(buf);
+        if (!(dpif->user_features & new_features)) {
+            return EOPNOTSUPP;
+        }
+    }
+    return error;
+}
+
+static uint32_t
+dpif_windows_get_features(struct dpif *dpif_)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+
+    return dpif->user_features;
 }
 
 static char *
@@ -2676,6 +2724,8 @@ const struct dpif_class dpif_windows_class = {
     .destroy = dpif_windows_destroy,
     .run = dpif_windows_run,
     .get_stats = dpif_windows_get_stats,
+    .set_features = dpif_windows_set_features,
+    .get_features = dpif_windows_get_features,
     .port_add = dpif_windows_port_add,
     .port_del = dpif_windows_port_del,
     .port_query_by_number = dpif_windows_port_query_by_number,

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1238,8 +1238,8 @@ dpif_windows_get_stats(const struct dpif *dpif_, struct dpif_dp_stats *stats)
 
 /* Requests 'new_features' from the kernel via OVS_DP_CMD_SET, mirroring
  * dpif_netlink_set_features().  The kernel echoes back the mask it accepted
- * returns EOPNOTSUPP if none of the requested bits came back set. */
- * returns EOPNOTSUPP if a requested bit did not come back set. */
+ * (rejecting any unsupported bit); the result is cached in dpif->user_features
+ * and EOPNOTSUPP is returned if none of the requested bits came back set. */
 static int
 dpif_windows_set_features(struct dpif *dpif_, uint32_t new_features)
 {

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -1238,7 +1238,7 @@ dpif_windows_get_stats(const struct dpif *dpif_, struct dpif_dp_stats *stats)
 
 /* Requests 'new_features' from the kernel via OVS_DP_CMD_SET, mirroring
  * dpif_netlink_set_features().  The kernel echoes back the mask it accepted
- * (rejecting any unsupported bit), which is cached in 'dpif->user_features';
+ * returns EOPNOTSUPP if none of the requested bits came back set. */
  * returns EOPNOTSUPP if a requested bit did not come back set. */
 static int
 dpif_windows_set_features(struct dpif *dpif_, uint32_t new_features)

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -143,6 +143,13 @@ struct mock_kernel {
     uint32_t meter_band_type;
     uint32_t meter_band_rate;
     uint32_t meter_band_burst;
+
+    /* OVS_DP_F_* handshake.  A SET request stores its (validated) feature mask
+     * here; when 'dp_echo_features' is set the DP reply carries USER_FEATURES
+     * and MEGAFLOW_STATS back (modelling the feature-aware kernel), otherwise it
+     * omits them (modelling an older kernel that never negotiates). */
+    uint32_t dp_user_features;
+    bool     dp_echo_features;
 };
 
 /* ---- record builders ----------------------------------------------------- */
@@ -480,6 +487,74 @@ mock_meter(struct mock_kernel *m, const void *in, DWORD in_len,
     return TRUE;
 }
 
+/* The datapath features the mock kernel honours, matching the ovsext
+ * OVSEXT_SUPPORTED_DP_FEATURES set. */
+#define MOCK_SUPPORTED_DP_FEATURES (OVS_DP_F_UNALIGNED | OVS_DP_F_VPORT_PIDS)
+
+/* Answers an OVS_DP_CMD_GET/SET transaction as OvsDpFillInfo +
+ * HandleDpTransactionCommon do: a SET validates the requested USER_FEATURES
+ * against the supported mask (rejecting unknown bits with EOPNOTSUPP) and
+ * stores it; every reply carries NAME + STATS, plus MEGAFLOW_STATS and the
+ * echoed USER_FEATURES when 'dp_echo_features' is set. */
+static BOOL
+mock_dp_transact(struct mock_kernel *m, const void *in, DWORD in_len,
+                 void *out, DWORD out_len, DWORD *bytes)
+{
+    const struct genlmsghdr *genl = ALIGNED_CAST(const struct genlmsghdr *,
+                                        (const char *) in + NLMSG_HDRLEN);
+    static const struct nl_policy pol[] = {
+        [OVS_DP_ATTR_NAME] = { .type = NL_A_STRING, .optional = true },
+        [OVS_DP_ATTR_UPCALL_PID] = { .type = NL_A_U32, .optional = true },
+        [OVS_DP_ATTR_USER_FEATURES] = { .type = NL_A_U32, .optional = true },
+    };
+    struct nlattr *attr[ARRAY_SIZE(pol)];
+    struct ofpbuf b = ofpbuf_const_initializer(in, in_len);
+    bool parsed = ofpbuf_try_pull(&b, NLMSG_HDRLEN)
+        && ofpbuf_try_pull(&b, GENL_HDRLEN)
+        && ofpbuf_try_pull(&b, sizeof(struct ovs_header))
+        && nl_policy_parse(&b, 0, pol, attr, ARRAY_SIZE(pol));
+
+    if (genl->cmd == OVS_DP_CMD_SET && parsed
+        && attr[OVS_DP_ATTR_USER_FEATURES]) {
+        uint32_t req = nl_attr_get_u32(attr[OVS_DP_ATTR_USER_FEATURES]);
+
+        if (req & ~MOCK_SUPPORTED_DP_FEATURES) {
+            return reply_nlmsgerr(EOPNOTSUPP, out, out_len, bytes);
+        }
+        m->dp_user_features = req;
+    }
+
+    uint64_t stub[1024 / 8];
+    struct ofpbuf r;
+    struct ovs_header *ovs_header;
+    struct ovs_dp_stats stats;
+    DWORD n;
+
+    ofpbuf_use_stub(&r, stub, sizeof stub);
+    nl_msg_put_genlmsghdr(&r, 0, OVS_WIN_NL_DATAPATH_FAMILY_ID, 0,
+                          OVS_DP_CMD_GET, OVS_DATAPATH_VERSION);
+    ovs_header = ofpbuf_put_uninit(&r, sizeof *ovs_header);
+    ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+    nl_msg_put_string(&r, OVS_DP_ATTR_NAME, "ovs-system");
+    memset(&stats, 0, sizeof stats);
+    nl_msg_put_unspec(&r, OVS_DP_ATTR_STATS, &stats, sizeof stats);
+    if (m->dp_echo_features) {
+        struct ovs_dp_megaflow_stats mf;
+
+        memset(&mf, 0, sizeof mf);
+        mf.n_masks = 1;
+        nl_msg_put_unspec(&r, OVS_DP_ATTR_MEGAFLOW_STATS, &mf, sizeof mf);
+        nl_msg_put_u32(&r, OVS_DP_ATTR_USER_FEATURES, m->dp_user_features);
+    }
+    nl_msg_nlmsghdr(&r)->nlmsg_len = r.size;
+
+    n = r.size < out_len ? (DWORD) r.size : out_len;
+    memcpy(out, r.data, n);
+    *bytes = n;
+    ofpbuf_uninit(&r);
+    return TRUE;
+}
+
 static BOOL
 mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
               void *out, DWORD out_len, DWORD *bytes)
@@ -517,7 +592,7 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
         return mock_meter(m, in, in_len, out, out_len, bytes);
 
     case OVS_WIN_NL_DATAPATH_FAMILY_ID:
-        return record_copy(&m->dp[0], out, out_len, bytes);
+        return mock_dp_transact(m, in, in_len, out, out_len, bytes);
 
     case OVS_WIN_NL_FLOW_FAMILY_ID:
         switch (m->flow_reply) {
@@ -739,6 +814,11 @@ mock_reset_content(struct mock_kernel *m)
     m->validate_dp_failed = false;
     m->flow_dump_done = false;
     m->flow_reply = FR_ACK;
+    /* Default to the feature-aware kernel: echo USER_FEATURES/MEGAFLOW_STATS so
+     * dpif_open()'s feature negotiation succeeds.  A SET clears this back to the
+     * negotiated value; tests that exercise the old-kernel path clear it. */
+    m->dp_echo_features = true;
+    m->dp_user_features = 0;
     /* Keep one datapath so dpif_open()'s resolve dump always succeeds. */
     m->n_dp = 1;
     build_dp_record(&m->dp[0]);
@@ -1508,6 +1588,43 @@ test_ct_limits(struct dpif *dpif, struct mock_kernel *m)
     CHECK(feat == 0);
 }
 
+/* Datapath feature negotiation: the open requested OVS_DP_F_UNALIGNED |
+ * OVS_DP_F_VPORT_PIDS, the kernel stored and echoed them, and
+ * get_features/get_stats reflect the negotiated mask.  An unsupported bit is
+ * rejected with EOPNOTSUPP, and a kernel that does not echo features falls back
+ * to the "no megaflow stats" sentinel. */
+static void
+test_feature_negotiation(struct dpif *dpif, struct mock_kernel *m)
+{
+    uint32_t want = OVS_DP_F_UNALIGNED | OVS_DP_F_VPORT_PIDS;
+    struct dpif_dp_stats stats;
+
+    mock_reset_content(m);
+
+    /* The request carries USER_FEATURES (proven by the kernel storing exactly
+     * the requested mask), the reply echoes it, and get_features returns the
+     * cached value. */
+    CHECK(dpif_set_features(dpif, want) == 0);
+    CHECK(m->dp_user_features == want);
+    CHECK(dpif_get_features(dpif) == want);
+
+    /* MEGAFLOW_STATS present -> get_stats reports the single implicit mask, not
+     * the UINT32_MAX "no megaflow stats" sentinel. */
+    CHECK(dpif_get_dp_stats(dpif, &stats) == 0);
+    CHECK(stats.n_masks == 1);
+
+    /* An unsupported bit is rejected and leaves the negotiated mask intact. */
+    CHECK(dpif_set_features(dpif, OVS_DP_F_TC_RECIRC_SHARING) == EOPNOTSUPP);
+    CHECK(dpif_get_features(dpif) == want);
+
+    /* Kernel without feature echo: set_features sees the bit never come back
+     * (EOPNOTSUPP) and get_stats falls back to the sentinel. */
+    m->dp_echo_features = false;
+    CHECK(dpif_set_features(dpif, want) == EOPNOTSUPP);
+    CHECK(dpif_get_dp_stats(dpif, &stats) == 0);
+    CHECK(stats.n_masks == UINT32_MAX);
+}
+
 /* OpenFlow meters round-trip through the OVS_METER genl family: features
  * advertises the kernel's limits, a single-band DROP meter is set (and the
  * request marshals id/rate/burst correctly), and get/del read back stats. */
@@ -1616,6 +1733,7 @@ main(int argc, char *argv[])
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);
     test_meters(dpif, &mock);
+    test_feature_negotiation(dpif, &mock);
 
     dpif_close(dpif);
     ovsext_set_transport(NULL);


### PR DESCRIPTION
The Windows datapath never participated in the OVS_DP_F_* user-feature handshake: the kernel parsed then discarded `OVS_DP_ATTR_USER_FEATURES` and never echoed `USER_FEATURES`/`MEGAFLOW_STATS`, so the provider's `get_features()` returned 0, `set_features()` was a no-op, and `get_dp_stats()` always reported the `UINT32_MAX` "no megaflow stats" sentinel.

This wires the handshake end to end:

- **Kernel** stores the requested feature mask on `OVS_DP_CMD_SET` (rejecting unsupported bits; only `OVS_DP_F_UNALIGNED` and `OVS_DP_F_VPORT_PIDS` are supported), echoes `USER_FEATURES` back, and reports a single implicit megaflow mask over its linear flow table.
- **Userspace** requests `OVS_DP_F_UNALIGNED | OVS_DP_F_VPORT_PIDS` on open via an explicit `OVS_DP_CMD_SET` (the datapath is resolved with GET, which carries no feature request) and gains `set_features`/`get_features`.

`ovs-dpctl show` now reports a real `masks:` line. Covered by a new `test-dpif-windows` case and verified on a live kernel datapath.