### PR TITLE
datapath-windows: support UFID-based flow delete

### DIFF
--- a/datapath-windows/ovsext/DpInternal.h
+++ b/datapath-windows/ovsext/DpInternal.h
@@ -288,6 +288,8 @@ typedef struct OvsFlowPut {
     OvsFlowKey key;
     uint32_t flags;
     PNL_ATTR  actions;
+    ovs_u128  ufid;
+    BOOLEAN   ufidPresent;
 } OvsFlowPut;
 
 #define OVS_MIN_PACKET_SIZE 60

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -373,10 +373,21 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         !flowAttrs[OVS_FLOW_ATTR_KEY] &&
         flowAttrs[OVS_FLOW_ATTR_UFID]) {
 
-        OVS_DATAPATH *datapath = &usrParamsCtx->switchContext->datapath;
+        POVS_SWITCH_CONTEXT switchContext = usrParamsCtx->switchContext;
+        OVS_DATAPATH *datapath;
         OvsFlow *flow;
         LOCK_STATE_EX dpLockState;
         ovs_u128 ufid;
+
+        /* Validate the target datapath against this switch, like the key-based
+         * paths (OvsPutFlowIoctl etc.) do, before touching any flow -- a request
+         * for another datapath must not delete from this one. */
+        if (switchContext == NULL ||
+            switchContext->dpNo != (UINT32)ovsHdr->dp_ifindex) {
+            rc = STATUS_INVALID_PARAMETER;
+            goto done;
+        }
+        datapath = &switchContext->datapath;
 
         RtlCopyMemory(&ufid, NlAttrGet(flowAttrs[OVS_FLOW_ATTR_UFID]),
                       sizeof(ufid));

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -314,8 +314,8 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         goto done;
     }
 
-    /* FLOW_DEL command w/o any key input is a flush case.
-       If we don't have any attr, we treat this as a flush command*/
+    /* A FLOW_DEL with no attributes at all is a flush. A DEL carrying only a
+       UFID (no key) is a targeted delete, handled further below. */
     if ((genlMsgHdr->cmd == OVS_FLOW_CMD_DEL) &&
         (!NlMsgAttrsLen(nlMsgHdr))) {
 
@@ -593,6 +593,17 @@ _FlowNlGetCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                      != TRUE) {
         OVS_LOG_ERROR("Attr Parsing failed for msg: %p",
                        nlMsgHdr);
+        rc = STATUS_INVALID_PARAMETER;
+        goto done;
+    }
+
+    /*
+     * OVS_FLOW_ATTR_KEY is optional in nlFlowPolicy (to admit UFID-only DEL),
+     * but GET is always key-based here (UFID-based GET is not implemented), so
+     * a keyless GET is rejected rather than dereferencing a NULL key below.
+     */
+    if (!nlAttrs[OVS_FLOW_ATTR_KEY]) {
+        OVS_LOG_ERROR("OVS_FLOW_ATTR_KEY missing for flow get");
         rc = STATUS_INVALID_PARAMETER;
         goto done;
     }
@@ -2973,6 +2984,8 @@ OvsLookupFlowByUfid(OVS_DATAPATH *datapath, const ovs_u128 *ufid)
     UINT32 hash = OvsJhashBytes(ufid, sizeof(*ufid), 0);
     PLIST_ENTRY head, link;
 
