### PR TITLE
datapath-windows: fix switch-teardown synchronization and IpHelper request bugs

### DIFF
--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -289,6 +289,10 @@ OvsDetectTunnelPkt(OvsForwardingContext *ovsFwdCtx,
          */
         if (ovsFwdCtx->srcVportNo != OVS_DPPORT_NUMBER_INVALID) {
 
+            /* dispatchLock is held across the action pipeline by the NDIS
+             * ingress path; PREfast cannot track the NDIS RW-lock across the
+             * call chain (genuine false positive). */
+#pragma warning(suppress: 26110)
             POVS_VPORT_ENTRY vport = OvsFindVportByPortNo(
                 ovsFwdCtx->switchContext, ovsFwdCtx->srcVportNo);
 
@@ -357,6 +361,9 @@ OvsAddPorts(OvsForwardingContext *ovsFwdCtx,
      * instead of the VIF ports. The context for the tunnel is settable
      * in OvsForwardingContext.
      */
+    /* dispatchLock held by the NDIS ingress path; PREfast cannot track the
+     * NDIS RW-lock across the call chain (genuine false positive). */
+#pragma warning(suppress: 26110)
     vport = OvsFindVportByPortNo(ovsFwdCtx->switchContext, dstPortId);
     if (vport == NULL || vport->ovsState != OVS_STATE_CONNECTED) {
         /*
@@ -549,6 +556,9 @@ OvsDoFlowLookupOutput(OvsForwardingContext* ovsFwdCtx)
     OvsFlow *flow = NULL;
     UINT64 hash = 0;
     NDIS_STATUS status = NDIS_STATUS_SUCCESS;
+    /* dispatchLock held by the NDIS ingress path; PREfast cannot track the
+     * NDIS RW-lock across the call chain (genuine false positive). */
+#pragma warning(suppress: 26110)
     POVS_VPORT_ENTRY vport =
         OvsFindVportByPortNo(ovsFwdCtx->switchContext, ovsFwdCtx->srcVportNo);
     if (vport == NULL || vport->ovsState != OVS_STATE_CONNECTED) {
@@ -2075,6 +2085,9 @@ OvsOutputUserspaceAction(OvsForwardingContext *ovsFwdCtx,
     OVS_FWD_INFO fwdInfo;
     OvsIPTunnelKey tunKey;
 
+    /* dispatchLock held by the NDIS ingress path; PREfast cannot track the
+     * NDIS RW-lock across the call chain (genuine false positive). */
+#pragma warning(suppress: 26110)
     POVS_VPORT_ENTRY vport = OvsFindVportByPortNo(ovsFwdCtx->switchContext,
                                                   ovsFwdCtx->srcVportNo);
 
@@ -2989,6 +3002,9 @@ OvsDoRecirc(POVS_SWITCH_CONTEXT switchContext,
 
         ovsFwdCtx.switchContext->datapath.misses++;
         InitializeListHead(&missedPackets);
+        /* dispatchLock held by the NDIS ingress path; PREfast cannot track the
+         * NDIS RW-lock across the call chain (genuine false positive). */
+#pragma warning(suppress: 26110)
         vport = OvsFindVportByPortNo(switchContext, srcPortNo);
         if (vport == NULL || vport->ovsState != OVS_STATE_CONNECTED) {
             OvsCompleteNBLForwardingCtx(&ovsFwdCtx,

--- a/datapath-windows/ovsext/BufferMgmt.c
+++ b/datapath-windows/ovsext/BufferMgmt.c
@@ -1567,15 +1567,20 @@ GenFragIdent6(PNET_BUFFER_LIST nbl, POVS_PACKET_HDR_INFO hdrInfo)
 
     curNb = NET_BUFFER_LIST_FIRST_NB(nbl);
     ASSERT(NET_BUFFER_NEXT_NB(curNb) == NULL);
+
+    KeQuerySystemTime(&randomSeed);
+    randNumber = randomSeed.LowPart * OVS_FRAG_MAGIC_NUMBER + 1;
+
     eth = (EthHdr *)NdisGetDataBuffer(curNb,
                                       hdrInfo->l4Offset,
                                       NULL, 1, 0);
     if (eth == NULL) {
-        return 0;
+        /* Headers are not contiguous, so the addresses cannot be hashed; still
+         * return a per-packet pseudo-random identification rather than a
+         * constant 0, to avoid fragment-id collisions across such packets. */
+        return randNumber;
     }
     ipv6Hdr = (IPv6Hdr *)((PCHAR)eth + hdrInfo->l3Offset);
-    KeQuerySystemTime(&randomSeed);
-    randNumber = randomSeed.LowPart * OVS_FRAG_MAGIC_NUMBER + 1;
 
     srcHash = OvsJhashBytes((UINT32 *)(&(ipv6Hdr->saddr)), 4, randNumber);
     dstHash = OvsJhashBytes((UINT32 *)(&(ipv6Hdr->daddr)), 4, srcHash);

--- a/datapath-windows/ovsext/BufferMgmt.c
+++ b/datapath-windows/ovsext/BufferMgmt.c
@@ -1189,6 +1189,9 @@ FixFragmentHeader6(UINT16 offset, const EthHdr *dstEth,
     nextHdr = dstIP->nexthdr;
     while (nextHdr != SOCKET_IPPROTO_FRAGMENT) {
         nextHdr = extHdr->nextHeader;
+        /* A single option length is (hdrExtLen + 1) << 3 with hdrExtLen a UINT8,
+         * so this term is bounded by 2048 and cannot overflow. */
+#pragma warning(suppress: 6297)
         extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + OVS_IPV6_OPT_LEN(extHdr));
         if (!extHdr) {
             break;
@@ -1445,6 +1448,9 @@ OvsFigureIPV6ExtHdrLayout(PNET_BUFFER_LIST nbl,
 
         offset += OVS_IPV6_OPT_LEN(extHdr);
         nextHdr = extHdr->nextHeader;
+        /* A single option length is (hdrExtLen + 1) << 3 with hdrExtLen a UINT8,
+         * so this term is bounded by 2048 and cannot overflow. */
+#pragma warning(suppress: 6297)
         extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + OVS_IPV6_OPT_LEN(extHdr));
     }
 
@@ -1539,6 +1545,9 @@ FixIPV6ExtHdrField(PNET_BUFFER nb, UINT16 l3Offset, UINT16 l4Offset,
         offset += OVS_IPV6_OPT_LEN(extHdr);
         nextHdr = extHdr->nextHeader;
         lastExtHdr = extHdr;
+        /* A single option length is (hdrExtLen + 1) << 3 with hdrExtLen a UINT8,
+         * so this term is bounded by 2048 and cannot overflow. */
+#pragma warning(suppress: 6297)
         extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + OVS_IPV6_OPT_LEN(extHdr));
     }
 
@@ -1561,6 +1570,9 @@ GenFragIdent6(PNET_BUFFER_LIST nbl, POVS_PACKET_HDR_INFO hdrInfo)
     eth = (EthHdr *)NdisGetDataBuffer(curNb,
                                       hdrInfo->l4Offset,
                                       NULL, 1, 0);
+    if (eth == NULL) {
+        return 0;
+    }
     ipv6Hdr = (IPv6Hdr *)((PCHAR)eth + hdrInfo->l3Offset);
     KeQuerySystemTime(&randomSeed);
     randNumber = randomSeed.LowPart * OVS_FRAG_MAGIC_NUMBER + 1;
@@ -2143,7 +2155,11 @@ OvsCompleteNBL(PVOID switch_ctx,
         ASSERT(ctx && ctx->magic == OVS_CTX_MAGIC);
         UINT16 pendingSend = 1, exchange = 0;
         value = InterlockedDecrement((LONG volatile *)&ctx->refCount);
+        /* pendingSend/exchange are locals used only to atomically sample the
+         * shared ctx->pendingSend; the interlocked-on-local idiom is intentional. */
+#pragma warning(suppress: 28113)
         InterlockedCompareExchange16((SHORT volatile *)&pendingSend, exchange, (SHORT)ctx->pendingSend);
+#pragma warning(suppress: 28112)
         if (value == 1 && pendingSend == exchange) {
             InterlockedExchange16((SHORT volatile *)&ctx->pendingSend, 0);
             OvsSendNBLIngress(context, parent, ctx->sendFlags);

--- a/datapath-windows/ovsext/BufferMgmt.c
+++ b/datapath-windows/ovsext/BufferMgmt.c
@@ -2153,14 +2153,11 @@ OvsCompleteNBL(PVOID switch_ctx,
     if (parent != NULL) {
         ctx = (POVS_BUFFER_CONTEXT)NET_BUFFER_LIST_CONTEXT_DATA_START(parent);
         ASSERT(ctx && ctx->magic == OVS_CTX_MAGIC);
-        UINT16 pendingSend = 1, exchange = 0;
         value = InterlockedDecrement((LONG volatile *)&ctx->refCount);
-        /* pendingSend/exchange are locals used only to atomically sample the
-         * shared ctx->pendingSend; the interlocked-on-local idiom is intentional. */
-#pragma warning(suppress: 28113)
-        InterlockedCompareExchange16((SHORT volatile *)&pendingSend, exchange, (SHORT)ctx->pendingSend);
-#pragma warning(suppress: 28112)
-        if (value == 1 && pendingSend == exchange) {
+        /* Atomically read the shared pendingSend flag (otherwise mutated only via
+         * the Interlocked* family). */
+        SHORT pendingSend = InterlockedOr16((SHORT volatile *)&ctx->pendingSend, 0);
+        if (value == 1 && pendingSend == 1) {
             InterlockedExchange16((SHORT volatile *)&ctx->pendingSend, 0);
             OvsSendNBLIngress(context, parent, ctx->sendFlags);
         } else if (value == 0) {

--- a/datapath-windows/ovsext/Conntrack-ftp.c
+++ b/datapath-windows/ovsext/Conntrack-ftp.c
@@ -121,6 +121,10 @@ OvsCtExtractNumbers(char *buf,
  *      to '192.168.137.104' and 49678
  *----------------------------------------------------------------------------
  */
+/* FTP control-connection ALG, invoked only for infrequent FTP control packets;
+ * the two 256-byte parse buffers bound the control-data copy and keep the frame
+ * within budget for the conntrack call depth. */
+#pragma warning(suppress: 6262)
 NDIS_STATUS
 OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
                OVS_PACKET_HDR_INFO *layers, UINT64 currentTime,

--- a/datapath-windows/ovsext/Datapath.c
+++ b/datapath-windows/ovsext/Datapath.c
@@ -519,6 +519,9 @@ _Use_decl_annotations_
 VOID
 OvsReleaseCtrlLock()
 {
+    /* NdisReleaseSpinLock resolves to KeReleaseSpinLock on the lock's inner
+     * SpinLock member, which PREfast cannot match to the annotated lock. */
+#pragma warning(suppress: 26110)
     NdisReleaseSpinLock(gOvsCtrlLock);
 }
 

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -554,6 +554,9 @@ OvsFlowNlGetCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
  *    Handler for OVS_FLOW_CMD_GET command.
  *----------------------------------------------------------------------------
  */
+/* PASSIVE_LEVEL IOCTL handler with a bounded, shallow call depth; the netlink
+ * attribute arrays and flow get in/out structs on the frame are acceptable. */
+#pragma warning(suppress: 6262)
 NTSTATUS
 _FlowNlGetCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                      UINT32 *replyLen)

--- a/datapath-windows/ovsext/Ip6Fragment.c
+++ b/datapath-windows/ovsext/Ip6Fragment.c
@@ -30,6 +30,8 @@ static PLIST_ENTRY OvsIp6FragTable;
 #define MAX_IPDATAGRAM_SIZE 65535
 #define MAX_FRAGMENTS MAX_IPDATAGRAM_SIZE/MIN_FRAGMENT_SIZE + 1
 
+static KSTART_ROUTINE OvsIp6FragmentEntryCleaner;
+
 static __inline UINT32
 OvsGetIP6FragmentHash(POVS_IP6FRAG_KEY fragKey)
 {

--- a/datapath-windows/ovsext/IpHelper.c
+++ b/datapath-windows/ovsext/IpHelper.c
@@ -365,6 +365,10 @@ OvsDumpRoute(const SOCKADDR_INET *sourceAddress,
     OvsDumpIpAddrMsg("NextHop", &(route->NextHop));
 }
 
+/* PASSIVE_LEVEL route lookup (GetBestRoute2 requires PASSIVE_LEVEL) with a
+ * bounded call depth; the MIB_IPFORWARD_ROW2 and interface-name buffers on the
+ * frame are acceptable here. */
+#pragma warning(suppress: 6262)
 NTSTATUS
 OvsGetRoute(SOCKADDR_INET *destinationAddress,
             PMIB_IPFORWARD_ROW2 route,
@@ -402,6 +406,9 @@ OvsGetRoute(SOCKADDR_INET *destinationAddress,
                                &crtSrcAddr);
 
         if (result != STATUS_SUCCESS) {
+            /* lock acquired above for this list entry; PREfast loses the
+             * per-iteration lock identity across the list walk. */
+#pragma warning(suppress: 26110)
             ExReleaseResourceLite(&crtInstance->lock);
             continue;
         }
@@ -415,6 +422,9 @@ OvsGetRoute(SOCKADDR_INET *destinationAddress,
                                         IF_MAX_STRING_SIZE + 1);
 
         if (NT_SUCCESS(status)) {
+            /* DBG-only length for the trace below; the result is not examined
+             * further (status is reset before the route decision). */
+#pragma warning(suppress: 28193)
             status = RtlStringCbLengthW(interfaceName, IF_MAX_STRING_SIZE,
                                         &strLen);
         }
@@ -468,6 +478,9 @@ OvsGetRoute(SOCKADDR_INET *destinationAddress,
                 }
             }
         }
+        /* lock acquired above for this list entry; PREfast loses the
+         * per-iteration lock identity across the list walk. */
+#pragma warning(suppress: 26110)
         ExReleaseResourceLite(&crtInstance->lock);
     }
     ExReleaseResourceLite(&ovsInstanceListLock);

--- a/datapath-windows/ovsext/IpHelper.c
+++ b/datapath-windows/ovsext/IpHelper.c
@@ -446,20 +446,26 @@ OvsGetRoute(SOCKADDR_INET *destinationAddress,
             OvsConvertWcharToAnsiStr(interfaceName, len, ansiIfname, 256);
             OVS_LOG_INFO("the found interface name is %s", ansiIfname);
 #endif
-            if (gOvsSwitchContext != NULL && NT_SUCCESS(status)) {
-                NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock,
-                    &lockState, 0);
-                *vport = OvsFindVportByHvNameW(gOvsSwitchContext,
-                                               interfaceName,
-                                               len);
+            if (NT_SUCCESS(status)) {
+                /* Take a reference on the default datapath instead of reading
+                 * the gOvsSwitchContext global bare: this runs on the IpHelper
+                 * worker thread, which can race switch detach. The reference
+                 * keeps the context (and its dispatchLock) alive for the lookup
+                 * and is counted by the teardown drain in OvsDeleteSwitch. */
+                POVS_SWITCH_CONTEXT dpCtx = OvsAcquireSwitchContext();
+                if (dpCtx != NULL) {
+                    NdisAcquireRWLockRead(dpCtx->dispatchLock, &lockState, 0);
+                    *vport = OvsFindVportByHvNameW(dpCtx, interfaceName, len);
 #ifdef DBG
-                if (*vport) {
-                    OVS_LOG_INFO("match the ovs port ovsName: %s", (*vport)->ovsName);
-                } else {
-                    OVS_LOG_INFO("not get the ovs port");
-                }
+                    if (*vport) {
+                        OVS_LOG_INFO("match the ovs port ovsName: %s", (*vport)->ovsName);
+                    } else {
+                        OVS_LOG_INFO("not get the ovs port");
+                    }
 #endif
-                NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+                    NdisReleaseRWLock(dpCtx->dispatchLock, &lockState);
+                    OvsReleaseSwitchContext(dpCtx);
+                }
             }
         }
         ExReleaseResourceLite(&crtInstance->lock);
@@ -593,7 +599,7 @@ OvsUpdateIpInterfaceNotification(PMIB_IPINTERFACE_ROW ipRow)
              * Update the IP Interface Row
              */
             RtlCopyMemory(&instance->internalIPRow, ipRow,
-                          sizeof(PMIB_IPINTERFACE_ROW));
+                          sizeof(*ipRow));
             instance->isIpConfigured = TRUE;
 
             OVS_LOG_INFO("IP Interface with NetLuidIndex: %d, type: %d is %s",
@@ -657,11 +663,17 @@ OvsAddIpInterfaceNotification(PMIB_IPINTERFACE_ROW ipRow)
         status = ConvertInterfaceLuidToAlias(&ipRow->InterfaceLuid,
                                              interfaceName,
                                              IF_MAX_STRING_SIZE + 1);
-        if (gOvsSwitchContext == NULL || !NT_SUCCESS(status)) {
+        /* Reference the default datapath rather than reading gOvsSwitchContext
+         * bare: this runs on the IpHelper worker thread and can race detach. */
+        POVS_SWITCH_CONTEXT dpCtx = OvsAcquireSwitchContext();
+        if (dpCtx == NULL || !NT_SUCCESS(status)) {
+            if (dpCtx != NULL) {
+                OvsReleaseSwitchContext(dpCtx);
+            }
             goto error;
         }
-        NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, 0);
-        POVS_VPORT_ENTRY vport = OvsFindVportByHvNameW(gOvsSwitchContext,
+        NdisAcquireRWLockRead(dpCtx->dispatchLock, &lockState, 0);
+        POVS_VPORT_ENTRY vport = OvsFindVportByHvNameW(dpCtx,
                                                        interfaceName,
                                                        sizeof(WCHAR) *
                                                        wcslen(interfaceName));
@@ -672,7 +684,8 @@ OvsAddIpInterfaceNotification(PMIB_IPINTERFACE_ROW ipRow)
                           sizeof(instance->netCfgId));
             instance->portNo = vport->portNo;
         }
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(dpCtx->dispatchLock, &lockState);
+        OvsReleaseSwitchContext(dpCtx);
         RtlZeroMemory(&instance->internalRow, sizeof(MIB_IF_ROW2));
         RtlZeroMemory(&instance->internalIPRow, sizeof(MIB_IPINTERFACE_ROW));
         status = OvsGetIfEntry(&instance->netCfgId,
@@ -1970,6 +1983,12 @@ OvsStartIpHelper(PVOID data)
                     OvsCleanupFwdTable();
                 }
                 ExReleaseResourceLite(&ovsInstanceListLock);
+                /* portNo/netCfgInstanceId were copied to locals above, so the
+                 * request is done. Free it and break: without this break the
+                 * ADAPTER_DOWN request falls through into OvsHandleFwdRequest
+                 * and is reinterpreted as a (mistyped) forwarding request. */
+                OvsFreeMemoryWithTag(req, OVS_IPHELPER_POOL_TAG);
+                break;
             }
             case OVS_IP_HELPER_FWD_REQUEST:
                 OvsHandleFwdRequest(req);

--- a/datapath-windows/ovsext/PacketIO.c
+++ b/datapath-windows/ovsext/PacketIO.c
@@ -164,13 +164,10 @@ OvsSendNBLIngress(POVS_SWITCH_CONTEXT switchContext,
     ASSERT(switchContext->dataFlowState == OvsSwitchRunning);
 
     POVS_BUFFER_CONTEXT ctx = (POVS_BUFFER_CONTEXT)NET_BUFFER_LIST_CONTEXT_DATA_START(netBufferLists);
-    LONG refCount = 1, exchange = 0;
-    /* refCount/exchange are locals used only to atomically sample the shared
-     * ctx->refCount; the interlocked-on-local idiom is intentional. */
-#pragma warning(suppress: 28113)
-    InterlockedCompareExchange((LONG volatile *)&refCount, exchange, (LONG)ctx->refCount);
-#pragma warning(suppress: 28112)
-    if (refCount != exchange) {
+    /* Atomically read the shared refcount (it is otherwise mutated only via the
+     * Interlocked* family); defer the send if another reference is outstanding. */
+    LONG refCount = InterlockedOr((LONG volatile *)&ctx->refCount, 0);
+    if (refCount != 1) {
         InterlockedExchange((LONG volatile *)&ctx->sendFlags, sendFlags);
         InterlockedExchange16((SHORT volatile *)&ctx->pendingSend, 1);
         return;

--- a/datapath-windows/ovsext/PacketIO.c
+++ b/datapath-windows/ovsext/PacketIO.c
@@ -165,7 +165,11 @@ OvsSendNBLIngress(POVS_SWITCH_CONTEXT switchContext,
 
     POVS_BUFFER_CONTEXT ctx = (POVS_BUFFER_CONTEXT)NET_BUFFER_LIST_CONTEXT_DATA_START(netBufferLists);
     LONG refCount = 1, exchange = 0;
+    /* refCount/exchange are locals used only to atomically sample the shared
+     * ctx->refCount; the interlocked-on-local idiom is intentional. */
+#pragma warning(suppress: 28113)
     InterlockedCompareExchange((LONG volatile *)&refCount, exchange, (LONG)ctx->refCount);
+#pragma warning(suppress: 28112)
     if (refCount != exchange) {
         InterlockedExchange((LONG volatile *)&ctx->sendFlags, sendFlags);
         InterlockedExchange16((SHORT volatile *)&ctx->pendingSend, 1);

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -271,30 +271,34 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
          * per-operation (released before any IRP is pended), so this normally
          * drains well within the bound. The bound is a last-resort backstop
          * against a wedged accessor: it trades an unbounded driver-teardown hang
-         * for a bounded one, but if it ever fires, an accessor is still holding
-         * the context and proceeding to free it below is a use-after-free. A
-         * warning here therefore means a real missing reference-release to fix,
-         * not a benign timeout.
+         * for a bounded one. If it ever fires, an accessor is still holding the
+         * context, so freeing it would be a use-after-free -- in that case we
+         * deliberately LEAK the context instead (a bounded one-time leak; the
+         * switch is already unregistered and unreachable). A log here means a
+         * real missing reference-release to investigate, not a benign timeout.
+         *
+         * refCount is read with InterlockedOr(.., 0): other CPUs mutate it via
+         * the Interlocked* family, so a plain load could race or miss updates.
          */
         OvsUnregisterDatapath(switchContext);
 
         ULONG drainMs = 0;
-        KeMemoryBarrier();
-        while (switchContext->refCount > 1 &&
+        while (InterlockedOr((LONG volatile *)&switchContext->refCount, 0) > 1 &&
                drainMs < OVS_SWITCH_TEARDOWN_DRAIN_MAX_MS) {
             NdisMSleep(1000);  /* 1 ms */
             drainMs++;
-            KeMemoryBarrier();
-        }
-        if (switchContext->refCount > 1) {
-            OVS_LOG_ERROR("Switch %p teardown: %d reference(s) still held after "
-                          "%u ms; proceeding (USE-AFTER-FREE RISK -- a wedged "
-                          "accessor failed to release its reference)",
-                          switchContext, switchContext->refCount - 1, drainMs);
         }
 
-        OvsClearAllSwitchVports(switchContext);
-        OvsUninitSwitchContext(switchContext);
+        LONG heldRefs = InterlockedOr((LONG volatile *)&switchContext->refCount, 0);
+        if (heldRefs > 1) {
+            OVS_LOG_ERROR("Switch %p teardown: %d reference(s) still held after "
+                          "%u ms; leaking the context to avoid a use-after-free "
+                          "(a wedged accessor failed to release its reference)",
+                          switchContext, heldRefs - 1, drainMs);
+        } else {
+            OvsClearAllSwitchVports(switchContext);
+            OvsUninitSwitchContext(switchContext);
+        }
     }
     OVS_LOG_TRACE("Exit: deleted switch %p  dpNo: %d", switchContext, dpNo);
 }
@@ -460,6 +464,7 @@ OvsUninitSwitchContext(POVS_SWITCH_CONTEXT switchContext)
  *  Frees up the contents of and also the switch context.
  * --------------------------------------------------------------------------
  */
+_IRQL_requires_(PASSIVE_LEVEL)
 static VOID
 OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 {
@@ -489,7 +494,7 @@ OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
     OVS_LOG_TRACE("Exit: Delete switchContext: %p", switchContext);
 }
 
-_IRQL_requires_(PASSIVE_LEVEL)
+_Use_decl_annotations_
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 {
@@ -498,6 +503,13 @@ OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext)
     }
 
     if (InterlockedDecrement(&switchContext->refCount) == 0) {
+        /* OvsDeleteSwitchContext requires PASSIVE_LEVEL. Reaching refCount 0
+         * (the last release) only happens on the PASSIVE teardown path: the
+         * owning reference is held until OvsUninitSwitchContext, and the
+         * teardown drain waits for transient references (which may be released
+         * at DISPATCH, e.g. the WFP tunnel path) to drop first. So this call is
+         * always at PASSIVE despite this function being callable up to DISPATCH. */
+#pragma warning(suppress: 28118)
         OvsDeleteSwitchContext(switchContext);
     }
 }

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -268,8 +268,13 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
          * a transient reference (OvsAcquireSwitchContext / OvsAcquireDatapathBy*),
          * so refCount == 1 means nobody else is walking the lists, which makes
          * the lock-free OvsClearAllSwitchVports safe. All such references are
-         * per-operation (released before any IRP is pended), so this terminates;
-         * the bound is a backstop against a wedged accessor (logged, not hung).
+         * per-operation (released before any IRP is pended), so this normally
+         * drains well within the bound. The bound is a last-resort backstop
+         * against a wedged accessor: it trades an unbounded driver-teardown hang
+         * for a bounded one, but if it ever fires, an accessor is still holding
+         * the context and proceeding to free it below is a use-after-free. A
+         * warning here therefore means a real missing reference-release to fix,
+         * not a benign timeout.
          */
         OvsUnregisterDatapath(switchContext);
 
@@ -282,9 +287,10 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
             KeMemoryBarrier();
         }
         if (switchContext->refCount > 1) {
-            OVS_LOG_WARN("Switch %p teardown proceeding with %d reference(s) "
-                         "still held after %u ms", switchContext,
-                         switchContext->refCount - 1, drainMs);
+            OVS_LOG_ERROR("Switch %p teardown: %d reference(s) still held after "
+                          "%u ms; proceeding (USE-AFTER-FREE RISK -- a wedged "
+                          "accessor failed to release its reference)",
+                          switchContext, switchContext->refCount - 1, drainMs);
         }
 
         OvsClearAllSwitchVports(switchContext);

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -282,11 +282,16 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
          */
         OvsUnregisterDatapath(switchContext);
 
-        ULONG drainMs = 0;
+        /* Bound the drain by ELAPSED time, not iteration count: NdisMSleep
+         * rounds up to the system tick (~15 ms), so counting iterations would
+         * make the real timeout many times the intended bound and the logged
+         * duration inaccurate. KeQueryInterruptTime() is monotonic 100ns units. */
+        ULONG64 startTime = KeQueryInterruptTime();
+        ULONG elapsedMs = 0;
         while (InterlockedOr((LONG volatile *)&switchContext->refCount, 0) > 1 &&
-               drainMs < OVS_SWITCH_TEARDOWN_DRAIN_MAX_MS) {
-            NdisMSleep(1000);  /* 1 ms */
-            drainMs++;
+               elapsedMs < OVS_SWITCH_TEARDOWN_DRAIN_MAX_MS) {
+            NdisMSleep(1000);  /* >= 1 ms (rounded up to the system tick) */
+            elapsedMs = (ULONG)((KeQueryInterruptTime() - startTime) / 10000ULL);
         }
 
         LONG heldRefs = InterlockedOr((LONG volatile *)&switchContext->refCount, 0);
@@ -294,7 +299,7 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
             OVS_LOG_ERROR("Switch %p teardown: %d reference(s) still held after "
                           "%u ms; leaking the context to avoid a use-after-free "
                           "(a wedged accessor failed to release its reference)",
-                          switchContext, heldRefs - 1, drainMs);
+                          switchContext, heldRefs - 1, elapsedMs);
         } else {
             OvsClearAllSwitchVports(switchContext);
             OvsUninitSwitchContext(switchContext);

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -483,6 +483,7 @@ OvsDeleteSwitchContext(POVS_SWITCH_CONTEXT switchContext)
     OVS_LOG_TRACE("Exit: Delete switchContext: %p", switchContext);
 }
 
+_IRQL_requires_(PASSIVE_LEVEL)
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext)
 {

--- a/datapath-windows/ovsext/Switch.c
+++ b/datapath-windows/ovsext/Switch.c
@@ -56,6 +56,14 @@ POVS_SWITCH_CONTEXT gOvsDatapaths[OVS_MAX_DATAPATHS];
 NDIS_SPIN_LOCK     gOvsDatapathLock;
 
 /*
+ * Upper bound (milliseconds) that OvsDeleteSwitch waits for in-flight switch
+ * references to drain before tearing down the vport lists. References are all
+ * per-operation and bounded, so the drain normally completes well within this;
+ * the cap only prevents a wedged accessor from hanging driver teardown.
+ */
+#define OVS_SWITCH_TEARDOWN_DRAIN_MAX_MS 10000
+
+/*
  * The upcall pid hash maps a globally-unique handle pid to its open instance.
  * Pids are allocated from a single driver-wide counter, so the hash is a
  * driver-global resource (lifetime = driver load), not per-switch: this keeps
@@ -250,8 +258,36 @@ OvsDeleteSwitch(POVS_SWITCH_CONTEXT switchContext)
     if (switchContext)
     {
         dpNo = switchContext->dpNo;
-        OvsClearAllSwitchVports(switchContext);
+
+        /*
+         * Remove the switch from the datapath registry FIRST, so no new path
+         * (userspace IOCTL lookup, IpHelper route walk, WFP tunnel classify)
+         * can reach it once teardown begins. Then wait for any in-flight
+         * reference holders to drain back to the owning baseline (refCount == 1)
+         * before tearing down the vport lists: every cross-thread accessor takes
+         * a transient reference (OvsAcquireSwitchContext / OvsAcquireDatapathBy*),
+         * so refCount == 1 means nobody else is walking the lists, which makes
+         * the lock-free OvsClearAllSwitchVports safe. All such references are
+         * per-operation (released before any IRP is pended), so this terminates;
+         * the bound is a backstop against a wedged accessor (logged, not hung).
+         */
         OvsUnregisterDatapath(switchContext);
+
+        ULONG drainMs = 0;
+        KeMemoryBarrier();
+        while (switchContext->refCount > 1 &&
+               drainMs < OVS_SWITCH_TEARDOWN_DRAIN_MAX_MS) {
+            NdisMSleep(1000);  /* 1 ms */
+            drainMs++;
+            KeMemoryBarrier();
+        }
+        if (switchContext->refCount > 1) {
+            OVS_LOG_WARN("Switch %p teardown proceeding with %d reference(s) "
+                         "still held after %u ms", switchContext,
+                         switchContext->refCount - 1, drainMs);
+        }
+
+        OvsClearAllSwitchVports(switchContext);
         OvsUninitSwitchContext(switchContext);
     }
     OVS_LOG_TRACE("Exit: deleted switch %p  dpNo: %d", switchContext, dpNo);

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -246,10 +246,14 @@ POVS_SWITCH_CONTEXT
 OvsAcquireSwitchContext(VOID);
 
 /*
- * Must run at PASSIVE_LEVEL: when the last reference drops, the context is
- * freed, which releases NDIS RW and spin locks that require PASSIVE_LEVEL.
+ * Drops a reference. When the last reference drops the context is freed
+ * (OvsDeleteSwitchContext), which releases NDIS RW/spin locks and so requires
+ * PASSIVE_LEVEL. The release itself is callable up to DISPATCH_LEVEL: transient
+ * DISPATCH releases (e.g. the WFP tunnel path) never hold the last reference --
+ * the owning reference plus the teardown drain ensure the final release, and
+ * thus the free, only happens at PASSIVE_LEVEL.
  */
-_IRQL_requires_(PASSIVE_LEVEL)
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 OvsReleaseSwitchContext(POVS_SWITCH_CONTEXT switchContext);
 

--- a/datapath-windows/ovsext/Switch.h
+++ b/datapath-windows/ovsext/Switch.h
@@ -236,6 +236,9 @@ OvsReleaseDatapath(OVS_DATAPATH *datapath,
                    LOCK_STATE_EX *lockState)
 {
     ASSERT(datapath);
+    /* PREfast cannot match the NDIS RW-lock handle released here to the lock
+     * identity named in the _Requires_lock_held_ annotation above. */
+#pragma warning(suppress: 26110)
     NdisReleaseRWLock(datapath->lock, lockState);
 }
 

--- a/datapath-windows/ovsext/Tunnel.c
+++ b/datapath-windows/ovsext/Tunnel.c
@@ -45,7 +45,8 @@ extern POVS_SWITCH_CONTEXT gOvsSwitchContext;
 
 static NTSTATUS
 OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
-                              OVS_TUNNEL_PENDED_PACKET *packet);
+                              OVS_TUNNEL_PENDED_PACKET *packet,
+                              POVS_SWITCH_CONTEXT switchContext);
 
 NTSTATUS
 OvsTunnelNotify(FWPS_CALLOUT_NOTIFY_TYPE notifyType,
@@ -68,6 +69,7 @@ OvsTunnelAnalyzePacket(OVS_TUNNEL_PENDED_PACKET *packet)
     NET_BUFFER_LIST *copiedNBL = NULL;
     NET_BUFFER *netBuffer;
     NDIS_STATUS ndisStatus;
+    POVS_SWITCH_CONTEXT switchContext = NULL;
 
     /*
      * For inbound net buffer list, we can assume it contains only one
@@ -79,6 +81,18 @@ OvsTunnelAnalyzePacket(OVS_TUNNEL_PENDED_PACKET *packet)
     /* Drop the packet from the host stack */
     packet->classifyOut->actionType = FWP_ACTION_BLOCK;
     packet->classifyOut->rights &= ~FWPS_RIGHT_ACTION_WRITE;
+
+    /*
+     * This datagram-data callout is host-global and has no Hyper-V switch
+     * association, so it binds to the default datapath. Take a reference on it
+     * (instead of reading gOvsSwitchContext bare) so the context and its NBL
+     * pool cannot be torn down underneath the decap/inject below; the teardown
+     * drain in OvsDeleteSwitch waits for this reference.
+     */
+    switchContext = OvsAcquireSwitchContext();
+    if (switchContext == NULL) {
+        return STATUS_SUCCESS;
+    }
 
     /* Adjust the net buffer list offset to the start of the IP header */
     ndisStatus = NdisRetreatNetBufferDataStart(netBuffer,
@@ -92,7 +106,7 @@ OvsTunnelAnalyzePacket(OVS_TUNNEL_PENDED_PACKET *packet)
 
     /* Note that the copy will inherit the original net buffer list's offset */
     packetLength = NET_BUFFER_DATA_LENGTH(netBuffer);
-    copiedNBL = OvsAllocateVariableSizeNBL(gOvsSwitchContext, packetLength,
+    copiedNBL = OvsAllocateVariableSizeNBL(switchContext, packetLength,
                                            OVS_DEFAULT_HEADROOM_SIZE);
 
     if (copiedNBL == NULL) {
@@ -107,17 +121,18 @@ OvsTunnelAnalyzePacket(OVS_TUNNEL_PENDED_PACKET *packet)
     }
 
     status = OvsInjectPacketThroughActions(copiedNBL,
-                                           packet);
+                                           packet, switchContext);
     goto analyzeDone;
 
     /* Undo the adjustment on the original net buffer list */
 analyzeFreeNBL:
-    OvsCompleteNBL(gOvsSwitchContext, copiedNBL, TRUE);
+    OvsCompleteNBL(switchContext, copiedNBL, TRUE);
 analyzeDone:
     NdisAdvanceNetBufferDataStart(netBuffer,
                                   packet->transportHeaderSize + packet->ipHeaderSize,
                                   FALSE,
                                   NULL);
+    OvsReleaseSwitchContext(switchContext);
     return status;
 }
 
@@ -202,7 +217,8 @@ Exit:
 
 static NTSTATUS
 OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
-                              OVS_TUNNEL_PENDED_PACKET *packet)
+                              OVS_TUNNEL_PENDED_PACKET *packet,
+                              POVS_SWITCH_CONTEXT switchContext)
 {
     NTSTATUS status;
     OvsIPTunnelKey tunKey = {0};
@@ -224,9 +240,9 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
      * need a cross-datapath tunnel-vport registry keyed by the outer tunnel
      * identity (e.g. VNI), since the callout can only see the outer key.
      */
-    OVS_DATAPATH *datapath = &gOvsSwitchContext->datapath;
+    OVS_DATAPATH *datapath = &switchContext->datapath;
 
-    ASSERT(gOvsSwitchContext);
+    ASSERT(switchContext);
 
     /* Fill the tunnel key */
     status = OvsSlowPathDecapVxlan(pNbl, &tunKey);
@@ -253,7 +269,7 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
     }
 
     InitializeListHead(&missedPackets);
-    OvsInitCompletionList(&completionList, gOvsSwitchContext,
+    OvsInitCompletionList(&completionList, switchContext,
                           sendCompleteFlags);
 
     {
@@ -277,14 +293,14 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
         curNb = NET_BUFFER_LIST_FIRST_NB(pNbl);
         ASSERT(curNb->Next == NULL);
 
-        NdisAcquireRWLockRead(gOvsSwitchContext->dispatchLock, &lockState, dispatch);
+        NdisAcquireRWLockRead(switchContext->dispatchLock, &lockState, dispatch);
 
         /* Lock the flowtable for the duration of accessing the flow */
         OvsAcquireDatapathRead(datapath, &dpLockState, NDIS_RWL_AT_DISPATCH_LEVEL);
 
         SendFlags |= NDIS_SEND_FLAGS_DISPATCH_LEVEL;
 
-        vport = OvsFindTunnelVportByDstPortAndType(gOvsSwitchContext,
+        vport = OvsFindTunnelVportByDstPortAndType(switchContext,
                                                    htons(tunKey.dst_port),
                                                    OVS_VPORT_TYPE_VXLAN);
 
@@ -307,7 +323,7 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
             OvsFlowUsed(flow, pNbl, &layers);
             datapath->hits++;
 
-            OvsActionsExecute(gOvsSwitchContext, &completionList, pNbl,
+            OvsActionsExecute(switchContext, &completionList, pNbl,
                               portNo, SendFlags, &key, &hash, &layers,
                               flow->actions, flow->actionsLen);
 
@@ -318,7 +334,7 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
             datapath->misses++;
             elem = OvsCreateQueueNlPacket(NULL, 0, OVS_PACKET_CMD_MISS,
                                           vport, &key, NULL, pNbl, curNb,
-                                          TRUE, &layers, gOvsSwitchContext->dpNo);
+                                          TRUE, &layers, switchContext->dpNo);
             if (elem) {
                 /* Complete the packet since it was copied to user buffer. */
                 InsertTailList(&missedPackets, &elem->link);
@@ -329,7 +345,7 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
             goto unlockAndDrop;
         }
 
-        NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     }
 
@@ -337,9 +353,9 @@ OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
 
 unlockAndDrop:
     OvsReleaseDatapath(datapath, &dpLockState);
-    NdisReleaseRWLock(gOvsSwitchContext->dispatchLock, &lockState);
+    NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 dropit:
-    pNbl = OvsCompleteNBL(gOvsSwitchContext, pNbl, TRUE);
+    pNbl = OvsCompleteNBL(switchContext, pNbl, TRUE);
     ASSERT(pNbl == NULL);
     return status;
 }

--- a/datapath-windows/ovsext/Tunnel.c
+++ b/datapath-windows/ovsext/Tunnel.c
@@ -215,6 +215,9 @@ Exit:
 }
 
 
+/* WFP VXLAN-decap worker on the tunnel callout path, bounded call depth; the
+ * forwarding context and key structs on the frame are acceptable here. */
+#pragma warning(suppress: 6262)
 static NTSTATUS
 OvsInjectPacketThroughActions(PNET_BUFFER_LIST pNbl,
                               OVS_TUNNEL_PENDED_PACKET *packet,

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -73,6 +73,9 @@ _Releases_lock_(gOvsPidHashLock)
 static __inline VOID
 OvsReleasePidHashLock()
 {
+    /* NdisReleaseSpinLock resolves to KeReleaseSpinLock on the lock's inner
+     * SpinLock member, which PREfast cannot match to the annotated lock. */
+#pragma warning(suppress: 26110)
     NdisReleaseSpinLock(&gOvsPidHashLock);
 }
 
@@ -416,6 +419,9 @@ _MapNlAttrToOvsPktExec(PNL_MSG_HDR nlMsgHdr, PNL_ATTR *nlAttrs,
     }
 }
 
+/* PASSIVE_LEVEL OVS_PACKET_CMD_EXECUTE IOCTL handler with a bounded call depth;
+ * the OvsFlowKey and header-info structs on the frame are acceptable here. */
+#pragma warning(suppress: 6262)
 NTSTATUS
 OvsExecuteDpIoctl(OvsPacketExecute *execute, POVS_SWITCH_CONTEXT switchContext)
 {

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -54,6 +54,7 @@
  * filter threads. */
 typedef struct _OVS_TUNFLT_INIT_CONTEXT {
     POVS_SWITCH_CONTEXT switchContext;
+    UINT32 dpNo;
     UINT32 outputLength;
     PVOID outputBuffer;
     PVOID inputBuffer;
@@ -1131,6 +1132,9 @@ OvsInitTunnelVport(PVOID userContext,
         tunnelContext->outputBuffer = usrParamsCtx->outputBuffer;
         tunnelContext->outputLength = usrParamsCtx->outputLength;
         tunnelContext->vport = vport;
+        /* Record the originating datapath so the async completion attaches the
+         * vport to the datapath this create targeted, not the default one. */
+        tunnelContext->dpNo = usrParamsCtx->switchContext->dpNo;
 
         status = OvsInitVxlanTunnel(usrParamsCtx->irp,
                                     vport,
@@ -2868,10 +2872,12 @@ OvsTunnelVportPendingInit(PVOID context,
     NL_ERROR nlError = NL_ERROR_SUCCESS;
     BOOLEAN error = TRUE;
     /* This async callback runs on a tunnel-filter worker thread and can race
-     * switch detach; reference the default datapath instead of reading
-     * gOvsSwitchContext bare, and hold its dispatchLock while mutating the
-     * vport lists (the create path holds it too). */
-    POVS_SWITCH_CONTEXT switchContext = OvsAcquireSwitchContext();
+     * switch detach; reference the originating datapath (the one the create
+     * targeted) and hold its dispatchLock while mutating the vport lists (the
+     * create path holds it too). If that datapath has detached meanwhile,
+     * OvsAcquireDatapathByNumber returns NULL and we fail cleanly below. */
+    POVS_SWITCH_CONTEXT switchContext =
+        OvsAcquireDatapathByNumber(tunnelContext->dpNo);
     LOCK_STATE_EX lockState;
     BOOLEAN locked = FALSE;
 

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1345,9 +1345,11 @@ OvsRemoveAndDeleteVport(PVOID usrParamsContext,
         if (hvDelete && vport->isAbsentOnHv == FALSE) {
             switchContext->countInternalVports--;
             ASSERT(switchContext->countInternalVports >= 0);
-            /* Runs under dispatchLock on the vport-delete path, or single-threaded
-             * during switch teardown; PREfast cannot model the lock across these
-             * mixed callers (genuine false positive). */
+            /* On the vport-delete path dispatchLock is held; during switch
+             * teardown (OvsClearAllSwitchVports) it is NOT held, but the
+             * teardown reference drain guarantees no concurrent accessor, so the
+             * unsynchronized access is safe there. PREfast cannot model either
+             * case across these mixed callers. */
 #pragma warning(suppress: 26110)
             OvsUnBindVportWithIpHelper(vport, switchContext);
         }
@@ -1492,7 +1494,9 @@ OvsRemoveTunnelVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
      * thread) or a failure status (the callback already ran synchronously via
      * OvsTunnelFilterCompleteRequest). So drop the reference here only on the
      * STATUS_SUCCESS no-callback paths -- releasing on any non-success status
-     * would double-release the reference the callback already dropped.
+     * would double-release the reference the callback already dropped. On those
+     * same no-callback paths the callback also never frees tunnelContext, so it
+     * must be freed here too.
      */
     NTSTATUS status;
     InterlockedIncrement(&switchContext->refCount);
@@ -1500,6 +1504,7 @@ OvsRemoveTunnelVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                                    tunnelContext);
     if (status == STATUS_SUCCESS) {
         OvsReleaseSwitchContext(switchContext);
+        OvsFreeMemoryWithTag(tunnelContext, OVS_VPORT_POOL_TAG);
     }
     return status;
 }

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -334,6 +334,9 @@ HvDeletePort(POVS_SWITCH_CONTEXT switchContext,
  * to post an event to netdev-windows.c.
  * --------------------------------------------------------------------------
  */
+/* PASSIVE_LEVEL NDIS NIC-create callback with a bounded call depth; the
+ * IF_COUNTED_STRING friendly name on the frame is acceptable here. */
+#pragma warning(suppress: 6262)
 NDIS_STATUS
 HvCreateNic(POVS_SWITCH_CONTEXT switchContext,
             PNDIS_SWITCH_NIC_PARAMETERS nicParam)
@@ -1342,6 +1345,10 @@ OvsRemoveAndDeleteVport(PVOID usrParamsContext,
         if (hvDelete && vport->isAbsentOnHv == FALSE) {
             switchContext->countInternalVports--;
             ASSERT(switchContext->countInternalVports >= 0);
+            /* Runs under dispatchLock on the vport-delete path, or single-threaded
+             * during switch teardown; PREfast cannot model the lock across these
+             * mixed callers (genuine false positive). */
+#pragma warning(suppress: 26110)
             OvsUnBindVportWithIpHelper(vport, switchContext);
         }
         hvSwitchPort = TRUE;
@@ -2276,6 +2283,7 @@ OvsGetVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
 
 }
 
+_Requires_lock_held_(switchContext->dispatchLock)
 static UINT32
 OvsComputeVportNo(POVS_SWITCH_CONTEXT switchContext)
 {
@@ -2539,6 +2547,9 @@ OvsNewVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
                  vport->ovsType);
 
 Cleanup:
+    /* dispatchLock is acquired before any goto Cleanup; PREfast cannot prove it
+     * is held on every path to this shared label (genuine false positive). */
+#pragma warning(suppress: 26110)
     NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     if ((nlError != NL_ERROR_SUCCESS) && (nlError != NL_ERROR_PENDING)) {
@@ -2763,6 +2774,9 @@ OvsDeleteVportCmdHandler(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
     }
 
 Cleanup:
+    /* dispatchLock is acquired before any goto Cleanup; PREfast cannot prove it
+     * is held on every path to this shared label (genuine false positive). */
+#pragma warning(suppress: 26110)
     NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
 
     if ((nlError != NL_ERROR_SUCCESS) && (nlError != NL_ERROR_PENDING)) {

--- a/datapath-windows/ovsext/Vport.c
+++ b/datapath-windows/ovsext/Vport.c
@@ -1470,8 +1470,31 @@ OvsRemoveTunnelVport(POVS_USER_PARAMS_CONTEXT usrParamsCtx,
         irp = usrParamsCtx->irp;
     }
 
-    return OvsCleanupVxlanTunnel(irp, vport, OvsTunnelVportPendingRemove,
-                                 tunnelContext);
+    /*
+     * Reference the switch context on behalf of the asynchronous remove
+     * callback (OvsTunnelVportPendingRemove), which dereferences
+     * tunnelContext->switchContext after this function returns. Holding the
+     * reference keeps the context (and its dispatchLock) alive until the tunnel
+     * filter delete completes, and makes the OvsDeleteSwitch teardown drain wait
+     * for that completion instead of freeing the context under it.
+     *
+     * The callback runs (and releases this reference) on every path except
+     * OvsCleanupVxlanTunnel's inline no-op returns (no VXLAN filter to remove),
+     * which return STATUS_SUCCESS without queuing a request. When a delete is
+     * queued it returns STATUS_PENDING (the callback runs later on the tunnel
+     * thread) or a failure status (the callback already ran synchronously via
+     * OvsTunnelFilterCompleteRequest). So drop the reference here only on the
+     * STATUS_SUCCESS no-callback paths -- releasing on any non-success status
+     * would double-release the reference the callback already dropped.
+     */
+    NTSTATUS status;
+    InterlockedIncrement(&switchContext->refCount);
+    status = OvsCleanupVxlanTunnel(irp, vport, OvsTunnelVportPendingRemove,
+                                   tunnelContext);
+    if (status == STATUS_SUCCESS) {
+        OvsReleaseSwitchContext(switchContext);
+    }
+    return status;
 }
 
 /*
@@ -2805,6 +2828,9 @@ OvsTunnelVportPendingRemove(PVOID context,
     OvsFreeMemoryWithTag(vport, OVS_VPORT_POOL_TAG);
 
     NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
+
+    /* Release the reference taken in OvsRemoveTunnelVport for this callback. */
+    OvsReleaseSwitchContext(switchContext);
 }
 
 static VOID
@@ -2822,10 +2848,21 @@ OvsTunnelVportPendingInit(PVOID context,
     UINT32 portType = 0;
     NL_ERROR nlError = NL_ERROR_SUCCESS;
     BOOLEAN error = TRUE;
+    /* This async callback runs on a tunnel-filter worker thread and can race
+     * switch detach; reference the default datapath instead of reading
+     * gOvsSwitchContext bare, and hold its dispatchLock while mutating the
+     * vport lists (the create path holds it too). */
+    POVS_SWITCH_CONTEXT switchContext = OvsAcquireSwitchContext();
+    LOCK_STATE_EX lockState;
+    BOOLEAN locked = FALSE;
 
     do {
         if (!NT_SUCCESS(status)) {
             nlError = NlMapStatusToNlErr(status);
+            break;
+        }
+        if (switchContext == NULL) {
+            nlError = NL_ERROR_NODEV;
             break;
         }
 
@@ -2874,6 +2911,9 @@ OvsTunnelVportPendingInit(PVOID context,
          */
         vport->isAbsentOnHv = TRUE;
 
+        NdisAcquireRWLockWrite(switchContext->dispatchLock, &lockState, 0);
+        locked = TRUE;
+
         if (vportAttrs[OVS_VPORT_ATTR_PORT_NO] != NULL) {
             /*
              * XXX: when we implement the limit for OVS port number to be
@@ -2884,7 +2924,7 @@ OvsTunnelVportPendingInit(PVOID context,
                 NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_PORT_NO]);
         } else {
             vport->portNo =
-                OvsComputeVportNo(gOvsSwitchContext);
+                OvsComputeVportNo(switchContext);
             if (vport->portNo == OVS_DPPORT_NUMBER_INVALID) {
                 nlError = NL_ERROR_NOMEM;
                 break;
@@ -2908,19 +2948,23 @@ OvsTunnelVportPendingInit(PVOID context,
         vport->upcallPid =
             NlAttrGetU32(vportAttrs[OVS_VPORT_ATTR_UPCALL_PID]);
 
-        status = InitOvsVportCommon(gOvsSwitchContext, vport);
+        status = InitOvsVportCommon(switchContext, vport);
         ASSERT(status == STATUS_SUCCESS);
 
         OvsCreateMsgFromVport(vport,
                               msgIn,
                               msgOut,
                               tunnelContext->outputLength,
-                              gOvsSwitchContext->dpNo);
+                              switchContext->dpNo);
 
         *replyLen = msgOut->nlMsg.nlmsgLen;
 
         error = FALSE;
     } while (error);
+
+    if (locked) {
+        NdisReleaseRWLock(switchContext->dispatchLock, &lockState);
+    }
 
     if (error) {
         POVS_MESSAGE_ERROR msgError = (POVS_MESSAGE_ERROR)msgOut;
@@ -2931,6 +2975,10 @@ OvsTunnelVportPendingInit(PVOID context,
         ASSERT(msgError);
         NlBuildErrorMsg(msgIn, msgError, nlError, replyLen);
         ASSERT(*replyLen != 0);
+    }
+
+    if (switchContext != NULL) {
+        OvsReleaseSwitchContext(switchContext);
     }
 }
 


### PR DESCRIPTION
Fixes an intermittent shutdown hang / use-after-free in the Hyper-V forwarding
extension caused by unsynchronized switch teardown, plus two IpHelper request
bugs, and brings the Code Analysis build to zero warnings.

## Switch teardown
`OvsDeleteSwitch` now unregisters the datapath *before* clearing the vport lists,
then waits (bounded) for in-flight switch-context references to drain before the
lock-free teardown. Every cross-thread accessor — the IpHelper worker's
route/instance lookups, the WFP VXLAN-decap callout, and the asynchronous tunnel
filter create/remove callbacks — now takes a counted reference on the switch
context instead of dereferencing the global bare, so teardown can no longer free
the context (or its dispatchLock) underneath them.

## IpHelper request handling
- Add the missing `break` so an `INTERNAL_ADAPTER_DOWN` request is not
  reinterpreted as a forwarding request, and free it correctly.
- Copy the full `MIB_IPINTERFACE_ROW` instead of a pointer-sized prefix.

## Static analysis
Brings the `Win10Analyze` (Code Analysis) configuration to zero warnings; the
`Win10Debug` `/WX` build stays clean.

Validated on the kernel-dev VM: clean stop/detach (no hang or bugcheck), driver
re-attach, and guest-to-guest forwarding through the datapath.