### PR TITLE
datapath-windows: harden packet hot-path input validation

### DIFF
--- a/datapath-windows/ovsext/Conntrack-ftp.c
+++ b/datapath-windows/ovsext/Conntrack-ftp.c
@@ -208,6 +208,10 @@ OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
         paren = strchr(ftpMsg, '|');
         if (paren) {
             req = paren + 3;
+            if (req >= ftpMsg + sizeof(ftpMsg)) {
+                /* The "|||" prefix ran off the end of the buffer. */
+                return NDIS_STATUS_INVALID_PACKET;
+            }
         } else {
             /* Not a valid EPSV packet. */
             return NDIS_STATUS_INVALID_PACKET;
@@ -269,10 +273,12 @@ OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
             if (reqLen >= sizeof(ftpStr)) {
                 return NDIS_STATUS_SUCCESS;
             }
-            RtlCopyMemory(ftpStr, req, reqLen);
-            ftpStrEnd = ftpStr + sizeof(ftpStr);
-            /* Scan for the leading '|'. The trailing zero-fill is not '|', so the
-             * scan must stop at the buffer end or it reads past ftpStr. */
+            /* Copy the NUL too (reqLen < sizeof(ftpStr)) and bound the scans to
+             * the actual payload, so they cannot run past it regardless of the
+             * zero-fill above. */
+            RtlCopyMemory(ftpStr, req, reqLen + 1);
+            ftpStrEnd = ftpStr + reqLen;
+            /* Scan for the leading '|', bounded by the copied payload. */
             for (curHdr = ftpStr; curHdr < ftpStrEnd && *curHdr != '|'; curHdr++);
             if (curHdr >= ftpStrEnd) {
                 /* No '|' delimiter in a malformed payload. */
@@ -316,7 +322,9 @@ OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
                 index++;
             } while (1);
 
-            if (index < 2) { /* Not valid packet due to less than three parameter */
+            if (index < 3) {
+                /* Need all three fields (family, address, port); a truncated
+                 * EPRT (e.g. an unterminated port field) leaves port == 0. */
                 return NDIS_STATUS_SUCCESS;
             }
             serverIp.ipv6 = key->ipv6Key.ipv6Dst;

--- a/datapath-windows/ovsext/Conntrack-ftp.c
+++ b/datapath-windows/ovsext/Conntrack-ftp.c
@@ -31,6 +31,18 @@ typedef enum FTP_TYPE {
     FTP_EXTEND_TYPE_ACTIVE
 } FTP_TYPE;
 
+/* ASCII-only uppercase. The CRT toupper() must not be used here: on Windows
+ * kernels it routes through RtlAnsiCharToUnicodeChar/RtlpIsUtf8Process, which
+ * touches pageable per-process locale state. The conntrack ALG runs in the
+ * datapath at DISPATCH_LEVEL, where such a page fault bugchecks the box
+ * (IRQL_NOT_LESS_OR_EQUAL). FTP control keywords are pure ASCII, so a plain
+ * 'a'..'z' fold is both correct and safe at any IRQL. */
+static __inline char
+OvsAsciiToUpper(char c)
+{
+    return (c >= 'a' && c <= 'z') ? (char)(c - ('a' - 'A')) : c;
+}
+
 static __inline UINT32
 OvsStrncmp(const char *s1, const char *s2, size_t n)
 {
@@ -39,7 +51,8 @@ OvsStrncmp(const char *s1, const char *s2, size_t n)
     }
 
     const char *s2end = s2 + n;
-    while (s2 < s2end && *s2 != '\0' && toupper(*s1) == toupper(*s2)) {
+    while (s2 < s2end && *s2 != '\0'
+           && OvsAsciiToUpper(*s1) == OvsAsciiToUpper(*s2)) {
         s1++, s2++;
     }
 
@@ -47,7 +60,7 @@ OvsStrncmp(const char *s1, const char *s2, size_t n)
         return 0;
     }
 
-    return (UINT32)(toupper(*s1) - toupper(*s2));
+    return (UINT32)(OvsAsciiToUpper(*s1) - OvsAsciiToUpper(*s2));
 }
 
 static __inline VOID

--- a/datapath-windows/ovsext/Conntrack-ftp.c
+++ b/datapath-windows/ovsext/Conntrack-ftp.c
@@ -244,21 +244,41 @@ OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
              * **/
             char *curHdr = NULL;
             char *nextHdr = NULL;
+            char *ftpStrEnd = NULL;
+            size_t reqLen = 0;
             int index = 0;
             int isIpv6AddressFamily = 0;
             char ftpStr[512] = {0x00};
 
-            RtlCopyMemory(ftpStr, req, strlen(req));
-            for (curHdr = ftpStr; *curHdr != '|'; curHdr++);
-            curHdr = curHdr + 1;;
+            /* 'req' is NUL-terminated inside ftpMsg[256], so it fits in ftpStr;
+             * bail defensively if a future caller passes something longer. */
+            reqLen = strlen(req);
+            if (reqLen >= sizeof(ftpStr)) {
+                return NDIS_STATUS_SUCCESS;
+            }
+            RtlCopyMemory(ftpStr, req, reqLen);
+            ftpStrEnd = ftpStr + sizeof(ftpStr);
+            /* Scan for the leading '|'. The trailing zero-fill is not '|', so the
+             * scan must stop at the buffer end or it reads past ftpStr. */
+            for (curHdr = ftpStr; curHdr < ftpStrEnd && *curHdr != '|'; curHdr++);
+            if (curHdr >= ftpStrEnd) {
+                /* No '|' delimiter in a malformed payload. */
+                return NDIS_STATUS_SUCCESS;
+            }
+            curHdr = curHdr + 1;
             do {
                 /** index == 0 parse address family,
                  *  index == 1 parse address,
                  *  index == 2 parse port **/
-                for (nextHdr = curHdr; *nextHdr != '|'; nextHdr++);
+                for (nextHdr = curHdr;
+                     nextHdr < ftpStrEnd && *nextHdr != '|'; nextHdr++);
+                if (nextHdr >= ftpStrEnd) {
+                    /* Field not terminated within the buffer. */
+                    break;
+                }
                 *nextHdr = '\0';
 
-                if (*curHdr == '0' || !curHdr || index > 2) {
+                if (!curHdr || *curHdr == '0' || index > 2) {
                     break;
                 }
 

--- a/datapath-windows/ovsext/Conntrack-ftp.c
+++ b/datapath-windows/ovsext/Conntrack-ftp.c
@@ -207,11 +207,14 @@ OvsCtHandleFtp(PNET_BUFFER_LIST curNbl, OvsFlowKey *key,
         char *paren;
         paren = strchr(ftpMsg, '|');
         if (paren) {
-            req = paren + 3;
-            if (req >= ftpMsg + sizeof(ftpMsg)) {
-                /* The "|||" prefix ran off the end of the buffer. */
+            /* Bound the offset before forming the pointer: paren + 3 could
+             * otherwise be more than one-past-the-end of ftpMsg, which is
+             * undefined behavior even when only compared. */
+            size_t off = (size_t)(paren - ftpMsg) + 3;
+            if (off >= sizeof(ftpMsg)) {
                 return NDIS_STATUS_INVALID_PACKET;
             }
+            req = ftpMsg + off;
         } else {
             /* Not a valid EPSV packet. */
             return NDIS_STATUS_INVALID_PACKET;

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -1498,10 +1498,18 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                         hasMaxIp = TRUE;
                         break;
                     case OVS_NAT_ATTR_PROTO_MIN:
+                        /* Policy-less walk (see IP_MIN above): NlAttrGetU16 only
+                         * ASSERTs the size, so guard the read for non-DBG. */
+                        if (NlAttrGetSize(natAttr) < sizeof(UINT16)) {
+                            return NDIS_STATUS_INVALID_PARAMETER;
+                        }
                         natActionInfo.minPort = NlAttrGetU16(natAttr);
                         hasMinPort = TRUE;
                         break;
                     case OVS_NAT_ATTR_PROTO_MAX:
+                        if (NlAttrGetSize(natAttr) < sizeof(UINT16)) {
+                            return NDIS_STATUS_INVALID_PARAMETER;
+                        }
                         natActionInfo.maxPort = NlAttrGetU16(natAttr);
                         hasMaxPort = TRUE;
                         break;

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -1477,11 +1477,22 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                                 ? NAT_ACTION_SRC : NAT_ACTION_DST);
                         break;
                     case OVS_NAT_ATTR_IP_MIN:
+                        /* This nested attribute is walked policy-less, so the
+                         * size is user-controlled; reject anything that would
+                         * overflow the address union (4 = IPv4, 16 = IPv6). */
+                        if (NlAttrGetSize(natAttr) >
+                                sizeof(natActionInfo.minAddr)) {
+                            return NDIS_STATUS_INVALID_PARAMETER;
+                        }
                         memcpy(&natActionInfo.minAddr,
                                 NlAttrData(natAttr), NlAttrGetSize(natAttr));
                         hasMinIp = TRUE;
                         break;
                     case OVS_NAT_ATTR_IP_MAX:
+                        if (NlAttrGetSize(natAttr) >
+                                sizeof(natActionInfo.maxAddr)) {
+                            return NDIS_STATUS_INVALID_PARAMETER;
+                        }
                         memcpy(&natActionInfo.maxAddr,
                                 NlAttrData(natAttr), NlAttrGetSize(natAttr));
                         hasMaxIp = TRUE;

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -1426,15 +1426,26 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
     NL_NESTED_FOR_EACH (ctAttr, left, a) {
         switch(NlAttrType(ctAttr)) {
             case OVS_CT_ATTR_ZONE:
+                /* Policy-less action attrs (see NAT below): guard the fixed-width
+                 * reads, which otherwise only ASSERT the attribute size. */
+                if (NlAttrGetSize(ctAttr) < sizeof(UINT16)) {
+                    return NDIS_STATUS_INVALID_PARAMETER;
+                }
                 zone = NlAttrGetU16(ctAttr);
                 break;
             case OVS_CT_ATTR_COMMIT:
                 commit = TRUE;
                 break;
             case OVS_CT_ATTR_MARK:
+                if (NlAttrGetSize(ctAttr) < sizeof(MD_MARK)) {
+                    return NDIS_STATUS_INVALID_PARAMETER;
+                }
                 mark = NlAttrGet(ctAttr);
                 break;
             case OVS_CT_ATTR_LABELS:
+                if (NlAttrGetSize(ctAttr) < sizeof(MD_LABELS)) {
+                    return NDIS_STATUS_INVALID_PARAMETER;
+                }
                 labels = NlAttrGet(ctAttr);
                 break;
             case OVS_CT_ATTR_HELPER:
@@ -1453,6 +1464,9 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                 commit = TRUE;
                 break;
             case OVS_CT_ATTR_EVENTMASK:
+                if (NlAttrGetSize(ctAttr) < sizeof(UINT32)) {
+                    return NDIS_STATUS_INVALID_PARAMETER;
+                }
                 eventmask = NlAttrGetU32(ctAttr);
                 /* Only mark and label updates are supported. */
                 if (eventmask & (1 << IPCT_MARK | 1 << IPCT_LABEL))
@@ -1478,10 +1492,12 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                         break;
                     case OVS_NAT_ATTR_IP_MIN:
                         /* This nested attribute is walked policy-less, so the
-                         * size is user-controlled; reject anything that would
-                         * overflow the address union (4 = IPv4, 16 = IPv6). */
-                        if (NlAttrGetSize(natAttr) >
-                                sizeof(natActionInfo.minAddr)) {
+                         * size is user-controlled. The payload must be exactly
+                         * an IPv4 (4) or IPv6 (16) address; reject anything else
+                         * so a short attr cannot leave a partial address. */
+                        if (NlAttrGetSize(natAttr) != sizeof(UINT32) &&
+                                NlAttrGetSize(natAttr) !=
+                                    sizeof(natActionInfo.minAddr)) {
                             return NDIS_STATUS_INVALID_PARAMETER;
                         }
                         memcpy(&natActionInfo.minAddr,
@@ -1489,8 +1505,9 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                         hasMinIp = TRUE;
                         break;
                     case OVS_NAT_ATTR_IP_MAX:
-                        if (NlAttrGetSize(natAttr) >
-                                sizeof(natActionInfo.maxAddr)) {
+                        if (NlAttrGetSize(natAttr) != sizeof(UINT32) &&
+                                NlAttrGetSize(natAttr) !=
+                                    sizeof(natActionInfo.maxAddr)) {
                             return NDIS_STATUS_INVALID_PARAMETER;
                         }
                         memcpy(&natActionInfo.maxAddr,
@@ -1499,15 +1516,15 @@ OvsExecuteConntrackAction(OvsForwardingContext *fwdCtx,
                         break;
                     case OVS_NAT_ATTR_PROTO_MIN:
                         /* Policy-less walk (see IP_MIN above): NlAttrGetU16 only
-                         * ASSERTs the size, so guard the read for non-DBG. */
-                        if (NlAttrGetSize(natAttr) < sizeof(UINT16)) {
+                         * ASSERTs the size, so require exactly a U16 here. */
+                        if (NlAttrGetSize(natAttr) != sizeof(UINT16)) {
                             return NDIS_STATUS_INVALID_PARAMETER;
                         }
                         natActionInfo.minPort = NlAttrGetU16(natAttr);
                         hasMinPort = TRUE;
                         break;
                     case OVS_NAT_ATTR_PROTO_MAX:
-                        if (NlAttrGetSize(natAttr) < sizeof(UINT16)) {
+                        if (NlAttrGetSize(natAttr) != sizeof(UINT16)) {
                             return NDIS_STATUS_INVALID_PARAMETER;
                         }
                         natActionInfo.maxPort = NlAttrGetU16(natAttr);

--- a/datapath-windows/ovsext/Ip6Fragment.c
+++ b/datapath-windows/ovsext/Ip6Fragment.c
@@ -250,6 +250,15 @@ OvsBuildNewIpv6Hdr(EthHdr *eth, POVS_IP6FRAG_ENTRY entry,
         return NULL;
     }
 
+    /* The reassembled IPv6 payload (ext headers + data) is written into a
+     * UINT16 payload_len below; reject a sum that would not fit, so the
+     * allocation, the copies, and the written header stay consistent. The
+     * guard above bounds totalLen but not behindFragHdrLen. */
+    if ((UINT32)entry->beforeFragHdrLen + entry->behindFragHdrLen +
+            entry->totalLen > MAX_IPDATAGRAM_SIZE) {
+        return NULL;
+    }
+
     packetLen = (layers->l3Offset + sizeof(IPv6Hdr) +
                  entry->beforeFragHdrLen + entry->behindFragHdrLen + entry->totalLen);
     packetBuf = (CHAR*)OvsAllocateMemoryWithTag(packetLen, OVS_IP6FRAG_POOL_TAG);
@@ -656,6 +665,11 @@ OvsGetPacketMeta(PIP6_PktExtHeader_Meta pktMeta, EthHdr *eth,
         return NDIS_STATUS_INVALID_PACKET;
     }
 
+    /* Bound the extension-header walk and its length accumulation against the
+     * claimed payload, computed in 32-bit so a crafted header chain cannot wrap
+     * the UINT16 total or run the pointer walk past the payload. */
+    UINT32 payloadLen = ntohs(ip6Hdr->payload_len);
+
     for (;;) {
         if ((nextHdr != SOCKET_IPPROTO_HOPOPTS)
             && (nextHdr != SOCKET_IPPROTO_ROUTING)
@@ -676,23 +690,28 @@ OvsGetPacketMeta(PIP6_PktExtHeader_Meta pktMeta, EthHdr *eth,
             nextHdr == SOCKET_IPPROTO_DSTOPTS ||
             nextHdr == SOCKET_IPPROTO_AH) {
             UINT8 len  = extHdr->hdrExtLen;
+            UINT32 hdrLen;
             nextHdr = extHdr->nextHeader;
             if (nextHdr == SOCKET_IPPROTO_FRAGMENT) {
                 pktMeta->beforeFragElePtr = (PCHAR)(extHdr);
             }
 
-            if (nextHdr == SOCKET_IPPROTO_AH) {
-                extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + (len  + 2) * 4);
-                pktMeta->extHdrTotalLen += ((len + 2) * 4);
-            } else {
-                extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + (len + 1) * 8);
-                pktMeta->extHdrTotalLen += ((len + 1) * 8);
+            hdrLen = (nextHdr == SOCKET_IPPROTO_AH)
+                     ? ((UINT32)len + 2) * 4 : ((UINT32)len + 1) * 8;
+            if ((UINT32)pktMeta->extHdrTotalLen + hdrLen > payloadLen) {
+                return NDIS_STATUS_INVALID_LENGTH;
             }
+            extHdr = (IPv6ExtHdr *)((PCHAR)extHdr + hdrLen);
+            pktMeta->extHdrTotalLen += (UINT16)hdrLen;
         } else if (nextHdr == SOCKET_IPPROTO_FRAGMENT) {
             IPv6FragHdr *fragHdr = (IPv6FragHdr *)extHdr;
             pktMeta->ident = fragHdr->ident;
             pktMeta->beforeFragExtHdrLen = pktMeta->extHdrTotalLen;
             pktMeta->fragExtHdrLen = sizeof(IPv6FragHdr);
+            if ((UINT32)pktMeta->extHdrTotalLen + sizeof(IPv6FragHdr) >
+                    payloadLen) {
+                return NDIS_STATUS_INVALID_LENGTH;
+            }
             pktMeta->extHdrTotalLen += sizeof(IPv6FragHdr);
             pktMeta->fragOffset = (ntohs(fragHdr->offlg)
                     & IP6F_OFF_HOST_ORDER_MASK) >> 3;
@@ -706,6 +725,8 @@ OvsGetPacketMeta(PIP6_PktExtHeader_Meta pktMeta, EthHdr *eth,
         }
     }
 
+    /* The walk above bounded extHdrTotalLen to the claimed payload, so this
+     * subtraction (UINT16) cannot underflow into a huge dataPayloadLen. */
     pktMeta->dataPayloadLen = (ntohs(ip6Hdr->payload_len) -
                                pktMeta->extHdrTotalLen);
     OVS_LOG_INFO("playload len %d, extotalLen %d, datapyaload len %d.",

--- a/datapath-windows/ovsext/Ip6Fragment.c
+++ b/datapath-windows/ovsext/Ip6Fragment.c
@@ -690,13 +690,17 @@ OvsGetPacketMeta(PIP6_PktExtHeader_Meta pktMeta, EthHdr *eth,
             nextHdr == SOCKET_IPPROTO_DSTOPTS ||
             nextHdr == SOCKET_IPPROTO_AH) {
             UINT8 len  = extHdr->hdrExtLen;
+            /* The AH vs non-AH length formula must key off the header being
+             * advanced past (the current one), so capture it before nextHdr is
+             * overwritten with the following header's type. */
+            UINT8 curHdr = nextHdr;
             UINT32 hdrLen;
             nextHdr = extHdr->nextHeader;
             if (nextHdr == SOCKET_IPPROTO_FRAGMENT) {
                 pktMeta->beforeFragElePtr = (PCHAR)(extHdr);
             }
 
-            hdrLen = (nextHdr == SOCKET_IPPROTO_AH)
+            hdrLen = (curHdr == SOCKET_IPPROTO_AH)
                      ? ((UINT32)len + 2) * 4 : ((UINT32)len + 1) * 8;
             if ((UINT32)pktMeta->extHdrTotalLen + hdrLen > payloadLen) {
                 return NDIS_STATUS_INVALID_LENGTH;

--- a/datapath-windows/ovsext/IpFragment.c
+++ b/datapath-windows/ovsext/IpFragment.c
@@ -191,7 +191,10 @@ OvsIpv4Reassemble(POVS_SWITCH_CONTEXT switchContext,
     packetHeader = layers->l3Offset + ipHdrLen;
     head = entry->head;
     while (head) {
-        if ((UINT32)(packetHeader + head->offset) > packetLen) {
+        /* Bound the full write extent (offset + len), not just the offset, so a
+         * crafted fragment cannot write past packetBuf. (The IPv6 reassembler
+         * already includes head->len in its equivalent guard.) */
+        if ((UINT32)(packetHeader + head->offset + head->len) > packetLen) {
             status = NDIS_STATUS_INVALID_DATA;
             goto cleanup;
         }

--- a/datapath-windows/ovsext/PacketParser.c
+++ b/datapath-windows/ovsext/PacketParser.c
@@ -284,6 +284,8 @@ OvsParseIcmpV6(const NET_BUFFER_LIST *packet,
              */
             IPv6NdOptHdr ndOptStorage;
             const IPv6NdOptHdr *ndOpt;
+            UINT8 ndLinkAddrStorage[ETH_ADDR_LENGTH];
+            const UINT8 *ndLinkAddr;
             UINT16 optLen;
 
             ndOpt = OvsGetPacketBytes(packet, sizeof *ndOpt, ofs, &ndOptStorage);
@@ -299,17 +301,29 @@ OvsParseIcmpV6(const NET_BUFFER_LIST *packet,
             /*
              * Store the link layer address if the appropriate option is
              * provided.  It is considered an error if the same link
-             * layer option is specified twice.
+             * layer option is specified twice.  The address follows the
+             * 2-byte option header; fetch it from the packet rather than
+             * reading past the 2-byte option-header storage above.
              */
             if (ndOpt->type == ND_OPT_SOURCE_LINKADDR && optLen == 8) {
                 if (Eth_IsNullAddr(icmp6Key->arpSha)) {
-                    memcpy(icmp6Key->arpSha, ndOpt + 1, ETH_ADDR_LENGTH);
+                    ndLinkAddr = OvsGetPacketBytes(packet, ETH_ADDR_LENGTH,
+                        ofs + sizeof *ndOpt, ndLinkAddrStorage);
+                    if (!ndLinkAddr) {
+                        return NDIS_STATUS_FAILURE;
+                    }
+                    memcpy(icmp6Key->arpSha, ndLinkAddr, ETH_ADDR_LENGTH);
                 } else {
                     goto invalid;
                 }
             } else if (ndOpt->type == ND_OPT_TARGET_LINKADDR && optLen == 8) {
                 if (Eth_IsNullAddr(icmp6Key->arpTha)) {
-                    memcpy(icmp6Key->arpTha, ndOpt + 1, ETH_ADDR_LENGTH);
+                    ndLinkAddr = OvsGetPacketBytes(packet, ETH_ADDR_LENGTH,
+                        ofs + sizeof *ndOpt, ndLinkAddrStorage);
+                    if (!ndLinkAddr) {
+                        return NDIS_STATUS_FAILURE;
+                    }
+                    memcpy(icmp6Key->arpTha, ndLinkAddr, ETH_ADDR_LENGTH);
                 } else {
                     goto invalid;
                 }

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -241,16 +241,25 @@ OvsReadDpIoctl(PFILE_OBJECT fileObject,
             UINT16 sum, *ptr;
             UINT16 size = (UINT16)(elem->packet.payload - elem->packet.data +
                                   elem->hdrInfo.l4Offset);
-            RtlCopyMemory(outputBuffer, &elem->packet.data, size);
-            ASSERT(len - size >= elem->hdrInfo.l4PayLoad);
-            sum = CopyAndCalculateChecksum((UINT8 *)outputBuffer + size,
-                                           (UINT8 *)&elem->packet.data + size,
-                                           elem->hdrInfo.l4PayLoad, 0);
-            ptr =(UINT16 *)((UINT8 *)outputBuffer + size +
-                            (elem->hdrInfo.tcpCsumNeeded ?
-                             TCP_CSUM_OFFSET : UDP_CSUM_OFFSET));
-            *ptr = sum;
-            ovsUserStats.l4Csum++;
+            /* l4PayLoad is derived from on-wire length fields (IPv4 TotalLength
+             * / IPv6 PayloadLength) and is not otherwise bounded against the
+             * actual packet, so a crafted length could drive the checksum copy
+             * past the buffer. Verify the L4 span fits before copying; if not,
+             * skip the (optional) checksum fixup and emit the packet as-is. */
+            if (size <= len &&
+                (UINT32)len - size >= elem->hdrInfo.l4PayLoad) {
+                RtlCopyMemory(outputBuffer, &elem->packet.data, size);
+                sum = CopyAndCalculateChecksum((UINT8 *)outputBuffer + size,
+                                               (UINT8 *)&elem->packet.data + size,
+                                               elem->hdrInfo.l4PayLoad, 0);
+                ptr =(UINT16 *)((UINT8 *)outputBuffer + size +
+                                (elem->hdrInfo.tcpCsumNeeded ?
+                                 TCP_CSUM_OFFSET : UDP_CSUM_OFFSET));
+                *ptr = sum;
+                ovsUserStats.l4Csum++;
+            } else {
+                RtlCopyMemory(outputBuffer, &elem->packet.data, len);
+            }
         } else {
             RtlCopyMemory(outputBuffer, &elem->packet.data, len);
         }

--- a/datapath-windows/ovsext/User.c
+++ b/datapath-windows/ovsext/User.c
@@ -883,21 +883,34 @@ OvsGetUpcallMsgSize(PVOID userData,
  */
 static VOID
 OvsCompletePacketHeader(UINT8 *packet,
+                        UINT32 packetLen,
                         BOOLEAN isRecv,
                         NDIS_TCP_IP_CHECKSUM_NET_BUFFER_LIST_INFO csumInfo,
                         POVS_PACKET_HDR_INFO hdrInfoIn,
                         POVS_PACKET_HDR_INFO hdrInfoOut)
 {
+    /* l3Offset/l4Offset come from a prior parse of this packet; re-validate
+     * them against the copied buffer before dereferencing, so a malformed
+     * packet cannot drive an out-of-bounds access in this csum fixup (which
+     * is only an optimization -- skipping it on a bad offset is safe). */
     if ((isRecv && csumInfo.Receive.IpChecksumValueInvalid) ||
         (!isRecv && csumInfo.Transmit.IsIPv4 &&
         csumInfo.Transmit.IpHeaderChecksum)) {
-        PIPV4_HEADER ipHdr = (PIPV4_HEADER)(packet + hdrInfoOut->l3Offset);
-        ASSERT(hdrInfoIn->isIPv4);
-        ASSERT(ipHdr->Version == 4);
-        ipHdr->HeaderChecksum = IPChecksum((UINT8 *)ipHdr,
-            ipHdr->HeaderLength << 2,
-            (UINT16)~ipHdr->HeaderChecksum);
-        ovsUserStats.ipCsum++;
+        if ((UINT32)hdrInfoOut->l3Offset + sizeof(IPV4_HEADER) <= packetLen) {
+            PIPV4_HEADER ipHdr = (PIPV4_HEADER)(packet + hdrInfoOut->l3Offset);
+            ASSERT(hdrInfoIn->isIPv4);
+            ASSERT(ipHdr->Version == 4);
+            /* IPChecksum spans the full header including options
+             * (HeaderLength * 4), which can exceed the fixed 20 bytes checked
+             * above; ensure that extent is also within the buffer. */
+            if ((UINT32)hdrInfoOut->l3Offset +
+                    ((UINT32)ipHdr->HeaderLength << 2) <= packetLen) {
+                ipHdr->HeaderChecksum = IPChecksum((UINT8 *)ipHdr,
+                    ipHdr->HeaderLength << 2,
+                    (UINT16)~ipHdr->HeaderChecksum);
+                ovsUserStats.ipCsum++;
+            }
+        }
     }
     ASSERT(hdrInfoIn->tcpCsumNeeded == 0 && hdrInfoOut->udpCsumNeeded == 0);
     /*
@@ -910,36 +923,46 @@ OvsCompletePacketHeader(UINT8 *packet,
          * filled already.
          *
          */
-        PTCP_HDR tcpHdr = (PTCP_HDR)(packet + hdrInfoIn->l4Offset);
-        if (hdrInfoIn->isIPv4) {
-            PIPV4_HEADER ipHdr = (PIPV4_HEADER)(packet + hdrInfoIn->l3Offset);
-            hdrInfoOut->l4PayLoad = (UINT16)(ntohs(ipHdr->TotalLength) -
-                                    (ipHdr->HeaderLength << 2));
-            tcpHdr->th_sum = IPPseudoChecksum((UINT32 *)&ipHdr->SourceAddress,
-                                         (UINT32 *)&ipHdr->DestinationAddress,
-                                         IPPROTO_TCP, hdrInfoOut->l4PayLoad);
-        } else {
-            PIPV6_HEADER ipv6Hdr = (PIPV6_HEADER)(packet +
-                                                  hdrInfoIn->l3Offset);
-            hdrInfoOut->l4PayLoad =
-                (UINT16)(ntohs(ipv6Hdr->PayloadLength) +
-                hdrInfoIn->l3Offset + sizeof(IPV6_HEADER)-
-                hdrInfoIn->l4Offset);
-            ASSERT(hdrInfoIn->isIPv6);
-            tcpHdr->th_sum =
-                IPv6PseudoChecksum((UINT32 *)&ipv6Hdr->SourceAddress,
-                (UINT32 *)&ipv6Hdr->DestinationAddress,
-                IPPROTO_TCP, hdrInfoOut->l4PayLoad);
+        UINT32 l3HdrSize = hdrInfoIn->isIPv4 ? sizeof(IPV4_HEADER)
+                                             : sizeof(IPV6_HEADER);
+        if ((UINT32)hdrInfoIn->l4Offset + sizeof(TCP_HDR) <= packetLen &&
+            (UINT32)hdrInfoIn->l3Offset + l3HdrSize <= packetLen) {
+            PTCP_HDR tcpHdr = (PTCP_HDR)(packet + hdrInfoIn->l4Offset);
+            if (hdrInfoIn->isIPv4) {
+                PIPV4_HEADER ipHdr =
+                    (PIPV4_HEADER)(packet + hdrInfoIn->l3Offset);
+                hdrInfoOut->l4PayLoad = (UINT16)(ntohs(ipHdr->TotalLength) -
+                                        (ipHdr->HeaderLength << 2));
+                tcpHdr->th_sum =
+                    IPPseudoChecksum((UINT32 *)&ipHdr->SourceAddress,
+                                     (UINT32 *)&ipHdr->DestinationAddress,
+                                     IPPROTO_TCP, hdrInfoOut->l4PayLoad);
+            } else {
+                PIPV6_HEADER ipv6Hdr = (PIPV6_HEADER)(packet +
+                                                      hdrInfoIn->l3Offset);
+                hdrInfoOut->l4PayLoad =
+                    (UINT16)(ntohs(ipv6Hdr->PayloadLength) +
+                    hdrInfoIn->l3Offset + sizeof(IPV6_HEADER)-
+                    hdrInfoIn->l4Offset);
+                ASSERT(hdrInfoIn->isIPv6);
+                tcpHdr->th_sum =
+                    IPv6PseudoChecksum((UINT32 *)&ipv6Hdr->SourceAddress,
+                    (UINT32 *)&ipv6Hdr->DestinationAddress,
+                    IPPROTO_TCP, hdrInfoOut->l4PayLoad);
+            }
+            hdrInfoOut->tcpCsumNeeded = 1;
+            ovsUserStats.recalTcpCsum++;
         }
-        hdrInfoOut->tcpCsumNeeded = 1;
-        ovsUserStats.recalTcpCsum++;
     } else if (!isRecv) {
         if (hdrInfoIn->isTcp && csumInfo.Transmit.TcpChecksum) {
             hdrInfoOut->tcpCsumNeeded = 1;
         } else if (hdrInfoIn->isUdp && csumInfo.Transmit.UdpChecksum) {
             hdrInfoOut->udpCsumNeeded = 1;
         }
-        if (hdrInfoOut->tcpCsumNeeded || hdrInfoOut->udpCsumNeeded) {
+        if ((hdrInfoOut->tcpCsumNeeded || hdrInfoOut->udpCsumNeeded) &&
+            (UINT32)hdrInfoIn->l3Offset +
+                (hdrInfoIn->isIPv4 ? sizeof(IPV4_HEADER) : sizeof(IPV6_HEADER))
+                <= packetLen) {
 #ifdef DBG
             UINT16 sum, *ptr;
             UINT8 proto =
@@ -970,10 +993,15 @@ OvsCompletePacketHeader(UINT8 *packet,
 #endif
             }
 #ifdef DBG
-            ptr = (UINT16 *)(packet + hdrInfoIn->l4Offset +
-                (hdrInfoOut->tcpCsumNeeded ?
-            TCP_CSUM_OFFSET : UDP_CSUM_OFFSET));
-            ASSERT(*ptr == sum);
+            if ((UINT32)hdrInfoIn->l4Offset +
+                    (hdrInfoOut->tcpCsumNeeded ?
+                         TCP_CSUM_OFFSET : UDP_CSUM_OFFSET) +
+                    sizeof(UINT16) <= packetLen) {
+                ptr = (UINT16 *)(packet + hdrInfoIn->l4Offset +
+                    (hdrInfoOut->tcpCsumNeeded ?
+                TCP_CSUM_OFFSET : UDP_CSUM_OFFSET));
+                ASSERT(*ptr == sum);
+            }
 #endif
         }
     }
@@ -1173,8 +1201,10 @@ OvsCreateQueueNlPacket(PVOID userData,
         RtlCopyMemory(dst, src, dataLen);
     }
 
-    /* Set csum if was offloaded */
-    OvsCompletePacketHeader(dst, isRecv, csumInfo, hdrInfo, &elem->hdrInfo);
+    /* Set csum if was offloaded. The packet payload occupies dataLen bytes at
+     * 'dst'; pass it so the header fixups stay within the copied buffer. */
+    OvsCompletePacketHeader(dst, dataLen, isRecv, csumInfo, hdrInfo,
+                            &elem->hdrInfo);
 
     /*
      * Finally insert VLAN tag


### PR DESCRIPTION
Adds bounds and integer-overflow checks on attacker- or userspace-controlled data in the conntrack and upcall paths, where header fields previously drove pointer math, copy lengths, and allocation sizes with no guard.

- **Conntrack-ftp.c** — bound the EPRT `|`-delimiter scans against the parse buffer (a payload with no delimiter walked off the end, since the zero-fill isn't `|`); reorder the NULL check ahead of the dereference.
- **Conntrack.c** — validate the NAT `IP_MIN`/`IP_MAX` attribute size against the address union before `memcpy` (the nested attributes are walked policy-less, so the size was user-controlled).
- **Ip6Fragment.c** — bound the IPv6 extension-header walk and its length accumulation in 32-bit against the claimed payload, so a crafted header chain can't wrap the `UINT16` total, run the walk past the payload, or underflow `dataPayloadLen`; bound the reassembled payload length for consistency with the written header.
- **User.c** — pass the packet length into `OvsCompletePacketHeader` and validate the L3/L4 offsets (and the full IPv4 header extent the checksum covers) before dereferencing; the checksum fixup is an optimization and is skipped on an out-of-bounds offset.

All checks are no-ops for well-formed traffic. Built clean under Win10Analyze (PREfast) and Win10Debug (/WX); validated on the live eryph stack — NAT'd external connectivity, TCP and ICMP upcalls, and fragmented-IPv6 processing — with no regression.