+    ASSERT(datapath->ufidTable != NULL);
+
     head = &datapath->ufidTable[HASH_BUCKET(hash)];
     link = head->Flink;
     while (link != head) {
@@ -3261,6 +3274,14 @@ HandleFlowPut(OvsFlowPut *put,
                 newFlow->byteCount = KernelFlow->byteCount;
                 newFlow->tcpFlags = KernelFlow->tcpFlags;
                 newFlow->used = KernelFlow->used;
+            }
+            /*
+             * Preserve the flow's UFID identity across a modify that does not
+             * repeat the UFID, so a later UFID-only delete still resolves it.
+             */
+            if (!newFlow->ufidValid && KernelFlow->ufidValid) {
+                newFlow->ufid = KernelFlow->ufid;
+                newFlow->ufidValid = TRUE;
             }
             RemoveFlow(datapath, &KernelFlow);
             status = AddFlow(datapath, newFlow);
@@ -3592,10 +3613,29 @@ OvsProbeSupportedFeature(POVS_MESSAGE msgIn,
     NTSTATUS status = STATUS_SUCCESS;
     PNL_MSG_HDR nlMsgHdr = &(msgIn->nlMsg);
 
-    UINT32 keyAttrOffset = (UINT32)((PCHAR)keyAttr - (PCHAR)nlMsgHdr);
+    UINT32 keyAttrOffset;
     UINT32 encapOffset = 0;
     PNL_ATTR keyAttrs[__OVS_KEY_ATTR_MAX] = { NULL };
     PNL_ATTR encapAttrs[__OVS_KEY_ATTR_MAX] = { NULL };
+
+    /*
+     * OVS_FLOW_ATTR_KEY is optional in nlFlowPolicy, so a probe may arrive
+     * without one. Such a probe carries its feature in the actions (or is
+     * malformed); validate the actions and never dereference a NULL key.
+     */
+    if (!keyAttr) {
+        if (actionAttr) {
+            if (!OvsProbeActionsSupported(NlAttrData(actionAttr),
+                                          NlAttrGetSize(actionAttr), 0)) {
+                status = STATUS_NOT_SUPPORTED;
+            }
+        } else {
+            status = STATUS_INVALID_PARAMETER;
+        }
+        goto done;
+    }
+
+    keyAttrOffset = (UINT32)((PCHAR)keyAttr - (PCHAR)nlMsgHdr);
 
     /* Get flow keys attributes */
     if ((NlAttrParseNested(nlMsgHdr, keyAttrOffset, NlAttrLen(keyAttr),

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -52,6 +52,7 @@ static VOID __inline *GetStartAddrNBL(const NET_BUFFER_LIST *_pNB);
 static NTSTATUS _MapNlToFlowPut(POVS_MESSAGE msgIn, PNL_ATTR keyAttr,
                                 PNL_ATTR actionAttr,
                                 PNL_ATTR flowAttrClear,
+                                PNL_ATTR ufidAttr,
                                 OvsFlowPut *mappedFlow);
 static VOID _MapKeyAttrToFlowPut(PNL_ATTR *keyAttrs,
                                  PNL_ATTR *tunnelAttrs,
@@ -104,7 +105,7 @@ UINT16 OvsGetFlowIPL2Offset(const OvsIPTunnelKey *tunKey);
 
 /* For Parsing attributes in FLOW_* commands */
 const NL_POLICY nlFlowPolicy[] = {
-    [OVS_FLOW_ATTR_KEY] = {.type = NL_A_NESTED, .optional = FALSE},
+    [OVS_FLOW_ATTR_KEY]  = {.type = NL_A_NESTED, .optional = TRUE},
     [OVS_FLOW_ATTR_MASK] = {.type = NL_A_NESTED, .optional = TRUE},
     [OVS_FLOW_ATTR_ACTIONS] = {.type = NL_A_NESTED, .optional = TRUE},
     [OVS_FLOW_ATTR_STATS] = {.type = NL_A_UNSPEC,
@@ -113,7 +114,12 @@ const NL_POLICY nlFlowPolicy[] = {
                              .optional = TRUE},
     [OVS_FLOW_ATTR_TCP_FLAGS] = {NL_A_U8, .optional = TRUE},
     [OVS_FLOW_ATTR_USED] = {NL_A_U64, .optional = TRUE},
-    [OVS_FLOW_ATTR_PROBE] = {.type = NL_A_FLAG, .optional = TRUE}
+    [OVS_FLOW_ATTR_PROBE] = {.type = NL_A_FLAG, .optional = TRUE},
+    [OVS_FLOW_ATTR_UFID] = {.type = NL_A_UNSPEC,
+                            .minLen = sizeof(ovs_u128),
+                            .maxLen = sizeof(ovs_u128),
+                            .optional = TRUE},
+    [OVS_FLOW_ATTR_UFID_FLAGS] = {.type = NL_A_U32, .optional = TRUE},
 };
 
 /* For Parsing nested OVS_FLOW_ATTR_KEY attributes. */
@@ -357,9 +363,86 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         }
     }
 
+    /*
+     * UFID-only DEL: delete a flow identified solely by its UFID, without a
+     * flow key.  This matches the Linux datapath behaviour.  GET-by-UFID and
+     * dump UFID echo are not implemented here; userspace computes the UFID
+     * from the key and does not need them for the DEL path.
+     */
+    if (genlMsgHdr->cmd == OVS_FLOW_CMD_DEL &&
+        !flowAttrs[OVS_FLOW_ATTR_KEY] &&
+        flowAttrs[OVS_FLOW_ATTR_UFID]) {
+
+        OVS_DATAPATH *datapath = &usrParamsCtx->switchContext->datapath;
+        OvsFlow *flow;
+        LOCK_STATE_EX dpLockState;
+        ovs_u128 ufid;
+
+        RtlCopyMemory(&ufid, NlAttrGet(flowAttrs[OVS_FLOW_ATTR_UFID]),
+                      sizeof(ufid));
+
+        OvsAcquireDatapathWrite(datapath, &dpLockState, FALSE);
+        flow = OvsLookupFlowByUfid(datapath, &ufid);
+        if (!flow) {
+            OvsReleaseDatapath(datapath, &dpLockState);
+            nlError = NL_ERROR_NOENT;
+            goto done;
+        }
+        /* Capture the stats before RemoveFlow() frees the flow and nulls the
+         * local pointer. */
+        stats.packetCount = flow->packetCount;
+        stats.byteCount   = flow->byteCount;
+        stats.tcpFlags    = flow->tcpFlags;
+        stats.used        = flow->used;
+        RemoveFlow(datapath, &flow);
+        OvsReleaseDatapath(datapath, &dpLockState);
+
+        replyStats.n_packets = stats.packetCount;
+        replyStats.n_bytes   = stats.byteCount;
+
+        NlBufInit(&nlBuf, usrParamsCtx->outputBuffer,
+                  usrParamsCtx->outputLength);
+        ok = NlFillOvsMsg(&nlBuf, nlMsgHdr->nlmsgType, 0,
+                          nlMsgHdr->nlmsgSeq, nlMsgHdr->nlmsgPid,
+                          genlMsgHdr->cmd, OVS_FLOW_VERSION,
+                          ovsHdr->dp_ifindex);
+        if (!ok) {
+            rc = STATUS_INVALID_BUFFER_SIZE;
+            goto done;
+        }
+
+        /* Echo the UFID back; key is not present in this request variant. */
+        if (!NlMsgPutTailUnspec(&nlBuf, OVS_FLOW_ATTR_UFID,
+                                (PCHAR)&ufid, sizeof(ufid))) {
+            OVS_LOG_ERROR("Adding OVS_FLOW_ATTR_UFID attribute failed.");
+            rc = STATUS_INVALID_BUFFER_SIZE;
+            goto done;
+        }
+
+        if (!NlMsgPutTailUnspec(&nlBuf, OVS_FLOW_ATTR_STATS,
+                                (PCHAR)(&replyStats), sizeof(replyStats))) {
+            OVS_LOG_ERROR("Adding OVS_FLOW_ATTR_STATS attribute failed.");
+            rc = STATUS_INVALID_BUFFER_SIZE;
+            goto done;
+        }
+
+        msgOut->nlMsg.nlmsgLen = NLMSG_ALIGN(NlBufSize(&nlBuf));
+        *replyLen = msgOut->nlMsg.nlmsgLen;
+        goto done;
+    }
+
+    /* KEY is required for all non-UFID-only paths. */
+    if (!flowAttrs[OVS_FLOW_ATTR_KEY]) {
+        OVS_LOG_ERROR("OVS_FLOW_ATTR_KEY missing for cmd %d",
+                      genlMsgHdr->cmd);
+        rc = STATUS_INVALID_PARAMETER;
+        goto done;
+    }
+
     if ((rc = _MapNlToFlowPut(msgIn, flowAttrs[OVS_FLOW_ATTR_KEY],
                               flowAttrs[OVS_FLOW_ATTR_ACTIONS],
                               flowAttrs[OVS_FLOW_ATTR_CLEAR],
+                              flowAttrs[OVS_FLOW_ATTR_UFID],
                               &mappedFlow))
         != STATUS_SUCCESS) {
         OVS_LOG_ERROR("Conversion to OvsFlowPut failed");
@@ -400,13 +483,15 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         rc = STATUS_SUCCESS;
     }
 
-    /* Append OVS_FLOW_ATTR_KEY attribute. This is need i.e. for flow delete*/
-    if (!NlMsgPutNested(&nlBuf, OVS_FLOW_ATTR_KEY,
-                        NlAttrData(flowAttrs[OVS_FLOW_ATTR_KEY]),
-                        NlAttrGetSize(flowAttrs[OVS_FLOW_ATTR_KEY]))) {
-        OVS_LOG_ERROR("Adding OVS_FLOW_ATTR_KEY attribute failed.");
-        rc = STATUS_INVALID_BUFFER_SIZE;
-        goto done;
+    /* Echo OVS_FLOW_ATTR_KEY back to userspace (e.g. for flow delete). */
+    if (flowAttrs[OVS_FLOW_ATTR_KEY]) {
+        if (!NlMsgPutNested(&nlBuf, OVS_FLOW_ATTR_KEY,
+                            NlAttrData(flowAttrs[OVS_FLOW_ATTR_KEY]),
+                            NlAttrGetSize(flowAttrs[OVS_FLOW_ATTR_KEY]))) {
+            OVS_LOG_ERROR("Adding OVS_FLOW_ATTR_KEY attribute failed.");
+            rc = STATUS_INVALID_BUFFER_SIZE;
+            goto done;
+        }
     }
 
     /* Append OVS_FLOW_ATTR_STATS attribute */
@@ -1431,6 +1516,7 @@ done:
 static NTSTATUS
 _MapNlToFlowPut(POVS_MESSAGE msgIn, PNL_ATTR keyAttr,
                 PNL_ATTR actionAttr, PNL_ATTR flowAttrClear,
+                PNL_ATTR ufidAttr,
                 OvsFlowPut *mappedFlow)
 {
     NTSTATUS rc = STATUS_SUCCESS;
@@ -1438,7 +1524,6 @@ _MapNlToFlowPut(POVS_MESSAGE msgIn, PNL_ATTR keyAttr,
     PGENL_MSG_HDR genlMsgHdr = &(msgIn->genlMsg);
     POVS_HDR ovsHdr = &(msgIn->ovsHdr);
 
-    UINT32 keyAttrOffset = (UINT32)((PCHAR)keyAttr - (PCHAR)nlMsgHdr);
     UINT32 tunnelKeyAttrOffset;
     UINT32 encapOffset = 0;
 
@@ -1446,60 +1531,71 @@ _MapNlToFlowPut(POVS_MESSAGE msgIn, PNL_ATTR keyAttr,
     PNL_ATTR tunnelAttrs[__OVS_TUNNEL_KEY_ATTR_MAX] = {NULL};
     PNL_ATTR encapAttrs[__OVS_KEY_ATTR_MAX] = { NULL };
 
-    /* Get flow keys attributes */
-    if ((NlAttrParseNested(nlMsgHdr, keyAttrOffset, NlAttrLen(keyAttr),
-                           nlFlowKeyPolicy, ARRAY_SIZE(nlFlowKeyPolicy),
-                           keyAttrs, ARRAY_SIZE(keyAttrs)))
-                           != TRUE) {
-        OVS_LOG_ERROR("Key Attr Parsing failed for msg: %p",
-                      nlMsgHdr);
-        rc = STATUS_INVALID_PARAMETER;
-        goto done;
-    }
+    if (keyAttr) {
+        UINT32 keyAttrOffset = (UINT32)((PCHAR)keyAttr - (PCHAR)nlMsgHdr);
 
-    if (keyAttrs[OVS_KEY_ATTR_ENCAP]) {
-        encapOffset = (UINT32)((PCHAR)(keyAttrs[OVS_KEY_ATTR_ENCAP])
-                          - (PCHAR)nlMsgHdr);
-
-        if ((NlAttrParseNested(nlMsgHdr, encapOffset,
-                               NlAttrLen(keyAttrs[OVS_KEY_ATTR_ENCAP]),
-                               nlFlowKeyPolicy,
-                               ARRAY_SIZE(nlFlowKeyPolicy),
-                               encapAttrs, ARRAY_SIZE(encapAttrs)))
+        /* Get flow keys attributes */
+        if ((NlAttrParseNested(nlMsgHdr, keyAttrOffset, NlAttrLen(keyAttr),
+                               nlFlowKeyPolicy, ARRAY_SIZE(nlFlowKeyPolicy),
+                               keyAttrs, ARRAY_SIZE(keyAttrs)))
                                != TRUE) {
-            OVS_LOG_ERROR("Encap Key Attr Parsing failed for msg: %p",
+            OVS_LOG_ERROR("Key Attr Parsing failed for msg: %p",
                           nlMsgHdr);
             rc = STATUS_INVALID_PARAMETER;
             goto done;
         }
-    }
 
-    if (keyAttrs[OVS_KEY_ATTR_TUNNEL]) {
-        tunnelKeyAttrOffset = (UINT32)((PCHAR)
-                              (keyAttrs[OVS_KEY_ATTR_TUNNEL])
+        if (keyAttrs[OVS_KEY_ATTR_ENCAP]) {
+            encapOffset = (UINT32)((PCHAR)(keyAttrs[OVS_KEY_ATTR_ENCAP])
                               - (PCHAR)nlMsgHdr);
 
-        /* Get tunnel keys attributes */
-        if ((NlAttrParseNested(nlMsgHdr, tunnelKeyAttrOffset,
-                               NlAttrLen(keyAttrs[OVS_KEY_ATTR_TUNNEL]),
-                               nlFlowTunnelKeyPolicy,
-                               ARRAY_SIZE(nlFlowTunnelKeyPolicy),
-                               tunnelAttrs, ARRAY_SIZE(tunnelAttrs)))
-                               != TRUE) {
-            OVS_LOG_ERROR("Tunnel key Attr Parsing failed for msg: %p",
-                          nlMsgHdr);
-            rc = STATUS_INVALID_PARAMETER;
-            goto done;
+            if ((NlAttrParseNested(nlMsgHdr, encapOffset,
+                                   NlAttrLen(keyAttrs[OVS_KEY_ATTR_ENCAP]),
+                                   nlFlowKeyPolicy,
+                                   ARRAY_SIZE(nlFlowKeyPolicy),
+                                   encapAttrs, ARRAY_SIZE(encapAttrs)))
+                                   != TRUE) {
+                OVS_LOG_ERROR("Encap Key Attr Parsing failed for msg: %p",
+                              nlMsgHdr);
+                rc = STATUS_INVALID_PARAMETER;
+                goto done;
+            }
+        }
+
+        if (keyAttrs[OVS_KEY_ATTR_TUNNEL]) {
+            tunnelKeyAttrOffset = (UINT32)((PCHAR)
+                                  (keyAttrs[OVS_KEY_ATTR_TUNNEL])
+                                  - (PCHAR)nlMsgHdr);
+
+            /* Get tunnel keys attributes */
+            if ((NlAttrParseNested(nlMsgHdr, tunnelKeyAttrOffset,
+                                   NlAttrLen(keyAttrs[OVS_KEY_ATTR_TUNNEL]),
+                                   nlFlowTunnelKeyPolicy,
+                                   ARRAY_SIZE(nlFlowTunnelKeyPolicy),
+                                   tunnelAttrs, ARRAY_SIZE(tunnelAttrs)))
+                                   != TRUE) {
+                OVS_LOG_ERROR("Tunnel key Attr Parsing failed for msg: %p",
+                              nlMsgHdr);
+                rc = STATUS_INVALID_PARAMETER;
+                goto done;
+            }
+        }
+
+        _MapKeyAttrToFlowPut(keyAttrs, tunnelAttrs,
+                             &(mappedFlow->key));
+        ASSERT(keyAttrs[OVS_KEY_ATTR_IN_PORT]);
+
+        if (encapOffset) {
+            _MapKeyAttrToFlowPut(encapAttrs, tunnelAttrs,
+                                 &(mappedFlow->key));
         }
     }
 
-    _MapKeyAttrToFlowPut(keyAttrs, tunnelAttrs,
-                         &(mappedFlow->key));
-    ASSERT(keyAttrs[OVS_KEY_ATTR_IN_PORT]);
-
-    if (encapOffset) {
-        _MapKeyAttrToFlowPut(encapAttrs, tunnelAttrs,
-                             &(mappedFlow->key));
+    /* Map the UFID if present. */
+    if (ufidAttr) {
+        RtlCopyMemory(&mappedFlow->ufid, NlAttrGet(ufidAttr),
+                      sizeof(mappedFlow->ufid));
+        mappedFlow->ufidPresent = TRUE;
     }
 
     /* Map the action */
@@ -2055,6 +2151,11 @@ OvsDeleteFlowTable(OVS_DATAPATH *datapath)
     OvsFreeMemoryWithTag(datapath->flowTable, OVS_FLOW_POOL_TAG);
     datapath->flowTable = NULL;
 
+    if (datapath->ufidTable != NULL) {
+        OvsFreeMemoryWithTag(datapath->ufidTable, OVS_FLOW_POOL_TAG);
+        datapath->ufidTable = NULL;
+    }
+
     if (datapath->lock == NULL) {
         return NDIS_STATUS_SUCCESS;
     }
@@ -2088,6 +2189,19 @@ OvsAllocateFlowTable(OVS_DATAPATH *datapath,
         bucket = &(datapath->flowTable[i]);
         InitializeListHead(bucket);
     }
+
+    datapath->ufidTable = OvsAllocateMemoryWithTag(
+        OVS_FLOW_TABLE_SIZE * sizeof(LIST_ENTRY), OVS_FLOW_POOL_TAG);
+    if (!datapath->ufidTable) {
+        OvsFreeMemoryWithTag(datapath->flowTable, OVS_FLOW_POOL_TAG);
+        datapath->flowTable = NULL;
+        return NDIS_STATUS_RESOURCES;
+    }
+    for (i = 0; i < OVS_FLOW_TABLE_SIZE; i++) {
+        bucket = &(datapath->ufidTable[i]);
+        InitializeListHead(bucket);
+    }
+
     datapath->lock = NdisAllocateRWLock(switchContext->NdisFilterHandle);
 
     if (!datapath->lock) {
@@ -2723,9 +2837,13 @@ AddFlow(OVS_DATAPATH *datapath, OvsFlow *flow)
      */
     KeMemoryBarrier();
 
-    //KeAcquireSpinLock(&FilterDeviceExtension->NblQueueLock, &oldIrql);
     InsertTailList(head, &flow->ListEntry);
-    //KeReleaseSpinLock(&FilterDeviceExtension->NblQueueLock, oldIrql);
+
+    if (flow->ufidValid) {
+        UINT32 ufidHash = OvsJhashBytes(&flow->ufid, sizeof(flow->ufid), 0);
+        InsertTailList(&datapath->ufidTable[HASH_BUCKET(ufidHash)],
+                       &flow->ufidEntry);
+    }
 
     datapath->nFlows++;
 
@@ -2747,8 +2865,10 @@ RemoveFlow(OVS_DATAPATH *datapath,
 
     ASSERT(datapath->nFlows);
     datapath->nFlows--;
-    // Remove the flow  from queue
     RemoveEntryList(&f->ListEntry);
+    if (f->ufidValid) {
+        RemoveEntryList(&f->ufidEntry);
+    }
     FreeFlow(f);
 }
 
@@ -2827,6 +2947,38 @@ OvsLookupFlow(OVS_DATAPATH *datapath,
         OvsFlow *flow = CONTAINING_RECORD(link, OvsFlow, ListEntry);
 
         if (FlowEqual(flow, key, start, *hash, offset, size)) {
+            return flow;
+        }
+        link = link->Flink;
+    }
+    return NULL;
+}
+
+
+/*
+ * ----------------------------------------------------------------------------
+ * OvsLookupFlowByUfid --
+ *
+ *    Find a flow by its unique flow identifier (UFID).
+ *    Caller must hold the datapath lock (read or write).
+ *    Only called from the control IOCTL path, not the packet fast path.
+ *
+ * Results:
+ *    Flow pointer if found, NULL otherwise.
+ * ----------------------------------------------------------------------------
+ */
+OvsFlow *
+OvsLookupFlowByUfid(OVS_DATAPATH *datapath, const ovs_u128 *ufid)
+{
+    UINT32 hash = OvsJhashBytes(ufid, sizeof(*ufid), 0);
+    PLIST_ENTRY head, link;
+
+    head = &datapath->ufidTable[HASH_BUCKET(hash)];
+    link = head->Flink;
+    while (link != head) {
+        OvsFlow *flow = CONTAINING_RECORD(link, OvsFlow, ufidEntry);
+        if (flow->ufidValid &&
+            RtlEqualMemory(&flow->ufid, ufid, sizeof(*ufid))) {
             return flow;
         }
         link = link->Flink;
@@ -3171,6 +3323,8 @@ OvsPrepareFlow(OvsFlow **flow,
         localFlow->byteCount = 0;
         localFlow->tcpFlags = 0;
         localFlow->hash = hash;
+        localFlow->ufid = put->ufid;
+        localFlow->ufidValid = put->ufidPresent;
     } while(FALSE);
 
     return status;

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -399,17 +399,13 @@ OvsFlowNlCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
             nlError = NL_ERROR_NOENT;
             goto done;
         }
-        /* Capture the stats before RemoveFlow() frees the flow and nulls the
-         * local pointer. */
-        stats.packetCount = flow->packetCount;
-        stats.byteCount   = flow->byteCount;
-        stats.tcpFlags    = flow->tcpFlags;
-        stats.used        = flow->used;
+        /* Capture the reply stats before RemoveFlow() frees the flow and nulls
+         * the local pointer. The reply carries OVS_FLOW_ATTR_STATS only, so just
+         * packet/byte counts are needed (matching the key-based delete reply). */
+        replyStats.n_packets = flow->packetCount;
+        replyStats.n_bytes   = flow->byteCount;
         RemoveFlow(datapath, &flow);
         OvsReleaseDatapath(datapath, &dpLockState);
-
-        replyStats.n_packets = stats.packetCount;
-        replyStats.n_bytes   = stats.byteCount;
 
         NlBufInit(&nlBuf, usrParamsCtx->outputBuffer,
                   usrParamsCtx->outputLength);

--- a/datapath-windows/ovsext/Flow.h
+++ b/datapath-windows/ovsext/Flow.h
@@ -34,6 +34,9 @@ typedef struct _OvsFlow {
     UINT64 byteCount;
     UINT32 userActionsLen;   // used for flow query
     UINT32 actionBufferLen;  // used for flow reuse
+    ovs_u128   ufid;         // Userspace-assigned unique flow identifier.
+    BOOLEAN    ufidValid;    // TRUE when ufid was supplied on flow creation.
+    LIST_ENTRY ufidEntry;    // In Datapath's ufidTable bucket.
     NL_ATTR actions[1];
 } OvsFlow;
 
@@ -59,6 +62,7 @@ NDIS_STATUS OvsExtractFlow(const NET_BUFFER_LIST *pkt, UINT32 inPort,
                            OvsIPTunnelKey *tunKey);
 OvsFlow* OvsLookupFlow(OVS_DATAPATH *datapath, const OvsFlowKey *key,
                        UINT64 *hash, BOOLEAN hashValid);
+OvsFlow* OvsLookupFlowByUfid(OVS_DATAPATH *datapath, const ovs_u128 *ufid);
 OvsFlow* OvsLookupFlowRecirc(OVS_DATAPATH *datapath,
                              const OvsFlowKey *key,
                              UINT64 *hash);

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -52,7 +52,8 @@ typedef struct _OVS_VPORT_ENTRY *POVS_VPORT_ENTRY;
 
 typedef struct _OVS_DATAPATH
 {
-   PLIST_ENTRY             flowTable;       // Contains OvsFlows.
+   PLIST_ENTRY             flowTable;       // Contains OvsFlows (key index).
+   PLIST_ENTRY             ufidTable;       // Contains OvsFlows (ufid index).
    UINT32                  nFlows;          // Number of entries in flowTable.
 
    // List_Links              queues[64];      // Hash table of queue IDs.

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -127,9 +127,6 @@ struct mock_kernel {
     enum flow_reply flow_reply;
     struct mock_record flow_echo;
     struct mock_record flow_bad;
-    bool flow_require_key;      /* Model ovsext nlFlowPolicy: a flow command
-                                 * without OVS_FLOW_ATTR_KEY is rejected EINVAL
-                                 * (the current kernel has no UFID lookup). */
     bool flow_req_had_key;      /* Last flow request carried OVS_FLOW_ATTR_KEY. */
     bool flow_req_had_ufid;     /* Last flow request carried OVS_FLOW_ATTR_UFID. */
 
@@ -657,10 +654,9 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
     case OVS_WIN_NL_FLOW_FAMILY_ID: {
         size_t hdrlen = NLMSG_HDRLEN + GENL_HDRLEN + sizeof(struct ovs_header);
 
-        /* Record what the provider put on the wire and, when modelling the
-         * current kernel, enforce its nlFlowPolicy: OVS_FLOW_ATTR_KEY is
-         * mandatory and there is no OVS_FLOW_ATTR_UFID lookup, so a UFID-only
-         * (terse) request is rejected with EINVAL. */
+        /* Record which identifiers the provider put on the wire, so tests can
+         * assert the FLOW request contract (e.g. a terse delete carries a UFID
+         * and omits the key). */
         m->flow_req_had_key = false;
         m->flow_req_had_ufid = false;
         if (in_len >= hdrlen) {
@@ -671,9 +667,6 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
                 nl_attr_find__(attrs, alen, OVS_FLOW_ATTR_KEY) != NULL;
             m->flow_req_had_ufid =
                 nl_attr_find__(attrs, alen, OVS_FLOW_ATTR_UFID) != NULL;
-        }
-        if (m->flow_require_key && !m->flow_req_had_key) {
-            return reply_nlmsgerr(EINVAL, out, out_len, bytes);
         }
 
         switch (m->flow_reply) {
@@ -896,7 +889,6 @@ mock_reset_content(struct mock_kernel *m)
     m->validate_dp_failed = false;
     m->flow_dump_done = false;
     m->flow_reply = FR_ACK;
-    m->flow_require_key = false;
     m->flow_req_had_key = false;
     m->flow_req_had_ufid = false;
     /* Default to the feature-aware kernel: echo USER_FEATURES/MEGAFLOW_STATS so
@@ -1513,13 +1505,13 @@ test_flow_del_stats(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
-/* Reproduces the live revalidator failure: after a terse flow dump the
- * revalidator deletes stale flows by UFID only (dpif_flow_del.terse = true,
- * .key = NULL).  The provider then omits OVS_FLOW_ATTR_KEY and sends only
- * OVS_FLOW_ATTR_UFID -- exactly like dpif-netlink.  The ovsext kernel, however,
- * makes OVS_FLOW_ATTR_KEY mandatory and has no UFID lookup, so it rejects the
- * request with EINVAL (the `failed to flow_del (Invalid argument) ufid:...`
- * spam).  The fix belongs in the kernel (add UFID lookup); userspace is correct. */
+/* Terse (UFID-only) delete contract. After a terse flow dump the revalidator
+ * deletes stale flows by UFID only (dpif_flow_del.terse = true, .key = NULL).
+ * The provider must then emit OVS_FLOW_ATTR_UFID and omit OVS_FLOW_ATTR_KEY --
+ * exactly like dpif-netlink -- and a UFID-capable kernel (the kernel now does
+ * UFID lookup) must accept it. (Guards the userspace marshalling; the live
+ * `failed to flow_del (Invalid argument) ufid:...` regression was the kernel
+ * lacking the lookup, fixed separately and validated on the VM.) */
 static void
 test_flow_del_ufid_terse(struct dpif *dpif, struct mock_kernel *m)
 {
@@ -1531,7 +1523,7 @@ test_flow_del_ufid_terse(struct dpif *dpif, struct mock_kernel *m)
     printf("test_flow_del_ufid_terse:\n");
 
     mock_reset_content(m);
-    m->flow_require_key = true;          /* model current ovsext nlFlowPolicy */
+    m->flow_reply = FR_ACK;
     memset(&del, 0, sizeof del);
     del.ufid = &ufid;
     del.terse = true;                    /* UFID-only delete: no key */
@@ -1541,41 +1533,11 @@ test_flow_del_ufid_terse(struct dpif *dpif, struct mock_kernel *m)
     ops[0] = &op;
     dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
 
-    /* The provider put a UFID on the wire and (correctly, per the dpif
-     * contract) omitted the key... */
+    /* The provider put a UFID on the wire and omitted the key (the dpif
+     * terse-delete contract)... */
     CHECK(m->flow_req_had_ufid);
     CHECK(!m->flow_req_had_key);
-    /* ...and the key-requiring kernel rejected it -- the reproduced bug. */
-    CHECK(op.error == EINVAL);
-}
-
-/* The fixed kernel resolves a terse (UFID-only) delete via its UFID index and
- * acks it. With the mock NOT requiring a key (flow_require_key = false), the
- * same UFID-only delete the provider emits must succeed. */
-static void
-test_flow_del_ufid_terse_supported(struct dpif *dpif, struct mock_kernel *m)
-{
-    struct dpif_flow_del del;
-    struct dpif_op op;
-    struct dpif_op *ops[1];
-    ovs_u128 ufid = { .u32 = { 5, 6, 7, 8 } };
-
-    printf("test_flow_del_ufid_terse_supported:\n");
-
-    mock_reset_content(m);
-    m->flow_require_key = false;         /* UFID-capable kernel */
-    m->flow_reply = FR_ACK;
-    memset(&del, 0, sizeof del);
-    del.ufid = &ufid;
-    del.terse = true;
-    memset(&op, 0, sizeof op);
-    op.type = DPIF_OP_FLOW_DEL;
-    op.flow_del = del;
-    ops[0] = &op;
-    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
-
-    CHECK(m->flow_req_had_ufid);
-    CHECK(!m->flow_req_had_key);
+    /* ...and a UFID-capable kernel accepts it. */
     CHECK(op.error == 0);
 }
 
@@ -2035,7 +1997,6 @@ main(int argc, char *argv[])
     test_flow_put_stats(dpif, &mock);
     test_flow_del_stats(dpif, &mock);
     test_flow_del_ufid_terse(dpif, &mock);
-    test_flow_del_ufid_terse_supported(dpif, &mock);
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -1549,6 +1549,36 @@ test_flow_del_ufid_terse(struct dpif *dpif, struct mock_kernel *m)
     CHECK(op.error == EINVAL);
 }
 
+/* The fixed kernel resolves a terse (UFID-only) delete via its UFID index and
+ * acks it. With the mock NOT requiring a key (flow_require_key = false), the
+ * same UFID-only delete the provider emits must succeed. */
+static void
+test_flow_del_ufid_terse_supported(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_del del;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    ovs_u128 ufid = { .u32 = { 5, 6, 7, 8 } };
+
+    printf("test_flow_del_ufid_terse_supported:\n");
+
+    mock_reset_content(m);
+    m->flow_require_key = false;         /* UFID-capable kernel */
+    m->flow_reply = FR_ACK;
+    memset(&del, 0, sizeof del);
+    del.ufid = &ufid;
+    del.terse = true;
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_DEL;
+    op.flow_del = del;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+
+    CHECK(m->flow_req_had_ufid);
+    CHECK(!m->flow_req_had_key);
+    CHECK(op.error == 0);
+}
+
 /* The class 'operate' is the 3-arg contract; dpif_operate resolves offload
  * before dispatch.  Drive a multi-op batch through the public path to exercise
  * it end to end. */
@@ -2005,6 +2035,7 @@ main(int argc, char *argv[])
     test_flow_put_stats(dpif, &mock);
     test_flow_del_stats(dpif, &mock);
     test_flow_del_ufid_terse(dpif, &mock);
+    test_flow_del_ufid_terse_supported(dpif, &mock);
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -127,6 +127,11 @@ struct mock_kernel {
     enum flow_reply flow_reply;
     struct mock_record flow_echo;
     struct mock_record flow_bad;
+    bool flow_require_key;      /* Model ovsext nlFlowPolicy: a flow command
+                                 * without OVS_FLOW_ATTR_KEY is rejected EINVAL
+                                 * (the current kernel has no UFID lookup). */
+    bool flow_req_had_key;      /* Last flow request carried OVS_FLOW_ATTR_KEY. */
+    bool flow_req_had_ufid;     /* Last flow request carried OVS_FLOW_ATTR_UFID. */
 
     /* Set when a validateDpIndex control command (subscribe/pend) arrives with a
      * dp_ifindex that is not the mock datapath -- the kernel rejects these. */
@@ -649,7 +654,26 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
     case OVS_WIN_NL_NETDEV_FAMILY_ID:
         return mock_netdev_get(m, in, in_len, out, out_len, bytes);
 
-    case OVS_WIN_NL_FLOW_FAMILY_ID:
+    case OVS_WIN_NL_FLOW_FAMILY_ID: {
+        size_t hdrlen = NLMSG_HDRLEN + GENL_HDRLEN + sizeof(struct ovs_header);
+
+        /* Record what the provider put on the wire and, when modelling the
+         * current kernel, enforce its nlFlowPolicy: OVS_FLOW_ATTR_KEY is
+         * mandatory and there is no OVS_FLOW_ATTR_UFID lookup, so a UFID-only
+         * (terse) request is rejected with EINVAL. */
+        if (in_len >= hdrlen) {
+            const struct nlattr *attrs =
+                ALIGNED_CAST(const struct nlattr *, (const char *) in + hdrlen);
+            size_t alen = in_len - hdrlen;
+            m->flow_req_had_key =
+                nl_attr_find__(attrs, alen, OVS_FLOW_ATTR_KEY) != NULL;
+            m->flow_req_had_ufid =
+                nl_attr_find__(attrs, alen, OVS_FLOW_ATTR_UFID) != NULL;
+        }
+        if (m->flow_require_key && !m->flow_req_had_key) {
+            return reply_nlmsgerr(EINVAL, out, out_len, bytes);
+        }
+
         switch (m->flow_reply) {
         case FR_ECHO:      return record_copy(&m->flow_echo, out, out_len, bytes);
         case FR_MALFORMED: return record_copy(&m->flow_bad, out, out_len, bytes);
@@ -658,6 +682,7 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
         case FR_ACK:
         default:           return TRUE;   /* ack, empty reply */
         }
+    }
 
     case OVS_WIN_NL_VPORT_FAMILY_ID:
     case OVS_WIN_NL_PACKET_FAMILY_ID:
@@ -869,6 +894,9 @@ mock_reset_content(struct mock_kernel *m)
     m->validate_dp_failed = false;
     m->flow_dump_done = false;
     m->flow_reply = FR_ACK;
+    m->flow_require_key = false;
+    m->flow_req_had_key = false;
+    m->flow_req_had_ufid = false;
     /* Default to the feature-aware kernel: echo USER_FEATURES/MEGAFLOW_STATS so
      * dpif_open()'s feature negotiation succeeds.  A SET clears this back to the
      * negotiated value; tests that exercise the old-kernel path clear it. */
@@ -1483,6 +1511,42 @@ test_flow_del_stats(struct dpif *dpif, struct mock_kernel *m)
     ofpbuf_uninit(&key);
 }
 
+/* Reproduces the live revalidator failure: after a terse flow dump the
+ * revalidator deletes stale flows by UFID only (dpif_flow_del.terse = true,
+ * .key = NULL).  The provider then omits OVS_FLOW_ATTR_KEY and sends only
+ * OVS_FLOW_ATTR_UFID -- exactly like dpif-netlink.  The ovsext kernel, however,
+ * makes OVS_FLOW_ATTR_KEY mandatory and has no UFID lookup, so it rejects the
+ * request with EINVAL (the `failed to flow_del (Invalid argument) ufid:...`
+ * spam).  The fix belongs in the kernel (add UFID lookup); userspace is correct. */
+static void
+test_flow_del_ufid_terse(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct dpif_flow_del del;
+    struct dpif_op op;
+    struct dpif_op *ops[1];
+    ovs_u128 ufid = { .u32 = { 1, 2, 3, 4 } };
+
+    printf("test_flow_del_ufid_terse:\n");
+
+    mock_reset_content(m);
+    m->flow_require_key = true;          /* model current ovsext nlFlowPolicy */
+    memset(&del, 0, sizeof del);
+    del.ufid = &ufid;
+    del.terse = true;                    /* UFID-only delete: no key */
+    memset(&op, 0, sizeof op);
+    op.type = DPIF_OP_FLOW_DEL;
+    op.flow_del = del;
+    ops[0] = &op;
+    dpif_operate(dpif, ops, 1, DPIF_OFFLOAD_NEVER);
+
+    /* The provider put a UFID on the wire and (correctly, per the dpif
+     * contract) omitted the key... */
+    CHECK(m->flow_req_had_ufid);
+    CHECK(!m->flow_req_had_key);
+    /* ...and the key-requiring kernel rejected it -- the reproduced bug. */
+    CHECK(op.error == EINVAL);
+}
+
 /* The class 'operate' is the 3-arg contract; dpif_operate resolves offload
  * before dispatch.  Drive a multi-op batch through the public path to exercise
  * it end to end. */
@@ -1938,6 +2002,7 @@ main(int argc, char *argv[])
     test_flow_get_miss_vs_malformed(dpif, &mock);
     test_flow_put_stats(dpif, &mock);
     test_flow_del_stats(dpif, &mock);
+    test_flow_del_ufid_terse(dpif, &mock);
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -661,6 +661,8 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
          * current kernel, enforce its nlFlowPolicy: OVS_FLOW_ATTR_KEY is
          * mandatory and there is no OVS_FLOW_ATTR_UFID lookup, so a UFID-only
          * (terse) request is rejected with EINVAL. */
+        m->flow_req_had_key = false;
+        m->flow_req_had_ufid = false;
         if (in_len >= hdrlen) {
             const struct nlattr *attrs =
                 ALIGNED_CAST(const struct nlattr *, (const char *) in + hdrlen);


### PR DESCRIPTION
The ovs-vswitchd revalidator deletes stale datapath flows by UFID after a terse dump (`OVS_FLOW_ATTR_UFID`, no `OVS_FLOW_ATTR_KEY`). The Windows ovsext kernel made `OVS_FLOW_ATTR_KEY` mandatory in `nlFlowPolicy` and had no UFID lookup, so every such delete failed: `failed to flow_del (Invalid argument) ufid:...` on every revalidation sweep. The userspace marshalling is already correct (it sends the UFID, matching dpif-netlink); the gap was kernel-side.

Mirror the Linux datapath, which keeps a UFID index:

- Make `OVS_FLOW_ATTR_KEY` optional and admit `OVS_FLOW_ATTR_UFID` / `OVS_FLOW_ATTR_UFID_FLAGS`.
- Store the UFID supplied on flow put in `OvsFlow` and index it in a parallel per-datapath UFID hash table, maintained alongside the key table under the datapath write lock.
- Add `OvsLookupFlowByUfid`; a DEL carrying only a UFID resolves the flow through that index, removes it, and echoes the UFID + stats (ENOENT when absent).

Key-based put/get/del/dump are unchanged. GET-by-UFID and dump UFID echo are not needed (userspace derives the UFID from the key) and are left out.

### Validation
- Mock-kernel harness (`tests/test-dpif-windows.c`): a new test reproduces the bug (a terse delete emits a UFID, omits the key, and a key-requiring mock returns EINVAL).
- Live eryph-zero stack (OVN 26.03 / OVS 3.7): after deploying the driver, `dpif/show-dp-features` still reports `Ufid: Yes`, and the `flow_del (Invalid argument)` spam stops — 0 occurrences across deliberate flow churn — with forwarding intact.
