### PR TITLE
ovsext: load the forwarding extension on demand, not at boot

### DIFF
--- a/datapath-windows/ovsext/ovsext.inf
+++ b/datapath-windows/ovsext/ovsext.inf
@@ -82,7 +82,7 @@ AddService = DBO_OVSE,,OVS_Install_AddService
 [OVS_Install_AddService]
 DisplayName     = %DBO_OVSE_Desc%
 ServiceType     = 1 ;SERVICE_KERNEL_DRIVER
-StartType       = 1 ;SERVICE_SYSTEM_START
+StartType       = 3 ;SERVICE_DEMAND_START
 ErrorControl    = 1 ;SERVICE_ERROR_NORMAL
 ServiceBinary   = %13%\DBO_OVSE.sys
 LoadOrderGroup  = NDIS
@@ -97,7 +97,7 @@ AddService = DBO_OVSE,,OVS_Install_Fallback_AddService
 [OVS_Install_Fallback_AddService]
 DisplayName     = %DBO_OVSE_Desc%
 ServiceType     = 1 ;SERVICE_KERNEL_DRIVER
-StartType       = 1 ;SERVICE_SYSTEM_START
+StartType       = 3 ;SERVICE_DEMAND_START
 ErrorControl    = 1 ;SERVICE_ERROR_NORMAL
 ServiceBinary   = %12%\DBO_OVSE.sys
 LoadOrderGroup  = NDIS

--- a/datapath-windows/packaging/ovsext-dual.inf
+++ b/datapath-windows/packaging/ovsext-dual.inf
@@ -70,7 +70,7 @@ AddService = DBO_OVSE,,Svc_Modern
 [Svc_Modern]
 DisplayName    = %DBO_OVSE_Desc%
 ServiceType    = 1 ;SERVICE_KERNEL_DRIVER
-StartType      = 1 ;SERVICE_SYSTEM_START
+StartType      = 3 ;SERVICE_DEMAND_START
 ErrorControl   = 1 ;SERVICE_ERROR_NORMAL
 ServiceBinary  = %13%\DBO_OVSE.sys
 LoadOrderGroup = NDIS
@@ -95,7 +95,7 @@ AddService = DBO_OVSE,,Svc_Floor13
 [Svc_Floor13]
 DisplayName    = %DBO_OVSE_Desc%
 ServiceType    = 1
-StartType      = 1
+StartType      = 3 ;SERVICE_DEMAND_START
 ErrorControl   = 1
 ServiceBinary  = %13%\DBO_OVSE60.sys
 LoadOrderGroup = NDIS
@@ -120,7 +120,7 @@ AddService = DBO_OVSE,,Svc_Floor12
 [Svc_Floor12]
 DisplayName    = %DBO_OVSE_Desc%
 ServiceType    = 1
-StartType      = 1
+StartType      = 3 ;SERVICE_DEMAND_START
 ErrorControl   = 1
 ServiceBinary  = %12%\DBO_OVSE60.sys
 LoadOrderGroup = NDIS


### PR DESCRIPTION
The driver's INF service entries set `StartType=1` (SERVICE_SYSTEM_START), so DBO_OVSE loaded during kernel init on every boot, independent of whether any Hyper-V switch had the extension bound. An NDIS forwarding extension should instead load on demand when NDIS attaches it to a switch.

This sets `StartType=3` (SERVICE_DEMAND_START) in all service sections, matching upstream. The driver now loads at `FilterAttach` and unloads at `FilterDetach`: it is no longer resident when unused, and can be reloaded by disabling and re-enabling the extension without a reboot. It also keeps the heavy filter-driver unload from being driven by a service stop while a filter may still be attached.