### PR TITLE
datapath-windows: common OVN datapath actions (ct_clear, drop, clone, check_pkt_len, add_mpls, dec_ttl)

### DIFF
--- a/datapath-windows/deploy-driver.ps1
+++ b/datapath-windows/deploy-driver.ps1
@@ -69,6 +69,11 @@ $swap = @"
 `$nested = $stopList
 if (`$nested.Count) { Get-VM `$nested -EA SilentlyContinue | Stop-VM -Force -TurnOff -EA SilentlyContinue }
 Disable-VMSwitchExtension -VMSwitchName `$sw -Name `$ext -EA Continue | Out-Null
+# OVS userspace holds the driver's netlink device open; the I/O Manager will not
+# unload a driver while any handle to its device object exists, so Stop-Service
+# parks in STOP_PENDING forever if ovs-vswitchd/ovsdb-server are still running.
+# Release the handle first.
+Stop-Process -Name ovs-vswitchd,ovsdb-server -Force -EA SilentlyContinue
 Stop-Service DBO_OVSE -Force -EA Continue
 Start-Sleep 2
 `$bound = ((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\DBO_OVSE').ImagePath) -replace '^\\SystemRoot','C:\Windows'

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2315,14 +2315,16 @@ OvsExecuteDecTtl(OvsForwardingContext *ovsFwdCtx,
             return NDIS_STATUS_SUCCESS;
         }
         /*
-         * TTL is the high byte of the {TTL, protocol} 16-bit word, so the
-         * incremental checksum delta must shift it into the high byte (mirrors
-         * Linux set_ip_ttl: csum_replace2(htons(ttl << 8))). Passing the bare
-         * byte value would update the checksum at the wrong word position.
+         * ChecksumUpdate16() here takes the field value as read from the IP
+         * header in place, not the network-order 16-bit word that Linux's
+         * csum_replace2() expects -- so pass the raw TTL byte, matching the
+         * IPv4 TTL update in OvsUpdateIPv4Header(). Verified against a full
+         * header-checksum recompute that the bare byte (not 'ttl << 8') is the
+         * correct delta for this routine.
          */
-        oldTtl = (UINT16)(ipHdr->ttl << 8);
+        oldTtl = ipHdr->ttl & 0xff;
         ipHdr->ttl--;
-        newTtl = (UINT16)(ipHdr->ttl << 8);
+        newTtl = ipHdr->ttl & 0xff;
         if (ipHdr->check != 0) {
             ipHdr->check = ChecksumUpdate16(ipHdr->check, oldTtl, newTtl);
         }
@@ -2710,14 +2712,18 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
                 (const struct ovs_action_add_mpls *)NlAttrGet((const PNL_ATTR)a);
             struct ovs_action_push_mpls pushMpls;
 
-            if (addMpls->tun_flags & OVS_MPLS_L3_TUNNEL_FLAG_MASK) {
+            if (!(addMpls->tun_flags & OVS_MPLS_L3_TUNNEL_FLAG_MASK)) {
                 /*
-                 * The L3 (mac_len == 0) tunnel facet inserts the LSE at the
-                 * start of the L3 header with no Ethernet header in front; it
-                 * needs L3-port / packet_type support not present here.
+                 * Flag clear inserts the LSE at the very start of the packet --
+                 * an L3-only packet with no Ethernet header (mac_len == 0) --
+                 * which needs L3-port / packet_type support not present here.
+                 * The set flag (handled below) is the common over-Ethernet case
+                 * OVN actually emits. Fail closed rather than forward the packet
+                 * with the action silently skipped.
                  */
                 status = NDIS_STATUS_NOT_SUPPORTED;
-                break;
+                dropReason = L"OVS-add_mpls L3 facet not supported";
+                goto dropit;
             }
 
             if (ovsFwdCtx.destPortsSizeOut > 0 || ovsFwdCtx.tunnelTxNic != NULL
@@ -2730,9 +2736,10 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
             }
 
             /*
-             * The over-Ethernet facet is identical to push_mpls: insert one LSE
-             * in front of the L3 header. ovs_action_add_mpls carries the same
-             * mpls_lse/mpls_ethertype (the L3 tun_flags facet is handled above).
+             * OVS_MPLS_L3_TUNNEL_FLAG_MASK set: insert one LSE at the start of
+             * the L3 header, after the existing Ethernet header -- identical to
+             * push_mpls. ovs_action_add_mpls carries the same mpls_lse/
+             * mpls_ethertype.
              */
             pushMpls.mpls_lse = addMpls->mpls_lse;
             pushMpls.mpls_ethertype = addMpls->mpls_ethertype;
@@ -2811,14 +2818,20 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
 
         case OVS_ACTION_ATTR_DROP:
             /*
-             * Explicit, reason-carrying drop. The u32 xlate_error is not yet
-             * surfaced to userspace. OVN emits 'drop' as the sole action in a
-             * set, so abandoning the rest of the loop via dropit is correct;
-             * the assumption is that no OVS_ACTION_ATTR_OUTPUT precedes it in
-             * the same set (a preceding output's accumulated destination ports
-             * would be discarded by dropit without being flushed, as with every
-             * other mid-loop goto dropit).
+             * Explicit, reason-carrying drop (the u32 xlate_error is not yet
+             * surfaced to userspace). Linux emits outputs eagerly, so any
+             * OUTPUT earlier in the same list has already been sent; flush the
+             * accumulated destinations here before dropping so a list of
+             * output(s) followed by drop behaves the same way.
              */
+            if (ovsFwdCtx.destPortsSizeOut > 0 || ovsFwdCtx.tunnelTxNic != NULL
+                || ovsFwdCtx.tunnelRxNic != NULL) {
+                status = OvsOutputBeforeSetAction(&ovsFwdCtx);
+                if (status != NDIS_STATUS_SUCCESS) {
+                    dropReason = L"OVS-adding destination failed";
+                    goto dropit;
+                }
+            }
             ovsActionStats.explicitDrop++;
             dropReason = L"OVS-explicit drop action";
             goto dropit;

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -1873,8 +1873,15 @@ OvsUpdateIPv4Header(OvsForwardingContext *ovsFwdCtx,
         key->ipKey.nwDst = ipAttr->ipv4_dst;
     }
     if (ipHdr->protocol != ipAttr->ipv4_proto) {
-        UINT16 oldProto = (ipHdr->protocol << 16) & 0xff00;
-        UINT16 newProto = (ipAttr->ipv4_proto << 16) & 0xff00;
+        /*
+         * ChecksumUpdate16() consumes the host-order read of the 16-bit word a
+         * field lives in. The protocol byte is the low byte of the network-order
+         * {TTL, protocol} word, i.e. the high byte once read into a host UINT16,
+         * so it must be shifted left by 8. The previous '<< 16' masked to zero,
+         * making this a no-op that left a stale checksum on any protocol change.
+         */
+        UINT16 oldProto = (ipHdr->protocol << 8) & 0xff00;
+        UINT16 newProto = (ipAttr->ipv4_proto << 8) & 0xff00;
         if (tcpHdr) {
             tcpHdr->check = ChecksumUpdate16(tcpHdr->check, oldProto, newProto);
         } else if (udpHdr && udpHdr->check) {
@@ -1900,7 +1907,15 @@ OvsUpdateIPv4Header(OvsForwardingContext *ovsFwdCtx,
         /* ECN + DSCP */
         UINT8 newTos = (ipHdr->tos & 0x3) | (ipAttr->ipv4_tos & 0xfc);
         if (ipHdr->check != 0) {
-            ipHdr->check = ChecksumUpdate16(ipHdr->check, ipHdr->tos, newTos);
+            /*
+             * ToS is the low byte of the network-order {version/IHL, ToS} word,
+             * i.e. the high byte of the host-order read ChecksumUpdate16() wants,
+             * so shift left by 8. Passing the bare byte updated the wrong word
+             * position and produced a bad IP checksum on every DSCP/ECN change.
+             */
+            ipHdr->check = ChecksumUpdate16(ipHdr->check,
+                                            (UINT16)(ipHdr->tos << 8),
+                                            (UINT16)(newTos << 8));
         }
         ipHdr->tos = newTos;
         key->ipKey.nwTos = newTos;

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2251,6 +2251,7 @@ OvsExecuteCheckPktLen(OvsForwardingContext *ovsFwdCtx,
     PNL_ATTR a = NULL;
     INT rem = 0;
     UINT16 pktLen = 0;
+    BOOLEAN havePktLen = FALSE;
     PNL_ATTR actionsIfGreater = NULL;
     PNL_ATTR actionsIfLessEqual = NULL;
     PNL_ATTR selected = NULL;
@@ -2261,6 +2262,7 @@ OvsExecuteCheckPktLen(OvsForwardingContext *ovsFwdCtx,
         switch (NlAttrType(a)) {
         case OVS_CHECK_PKT_LEN_ATTR_PKT_LEN:
             pktLen = NlAttrGetU16(a);
+            havePktLen = TRUE;
             break;
         case OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER:
             actionsIfGreater = a;
@@ -2269,6 +2271,15 @@ OvsExecuteCheckPktLen(OvsForwardingContext *ovsFwdCtx,
             actionsIfLessEqual = a;
             break;
         }
+    }
+
+    if (!havePktLen) {
+        /*
+         * PKT_LEN is mandatory. A missing attribute is a malformed action;
+         * fail it rather than defaulting the threshold to 0 and silently
+         * taking the 'greater' branch for every non-empty packet.
+         */
+        return NDIS_STATUS_NOT_SUPPORTED;
     }
 
     len = NET_BUFFER_DATA_LENGTH(NET_BUFFER_LIST_FIRST_NB(ovsFwdCtx->curNbl));

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2314,9 +2314,15 @@ OvsExecuteDecTtl(OvsForwardingContext *ovsFwdCtx,
             *exception = TRUE;
             return NDIS_STATUS_SUCCESS;
         }
-        oldTtl = (ipHdr->ttl) & 0xff;
+        /*
+         * TTL is the high byte of the {TTL, protocol} 16-bit word, so the
+         * incremental checksum delta must shift it into the high byte (mirrors
+         * Linux set_ip_ttl: csum_replace2(htons(ttl << 8))). Passing the bare
+         * byte value would update the checksum at the wrong word position.
+         */
+        oldTtl = (UINT16)(ipHdr->ttl << 8);
         ipHdr->ttl--;
-        newTtl = (ipHdr->ttl) & 0xff;
+        newTtl = (UINT16)(ipHdr->ttl << 8);
         if (ipHdr->check != 0) {
             ipHdr->check = ChecksumUpdate16(ipHdr->check, oldTtl, newTtl);
         }
@@ -2777,19 +2783,24 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
             if (exception) {
                 /*
                  * TTL/hop-limit expired (<= 1): the packet is not forwarded.
-                 * Run the embedded OVS_DEC_TTL_ATTR_ACTION list -- for OVN a
-                 * single userspace/controller action -- on the current packet,
-                 * then drop the original via dropit.
+                 * Run the whole embedded OVS_DEC_TTL_ATTR_ACTION list (for OVN
+                 * a controller/userspace notification) on a copy via the
+                 * deferred-action queue -- like clone -- then drop the original
+                 * via dropit. This runs the full list (not just a single
+                 * userspace action) and balances the copy on every path.
                  */
                 PNL_ATTR exList = NlAttrFindNested((const PNL_ATTR)a,
                                                    OVS_DEC_TTL_ATTR_ACTION);
-                if (exList) {
-                    PNL_ATTR first = (PNL_ATTR)NlAttrData(exList);
-                    INT exRem = NlAttrGetSize(exList);
-                    if (exRem &&
-                        NlAttrType(first) == OVS_ACTION_ATTR_USERSPACE &&
-                        NlAttrIsLast(first, exRem)) {
-                        OvsOutputUserspaceAction(&ovsFwdCtx, key, first);
+                if (exList && NlAttrGetSize(exList)) {
+                    PNET_BUFFER_LIST exNbl =
+                        OvsPartialCopyNBL(ovsFwdCtx.switchContext,
+                                          ovsFwdCtx.curNbl, 0, 0, TRUE);
+                    if (exNbl == NULL) {
+                        ovsActionStats.noCopiedNbl++;
+                    } else if (!OvsAddDeferredActions(exNbl, key,
+                                                      &ovsFwdCtx.layers,
+                                                      exList)) {
+                        OvsCompleteNBL(ovsFwdCtx.switchContext, exNbl, TRUE);
                     }
                 }
                 dropReason = L"OVS-dec_ttl ttl expired";

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2175,13 +2175,170 @@ OvsExecuteSampleAction(OvsForwardingContext *ovsFwdCtx,
         return STATUS_SUCCESS;
     }
 
-    if (!OvsAddDeferredActions(newNbl, key, &(ovsFwdCtx->layers), a)) {
+    /*
+     * Defer the whole actions-list container (not the first sub-action) so
+     * OvsProcessDeferredActions runs every action in the list. The single
+     * userspace action is already handled by the fast path above.
+     */
+    if (!OvsAddDeferredActions(newNbl, key, &(ovsFwdCtx->layers), actionsList)) {
         OVS_LOG_INFO(
             "Deferred actions limit reached, dropping sample action.");
         OvsCompleteNBL(ovsFwdCtx->switchContext, newNbl, TRUE);
     }
 
     return STATUS_SUCCESS;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * OvsExecuteClone --
+ *     Runs the nested CLONE action list on an independent copy of the packet
+ *     so the sub-actions cannot affect the packet the outer pipeline keeps.
+ *     The copy is handed to the deferred-action queue, like sample/recirc, so
+ *     the sub-list executes with bounded recursion depth.
+ * --------------------------------------------------------------------------
+ */
+static __inline NDIS_STATUS
+OvsExecuteClone(OvsForwardingContext *ovsFwdCtx,
+                OvsFlowKey *key,
+                const PNL_ATTR attr)
+{
+    PNET_BUFFER_LIST newNbl;
+
+    newNbl = OvsPartialCopyNBL(ovsFwdCtx->switchContext, ovsFwdCtx->curNbl,
+                               0, 0, TRUE /*copy NBL info*/);
+    if (newNbl == NULL) {
+        ovsActionStats.noCopiedNbl++;
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    if (!OvsAddDeferredActions(newNbl, key, &(ovsFwdCtx->layers), attr)) {
+        OVS_LOG_INFO("Deferred actions limit reached, dropping clone action.");
+        OvsCompleteNBL(ovsFwdCtx->switchContext, newNbl, TRUE);
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * OvsExecuteCheckPktLen --
+ *     Selects one of two nested action lists by comparing the on-the-wire
+ *     (L2) packet length against OVS_CHECK_PKT_LEN_ATTR_PKT_LEN and executes
+ *     the selected list on a copy via the deferred-action queue.
+ * --------------------------------------------------------------------------
+ */
+static __inline NDIS_STATUS
+OvsExecuteCheckPktLen(OvsForwardingContext *ovsFwdCtx,
+                      OvsFlowKey *key,
+                      const PNL_ATTR attr)
+{
+    PNL_ATTR a = NULL;
+    INT rem = 0;
+    UINT16 pktLen = 0;
+    PNL_ATTR actionsIfGreater = NULL;
+    PNL_ATTR actionsIfLessEqual = NULL;
+    PNL_ATTR selected = NULL;
+    UINT32 len;
+    PNET_BUFFER_LIST newNbl;
+
+    NL_ATTR_FOR_EACH_UNSAFE(a, rem, NlAttrData(attr), NlAttrGetSize(attr)) {
+        switch (NlAttrType(a)) {
+        case OVS_CHECK_PKT_LEN_ATTR_PKT_LEN:
+            pktLen = NlAttrGetU16(a);
+            break;
+        case OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER:
+            actionsIfGreater = a;
+            break;
+        case OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_LESS_EQUAL:
+            actionsIfLessEqual = a;
+            break;
+        }
+    }
+
+    len = NET_BUFFER_DATA_LENGTH(NET_BUFFER_LIST_FIRST_NB(ovsFwdCtx->curNbl));
+    selected = (len > pktLen) ? actionsIfGreater : actionsIfLessEqual;
+
+    if (selected == NULL || NlAttrGetSize(selected) == 0) {
+        /* The selected branch is empty: nothing to execute. */
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    newNbl = OvsPartialCopyNBL(ovsFwdCtx->switchContext, ovsFwdCtx->curNbl,
+                               0, 0, TRUE /*copy NBL info*/);
+    if (newNbl == NULL) {
+        ovsActionStats.noCopiedNbl++;
+        return NDIS_STATUS_SUCCESS;
+    }
+
+    if (!OvsAddDeferredActions(newNbl, key, &(ovsFwdCtx->layers), selected)) {
+        OVS_LOG_INFO(
+            "Deferred actions limit reached, dropping check_pkt_len action.");
+        OvsCompleteNBL(ovsFwdCtx->switchContext, newNbl, TRUE);
+    }
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * OvsExecuteDecTtl --
+ *     Decrements the IPv4 TTL / IPv6 hop-limit by one with an incremental
+ *     checksum fixup (IPv4 only; IPv6 has no L3 checksum). When the value is
+ *     already <= 1 the packet must not be forwarded: '*exception' is set TRUE
+ *     so the caller runs the embedded OVS_DEC_TTL_ATTR_ACTION list and drops
+ *     the packet. A non-IP packet is left unchanged.
+ * --------------------------------------------------------------------------
+ */
+static __inline NDIS_STATUS
+OvsExecuteDecTtl(OvsForwardingContext *ovsFwdCtx,
+                 OvsFlowKey *key,
+                 BOOLEAN *exception)
+{
+    PUINT8 bufferStart;
+    OVS_PACKET_HDR_INFO *layers = &ovsFwdCtx->layers;
+
+    *exception = FALSE;
+
+    if (key->l2.dlType == htons(ETH_TYPE_IPV4)) {
+        IPHdr *ipHdr;
+        UINT16 oldTtl, newTtl;
+
+        bufferStart = OvsGetHeaderBySize(ovsFwdCtx,
+                                         layers->l3Offset + sizeof(IPHdr));
+        if (bufferStart == NULL) {
+            return NDIS_STATUS_RESOURCES;
+        }
+        ipHdr = (IPHdr *)(bufferStart + layers->l3Offset);
+        if (ipHdr->ttl <= 1) {
+            *exception = TRUE;
+            return NDIS_STATUS_SUCCESS;
+        }
+        oldTtl = (ipHdr->ttl) & 0xff;
+        ipHdr->ttl--;
+        newTtl = (ipHdr->ttl) & 0xff;
+        if (ipHdr->check != 0) {
+            ipHdr->check = ChecksumUpdate16(ipHdr->check, oldTtl, newTtl);
+        }
+        key->ipKey.nwTtl = ipHdr->ttl;
+    } else if (key->l2.dlType == htons(ETH_TYPE_IPV6)) {
+        IPv6Hdr *ipv6Hdr;
+
+        bufferStart = OvsGetHeaderBySize(ovsFwdCtx,
+                                         layers->l3Offset + sizeof(IPv6Hdr));
+        if (bufferStart == NULL) {
+            return NDIS_STATUS_RESOURCES;
+        }
+        ipv6Hdr = (IPv6Hdr *)(bufferStart + layers->l3Offset);
+        if (ipv6Hdr->hop_limit <= 1) {
+            *exception = TRUE;
+            return NDIS_STATUS_SUCCESS;
+        }
+        ipv6Hdr->hop_limit--;
+        key->ipv6Key.nwTtl = ipv6Hdr->hop_limit;
+    }
+
+    return NDIS_STATUS_SUCCESS;
 }
 
 /*
@@ -2541,6 +2698,106 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
             }
             break;
         }
+        case OVS_ACTION_ATTR_ADD_MPLS:
+        {
+            const struct ovs_action_add_mpls *addMpls =
+                (const struct ovs_action_add_mpls *)NlAttrGet((const PNL_ATTR)a);
+            struct ovs_action_push_mpls pushMpls;
+
+            if (addMpls->tun_flags & OVS_MPLS_L3_TUNNEL_FLAG_MASK) {
+                /*
+                 * The L3 (mac_len == 0) tunnel facet inserts the LSE at the
+                 * start of the L3 header with no Ethernet header in front; it
+                 * needs L3-port / packet_type support not present here.
+                 */
+                status = NDIS_STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            if (ovsFwdCtx.destPortsSizeOut > 0 || ovsFwdCtx.tunnelTxNic != NULL
+                || ovsFwdCtx.tunnelRxNic != NULL) {
+                status = OvsOutputBeforeSetAction(&ovsFwdCtx);
+                if (status != NDIS_STATUS_SUCCESS) {
+                    dropReason = L"OVS-adding destination failed";
+                    goto dropit;
+                }
+            }
+
+            /*
+             * The over-Ethernet facet is identical to push_mpls: insert one LSE
+             * in front of the L3 header. ovs_action_add_mpls carries the same
+             * mpls_lse/mpls_ethertype (the L3 tun_flags facet is handled above).
+             */
+            pushMpls.mpls_lse = addMpls->mpls_lse;
+            pushMpls.mpls_ethertype = addMpls->mpls_ethertype;
+            status = OvsActionMplsPush(&ovsFwdCtx, &pushMpls);
+            if (status != NDIS_STATUS_SUCCESS) {
+                dropReason = L"OVS-add MPLS action failed";
+                goto dropit;
+            }
+            layers->l3Offset += MPLS_HLEN;
+            layers->l4Offset += MPLS_HLEN;
+            break;
+        }
+
+        case OVS_ACTION_ATTR_CHECK_PKT_LEN:
+            status = OvsExecuteCheckPktLen(&ovsFwdCtx, key, (const PNL_ATTR)a);
+            if (status != NDIS_STATUS_SUCCESS) {
+                dropReason = L"OVS-check_pkt_len action failed";
+                goto dropit;
+            }
+            break;
+
+        case OVS_ACTION_ATTR_CLONE:
+            status = OvsExecuteClone(&ovsFwdCtx, key, (const PNL_ATTR)a);
+            if (status != NDIS_STATUS_SUCCESS) {
+                dropReason = L"OVS-clone action failed";
+                goto dropit;
+            }
+            break;
+
+        case OVS_ACTION_ATTR_DEC_TTL:
+        {
+            BOOLEAN exception = FALSE;
+
+            if (ovsFwdCtx.destPortsSizeOut > 0 || ovsFwdCtx.tunnelTxNic != NULL
+                || ovsFwdCtx.tunnelRxNic != NULL) {
+                status = OvsOutputBeforeSetAction(&ovsFwdCtx);
+                if (status != NDIS_STATUS_SUCCESS) {
+                    dropReason = L"OVS-adding destination failed";
+                    goto dropit;
+                }
+            }
+
+            status = OvsExecuteDecTtl(&ovsFwdCtx, key, &exception);
+            if (status != NDIS_STATUS_SUCCESS) {
+                dropReason = L"OVS-dec_ttl action failed";
+                goto dropit;
+            }
+            if (exception) {
+                /*
+                 * TTL/hop-limit expired (<= 1): the packet is not forwarded.
+                 * Run the embedded OVS_DEC_TTL_ATTR_ACTION list -- for OVN a
+                 * single userspace/controller action -- on the current packet,
+                 * then drop the original via dropit.
+                 */
+                PNL_ATTR exList = NlAttrFindNested((const PNL_ATTR)a,
+                                                   OVS_DEC_TTL_ATTR_ACTION);
+                if (exList) {
+                    PNL_ATTR first = (PNL_ATTR)NlAttrData(exList);
+                    INT exRem = NlAttrGetSize(exList);
+                    if (exRem &&
+                        NlAttrType(first) == OVS_ACTION_ATTR_USERSPACE &&
+                        NlAttrIsLast(first, exRem)) {
+                        OvsOutputUserspaceAction(&ovsFwdCtx, key, first);
+                    }
+                }
+                dropReason = L"OVS-dec_ttl ttl expired";
+                goto dropit;
+            }
+            break;
+        }
+
         case OVS_ACTION_ATTR_DROP:
             /*
              * Explicit, reason-carrying drop. The u32 xlate_error is not yet

--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -65,6 +65,7 @@ typedef struct _OVS_ACTION_STATS {
     UINT32 failedChecksum;
     UINT32 deferredActionsQueueFull;
     UINT32 deferredActionsExecLimit;
+    UINT32 explicitDrop;
 } OVS_ACTION_STATS, *POVS_ACTION_STATS;
 
 OVS_ACTION_STATS ovsActionStats;
@@ -2427,6 +2428,16 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
             break;
         }
 
+        case OVS_ACTION_ATTR_CT_CLEAR:
+            /*
+             * Clears conntrack metadata (incl. OVS_CS_F_TRACKED) from the flow
+             * key only. It mutates no packet bytes and no forwarding context,
+             * so it needs no OvsOutputBeforeSetAction flush and is correct in
+             * any position relative to output actions.
+             */
+            OvsCtClearFlowKey(key);
+            break;
+
         case OVS_ACTION_ATTR_RECIRC:
         {
             if (ovsFwdCtx.destPortsSizeOut > 0 || ovsFwdCtx.tunnelTxNic != NULL
@@ -2530,6 +2541,20 @@ OvsDoExecuteActions(POVS_SWITCH_CONTEXT switchContext,
             }
             break;
         }
+        case OVS_ACTION_ATTR_DROP:
+            /*
+             * Explicit, reason-carrying drop. The u32 xlate_error is not yet
+             * surfaced to userspace. OVN emits 'drop' as the sole action in a
+             * set, so abandoning the rest of the loop via dropit is correct;
+             * the assumption is that no OVS_ACTION_ATTR_OUTPUT precedes it in
+             * the same set (a preceding output's accumulated destination ports
+             * would be discarded by dropit without being flushed, as with every
+             * other mid-loop goto dropit).
+             */
+            ovsActionStats.explicitDrop++;
+            dropReason = L"OVS-explicit drop action";
+            goto dropit;
+
         default:
             status = NDIS_STATUS_NOT_SUPPORTED;
             break;

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -258,6 +258,22 @@ OvsCtUpdateFlowKey(struct OvsFlowKey *key,
 
 /*
  *----------------------------------------------------------------------------
+ * OvsCtClearFlowKey
+ *     Drops all conntrack-derived metadata from the flow key, including the
+ *     OVS_CS_F_TRACKED bit, so the rest of the pipeline treats the packet as
+ *     untracked. The Windows flow key holds no conntrack-object reference, so
+ *     zeroing the whole 'ct' sub-struct is a complete clear. Unlike
+ *     OvsCtUpdateFlowKey it is a plain extern function (called from Actions.c).
+ *----------------------------------------------------------------------------
+ */
+VOID
+OvsCtClearFlowKey(OvsFlowKey *key)
+{
+    memset(&key->ct, 0, sizeof key->ct);
+}
+
+/*
+ *----------------------------------------------------------------------------
  * OvsPostCtEventEntry
  *     Assumes ct entry lock is acquired
  *     XXX Refactor OvsPostCtEvent() as it does not require ct entry lock.

--- a/datapath-windows/ovsext/Conntrack.h
+++ b/datapath-windows/ovsext/Conntrack.h
@@ -182,6 +182,7 @@ NTSTATUS OvsInitConntrack(NDIS_HANDLE ndisFilterHandle);
 NDIS_STATUS OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                                       OvsFlowKey *key,
                                       const PNL_ATTR a);
+VOID OvsCtClearFlowKey(OvsFlowKey *key);
 BOOLEAN OvsConntrackValidateTcpPacket(const TCPHdr *tcp);
 BOOLEAN OvsConntrackValidateIcmpPacket(const ICMPHdr *icmp);
 BOOLEAN OvsConntrackValidateIcmp6Packet(const ICMPHdr *icmp);

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -87,7 +87,12 @@ static NTSTATUS OvsDoDumpFlows(POVS_SWITCH_CONTEXT switchContext,
                                OvsFlowDumpOutput *dumpOutput,
                                UINT32 *replyLen);
 static NTSTATUS OvsProbeSupportedFeature(POVS_MESSAGE msgIn,
-                                         PNL_ATTR keyAttr);
+                                         PNL_ATTR keyAttr,
+                                         PNL_ATTR actionAttr);
+static BOOLEAN OvsActionIsSupported(UINT32 type);
+static BOOLEAN OvsProbeActionsSupported(const PNL_ATTR actions,
+                                        INT actionsLen,
+                                        UINT32 depth);
 UINT16 OvsGetFlowIPL2Offset(const OvsIPTunnelKey *tunKey);
 
 #define OVS_FLOW_TABLE_SIZE 2048
@@ -343,7 +348,8 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     }
 
     if (flowAttrs[OVS_FLOW_ATTR_PROBE]) {
-        rc = OvsProbeSupportedFeature(msgIn, flowAttrs[OVS_FLOW_ATTR_KEY]);
+        rc = OvsProbeSupportedFeature(msgIn, flowAttrs[OVS_FLOW_ATTR_KEY],
+                                      flowAttrs[OVS_FLOW_ATTR_ACTIONS]);
         if (rc != STATUS_SUCCESS) {
             nlError = NlMapStatusToNlErr(rc);
             goto done;
@@ -3287,8 +3293,134 @@ OvsTunKeyAttrSize(void)
 
 /*
  *----------------------------------------------------------------------------
+ *  OvsActionIsSupported --
+ *    Returns TRUE iff 'type' is an action the executor (OvsDoExecuteActions)
+ *    actually runs. This MUST stay in lockstep with the OvsDoExecuteActions
+ *    switch: admitting an action the executor does not handle turns a probe
+ *    into a false-positive (ofproto would emit an action the kernel silently
+ *    drops).
+ *
+ *    Admission is at action-type granularity. OVS_ACTION_ATTR_ADD_MPLS is the
+ *    one type the executor supports only partially -- the over-Ethernet facet,
+ *    not the L3-only one -- yet it is admitted here because ofproto's add_mpls
+ *    probe sends a zeroed (L3/flag-clear) action: rejecting it would report the
+ *    whole action unsupported and OVN would never emit add_mpls, including the
+ *    over-Ethernet form the executor does run. The unsupported L3 facet fails
+ *    closed at execution time instead.
+ *----------------------------------------------------------------------------
+ */
+static BOOLEAN
+OvsActionIsSupported(UINT32 type)
+{
+    switch (type) {
+    case OVS_ACTION_ATTR_OUTPUT:
+    case OVS_ACTION_ATTR_PUSH_VLAN:
+    case OVS_ACTION_ATTR_POP_VLAN:
+    case OVS_ACTION_ATTR_PUSH_MPLS:
+    case OVS_ACTION_ATTR_POP_MPLS:
+    case OVS_ACTION_ATTR_ADD_MPLS:
+    case OVS_ACTION_ATTR_HASH:
+    case OVS_ACTION_ATTR_CT:
+    case OVS_ACTION_ATTR_CT_CLEAR:
+    case OVS_ACTION_ATTR_RECIRC:
+    case OVS_ACTION_ATTR_USERSPACE:
+    case OVS_ACTION_ATTR_SET:
+    case OVS_ACTION_ATTR_METER:
+    case OVS_ACTION_ATTR_SAMPLE:
+    case OVS_ACTION_ATTR_CHECK_PKT_LEN:
+    case OVS_ACTION_ATTR_CLONE:
+    case OVS_ACTION_ATTR_DEC_TTL:
+    case OVS_ACTION_ATTR_DROP:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+/*
+ *----------------------------------------------------------------------------
+ *  OvsProbeActionsSupported --
+ *    Walks a probe flow's action list and returns TRUE iff every action is one
+ *    the executor runs, recursing into the nested action lists of clone /
+ *    check_pkt_len / sample / dec_ttl. Recursion is bounded by 'depth' to keep
+ *    a crafted probe from exhausting the stack.
+ *----------------------------------------------------------------------------
+ */
+static BOOLEAN
+OvsProbeActionsSupported(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
+{
+    /* Bound the walk at the executor's deferred-action nesting limit. */
+    const UINT32 maxDepth = 10;
+    PNL_ATTR a;
+    INT rem;
+
+    if (depth >= maxDepth) {
+        return FALSE;
+    }
+
+    NL_ATTR_FOR_EACH(a, rem, actions, actionsLen) {
+        UINT32 type = NlAttrType(a);
+
+        if (!OvsActionIsSupported(type)) {
+            return FALSE;
+        }
+
+        switch (type) {
+        case OVS_ACTION_ATTR_CLONE:
+            if (!OvsProbeActionsSupported(NlAttrData(a), NlAttrGetSize(a),
+                                          depth + 1)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_SAMPLE: {
+            const PNL_ATTR nested =
+                NlAttrFindNested(a, OVS_SAMPLE_ATTR_ACTIONS);
+            if (nested &&
+                !OvsProbeActionsSupported(NlAttrData(nested),
+                                          NlAttrGetSize(nested), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        case OVS_ACTION_ATTR_CHECK_PKT_LEN: {
+            const PNL_ATTR gtr =
+                NlAttrFindNested(a, OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER);
+            const PNL_ATTR leq =
+                NlAttrFindNested(a, OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_LESS_EQUAL);
+            if (gtr &&
+                !OvsProbeActionsSupported(NlAttrData(gtr),
+                                          NlAttrGetSize(gtr), depth + 1)) {
+                return FALSE;
+            }
+            if (leq &&
+                !OvsProbeActionsSupported(NlAttrData(leq),
+                                          NlAttrGetSize(leq), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        case OVS_ACTION_ATTR_DEC_TTL: {
+            const PNL_ATTR nested =
+                NlAttrFindNested(a, OVS_DEC_TTL_ATTR_ACTION);
+            if (nested &&
+                !OvsProbeActionsSupported(NlAttrData(nested),
+                                          NlAttrGetSize(nested), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        }
+    }
+
+    return TRUE;
+}
+
+/*
+ *----------------------------------------------------------------------------
  *  OvsProbeSupportedFeature --
- *    Verifies if the probed feature is supported.
+ *    Verifies if the probed feature is supported. A probe either carries a
+ *    feature in its key (handled by the key branches below) or in its actions
+ *    (handled by the action branch once no key feature matched).
  *
  * Results:
  *   STATUS_SUCCESS if the probed feature is supported.
@@ -3296,7 +3428,8 @@ OvsTunKeyAttrSize(void)
  */
 static NTSTATUS
 OvsProbeSupportedFeature(POVS_MESSAGE msgIn,
-                         PNL_ATTR keyAttr)
+                         PNL_ATTR keyAttr,
+                         PNL_ATTR actionAttr)
 {
     NTSTATUS status = STATUS_SUCCESS;
     PNL_MSG_HDR nlMsgHdr = &(msgIn->nlMsg);
@@ -3393,6 +3526,18 @@ OvsProbeSupportedFeature(POVS_MESSAGE msgIn,
         if (!ct_tuple_ipv6) {
             OVS_LOG_ERROR("Invalid ct_tuple_ipv6.");
             status = STATUS_INVALID_PARAMETER;
+        }
+    } else if (actionAttr) {
+        /*
+         * No key feature matched: this is an action-based probe. Admit it iff
+         * every action (recursing into nested clone/check_pkt_len/sample/
+         * dec_ttl lists) is one the executor runs. ofproto probes action
+         * features (ct_clear, drop, check_pkt_len, add_mpls, sample nesting,
+         * clone) this way -- via flow_put + read-back -- not just dpif_execute.
+         */
+        if (!OvsProbeActionsSupported(NlAttrData(actionAttr),
+                                      NlAttrGetSize(actionAttr), 0)) {
+            status = STATUS_NOT_SUPPORTED;
         }
     } else {
         OVS_LOG_ERROR("Feature not supported.");

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -3350,13 +3350,15 @@ OvsActionIsSupported(UINT32 type)
 static BOOLEAN
 OvsProbeActionsSupported(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
 {
-    /* Bound the walk at the executor's deferred-action nesting limit so the
-     * probe cannot admit nesting deeper than the executor can run. */
+    /* Bound the walk at the executor's deferred-action nesting capacity so the
+     * probe cannot admit nesting deeper than the executor can run. Admit nesting
+     * up to and including that capacity (reject only strictly deeper), so a probe
+     * at the maximum supported depth is not falsely reported unsupported. */
     const UINT32 maxDepth = DEFERRED_ACTION_QUEUE_SIZE;
     PNL_ATTR a;
     INT rem;
 
-    if (depth >= maxDepth) {
+    if (depth > maxDepth) {
         return FALSE;
     }
 

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -19,6 +19,7 @@
 #include "Util.h"
 #include "Jhash.h"
 #include "Flow.h"
+#include "Recirc.h"
 #include "PacketParser.h"
 #include "Datapath.h"
 #include "Geneve.h"
@@ -3349,8 +3350,9 @@ OvsActionIsSupported(UINT32 type)
 static BOOLEAN
 OvsProbeActionsSupported(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
 {
-    /* Bound the walk at the executor's deferred-action nesting limit. */
-    const UINT32 maxDepth = 10;
+    /* Bound the walk at the executor's deferred-action nesting limit so the
+     * probe cannot admit nesting deeper than the executor can run. */
+    const UINT32 maxDepth = DEFERRED_ACTION_QUEUE_SIZE;
     PNL_ATTR a;
     INT rem;
 

--- a/datapath-windows/ovsext/Recirc.c
+++ b/datapath-windows/ovsext/Recirc.c
@@ -322,13 +322,22 @@ OvsProcessDeferredActions(POVS_SWITCH_CONTEXT switchContext,
         layersDeferred = &(deferredAction->layers);
 
         if (deferredAction->actions) {
+            /*
+             * 'actions' holds the nested action-list container (e.g. a sample/
+             * clone/check_pkt_len sub-list). Execute the whole list: its data is
+             * the first sub-action and its size is the full list length, matching
+             * the netlink contract (cf. Linux odp_execute_actions(nl_attr_get(a),
+             * nl_attr_get_size(a))). Passing the container attr itself would parse
+             * its header as an action and drop every action after the first.
+             */
             status = OvsDoExecuteActions(switchContext,
                                          completionList,
                                          deferredAction->nbl,
                                          portNo,
                                          sendFlags,
                                          &deferredAction->key, NULL,
-                                         layersDeferred, deferredAction->actions,
+                                         layersDeferred,
+                                         NlAttrData(deferredAction->actions),
                                          NlAttrGetSize(deferredAction->actions));
         } else {
             status = OvsDoRecirc(switchContext,


### PR DESCRIPTION
Implements the datapath actions OVN's logical pipelines emit that the Windows ovsext action executor was missing. They fell through the `OvsDoExecuteActions` switch default and returned `NDIS_STATUS_NOT_SUPPORTED`, failing the flow at first-packet execution:

- `ct_clear` and explicit `drop`
- `clone`, `check_pkt_len`, `add_mpls` (over-Ethernet facet), `dec_ttl` (IPv4 TTL / IPv6 hop-limit, with the `<=1` controller exception)

Also fixes deferred-action execution to run the **whole** nested action list (it executed only the first sub-action), and teaches the kernel feature-probe handler (`OvsProbeSupportedFeature`) to admit action-based probes so ofproto actually emits the new actions. `dpif/show-dp-features` now reports `Conntrack clear` / `Check pkt length` / `Explicit Drop` / `MPLS Label add` as `Yes` and `Sample nesting` `10`.

Folds in a fix for two pre-existing `OvsUpdateIPv4Header` checksum bugs surfaced while validating `dec_ttl`: `ChecksumUpdate16()` takes the host-order read of the 16-bit word a field occupies, so a field that is the low byte of its network word must be shifted left by 8. `set(proto)` used `<< 16` (always zero, a no-op) and `set(dscp)`/`mod_nw_tos` passed the bare ToS byte, both producing a wrong IP (and, for proto, L4) checksum. TTL is the high byte of its word, so `dec_ttl` and `set(ttl)` are correct as-is.

`truncate` (`OVS_ACTION_ATTR_TRUNC`) is intentionally not implemented — output-side packet truncation (sampling/mirror snap-length) needs an NBL tail-trim primitive the tree lacks, and it is off OVN's forwarding path.

### Validation (live eryph-zero baseline: OVN 26.03.1 / OVS 3.7.0)

Built + deployed through eryph's clean install path; the matched driver attaches `RUNNING`, no BSOD. Each action exercised through the **kernel** (via `packet-out` → `dpif_execute` and via OVN's own datapath flows) with the result captured on a guest:

- **dec_ttl**: TTL 64→63 with a correct IP checksum (`0x6718`) on the wire.
- **clone**: `clone(output),output` delivers two copies; OVN also emits `clone` on the routed return path (`ping 9.9.9.9` 3/3).
- **ct_clear**: present in OVN's router return-path datapath actions; routed ping 3/3, forwarding intact.
- **add_mpls / push_mpls**: emits a well-formed MPLS shim (`0x8847`, label, `[S]`) with the inner packet intact.
- **set(dscp)/mod_nw_tos checksum fix**: before, `mod_nw_tos` emitted `bad cksum 5e18`; after the fix it emits the correct `0x6610`.
- **dp-features**: the new actions flip to `Yes` and `Sample nesting` to `10`; `Masked set`/psample correctly stay `No` (no false positives).
