### PR TITLE
dpif-windows: wire up conntrack dump & flush

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,11 +196,14 @@ set(OVS_LIB_SOURCES
   lib/netdev-windows.c lib/wmi.c
   # --- dbosoft native dpif provider ---
   # The Windows datapath is the native dpif-windows provider talking to the ovsext
-  # driver via ovsext-channel, so the netlink datapath transport is not built on
-  # Windows: dpif-netlink.c, netlink-socket.c, netlink-conntrack.c and
-  # netlink-notifier.c are omitted.  netlink.c (the message codec) IS built -- the
-  # ovsext ABI is netlink-message-framed and message bodies use nl_msg_*.
-  lib/dpif-windows.c lib/ovsext-channel.c)
+  # driver via ovsext-channel, so the netlink datapath socket transport is not
+  # built on Windows: dpif-netlink.c, netlink-socket.c and netlink-notifier.c are
+  # omitted.  netlink.c (the message codec) IS built -- the ovsext ABI is
+  # netlink-message-framed and message bodies use nl_msg_*.  netlink-conntrack.c
+  # IS built for its ctnetlink parser/encoder (the ovsext CT family speaks the
+  # same wire format); only its NETLINK_NETFILTER socket functions are compiled
+  # out (#ifndef _WIN32) -- the provider drives ct dump/flush over ovsext-channel.
+  lib/dpif-windows.c lib/ovsext-channel.c lib/netlink-conntrack.c)
 
 add_library(openvswitch STATIC ${OVS_LIB_SOURCES} ${OVS_GENERATED_SOURCES})
 

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -2468,12 +2468,6 @@ dpif_windows_ct_get_features(struct dpif *dpif_ OVS_UNUSED,
  * applied here.
  * ==================================================================== */
 
-/* CTA_ZONE is not in the (older) ctnetlink uapi; netlink-conntrack.c defines it
- * internally.  Mirror that here for the flush request. */
-#ifndef CTA_ZONE
-#define CTA_ZONE (CTA_SECMARK + 1)
-#endif
-
 struct dpif_windows_ct_dump_state {
     struct ct_dpif_dump_state up;
     struct ovsext_dump dump;
@@ -2523,7 +2517,10 @@ dpif_windows_ct_dump_next(struct dpif *dpif_ OVS_UNUSED,
             return EOF;
         }
         if (!nl_ct_parse_entry(&reply, entry, &type)) {
-            continue;       /* Skip a record we cannot decode. */
+            /* Skip a record we cannot decode.  nl_ct_parse_entry() already
+             * uninitializes and zeroes 'entry' on its failure path, so no
+             * ct_dpif_entry_uninit() is needed here. */
+            continue;
         }
         if (dump->filter_zone && entry->zone != dump->zone) {
             ct_dpif_entry_uninit(entry);
@@ -2550,14 +2547,24 @@ dpif_windows_ct_flush(struct dpif *dpif_, const uint16_t *zone,
                       const struct ct_dpif_tuple *tuple)
 {
     struct dpif_windows *dpif = dpif_windows_cast(dpif_);
-    struct ofpbuf *request = ofpbuf_new(1024);
-    int family = tuple ? tuple->l3_type : AF_UNSPEC;
+    struct ofpbuf *request;
     int error;
 
-    nl_msg_put_nfgenmsg(request, 0, family, NFNL_SUBSYS_CTNETLINK,
-                        IPCTNL_MSG_CT_DELETE, NLM_F_REQUEST);
-    if (zone) {
-        nl_msg_put_be16(request, CTA_ZONE, htons(*zone));
+    /* The kernel's tuple-scoped delete (OvsCtDeleteCmdHandler -> MapNlToCtTuple)
+     * only handles IPv4 tuples (struct ovs_key_ct_tuple_ipv4).  Reject an IPv6
+     * tuple rather than issue a delete that would silently match nothing. */
+    if (tuple && tuple->l3_type != AF_INET) {
+        return EOPNOTSUPP;
+    }
+
+    request = ofpbuf_new(1024);
+    nl_msg_put_nfgenmsg(request, 0, tuple ? tuple->l3_type : AF_UNSPEC,
+                        NFNL_SUBSYS_CTNETLINK, IPCTNL_MSG_CT_DELETE,
+                        NLM_F_REQUEST);
+    /* A tuple-scoped flush with no zone targets the default zone (0); emit
+     * CTA_ZONE in that case too, matching nl_ct_flush_tuple(). */
+    if (zone || tuple) {
+        nl_msg_put_be16(request, CTA_ZONE, htons(zone ? *zone : 0));
     }
     if (tuple) {
         if (!nl_ct_put_ct_tuple(request, tuple, CTA_TUPLE_ORIG)) {

--- a/lib/dpif-windows.c
+++ b/lib/dpif-windows.c
@@ -25,13 +25,13 @@
  * Conntrack zone-limit management (ct_set/get/del_limits, ct_get_features) and
  * OpenFlow meters (meter_get_features/set/get/del) are wired against the
  * kernel's OVS_CT_LIMIT and OVS_METER genl families over the ordinary
- * transaction channel.  Conntrack dump/flush are not provided here: their
- * userspace helpers (nl_ct_*) live in lib/netlink-conntrack.c, the
- * NETLINK_NETFILTER ctnetlink transport, which is not built on Windows -- a
- * userspace gap, not a kernel one (the ovsext kernel does serve the ctnetlink
- * dump/delete path).  Bond and timeout-policy management remain absent (not
- * wired yet); those class members default to NULL.  Upcalls use a single
- * handler, as Windows always has.
+ * transaction channel.  Conntrack dump/flush (ct_dump_*, ct_flush) are served
+ * by the kernel's netfilter-framed CT family; the provider drives them over
+ * ovsext-channel and reuses lib/netlink-conntrack.c's ctnetlink parser/encoder
+ * (only that file's NETLINK_NETFILTER socket transport is compiled out on
+ * Windows).  Bond and timeout-policy management remain absent (not wired yet);
+ * those class members default to NULL.  Upcalls use a single handler, as
+ * Windows always has.
  *
  * See datapath-windows/NATIVE-DPIF-EXPERIMENT.md for the full spec. */
 
@@ -45,6 +45,7 @@
 
 #include "ct-dpif.h"
 #include "dpif-provider.h"
+#include "netlink-conntrack.h"  /* nl_ct_parse_entry, nl_msg_put_nfgenmsg. */
 #include "odp-netlink.h"        /* struct ovs_header, OVS_*_ATTR_*. */
 #include "ovsext-channel.h"
 #include "flow.h"
@@ -2456,6 +2457,121 @@ dpif_windows_ct_get_features(struct dpif *dpif_ OVS_UNUSED,
 }
 
 /* ====================================================================
+ * Conntrack dump & flush.
+ *
+ * The ovsext kernel serves the conntrack table over the netfilter-framed CT
+ * family (NFNL_SUBSYS_CTNETLINK): IPCTNL_MSG_CT_GET dumps every entry in the
+ * ctnetlink wire format, IPCTNL_MSG_CT_DELETE flushes (optionally scoped by
+ * zone and/or the original tuple).  The dump rides the ordinary dump-IOCTL
+ * cursor and each record is decoded by nl_ct_parse_entry(), shared with the
+ * Linux ctnetlink path.  The kernel dumps every zone, so the zone filter is
+ * applied here.
+ * ==================================================================== */
+
+/* CTA_ZONE is not in the (older) ctnetlink uapi; netlink-conntrack.c defines it
+ * internally.  Mirror that here for the flush request. */
+#ifndef CTA_ZONE
+#define CTA_ZONE (CTA_SECMARK + 1)
+#endif
+
+struct dpif_windows_ct_dump_state {
+    struct ct_dpif_dump_state up;
+    struct ovsext_dump dump;
+    bool filter_zone;
+    uint16_t zone;
+};
+
+static int
+dpif_windows_ct_dump_start(struct dpif *dpif_,
+                           struct ct_dpif_dump_state **dump_,
+                           const uint16_t *zone, int *ptot_bkts)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct dpif_windows_ct_dump_state *dump;
+    struct ofpbuf *buf;
+
+    dump = xzalloc(sizeof *dump);
+    if (zone) {
+        dump->filter_zone = true;
+        dump->zone = *zone;
+    }
+
+    buf = ofpbuf_new(1024);
+    nl_msg_put_nfgenmsg(buf, 0, AF_UNSPEC, NFNL_SUBSYS_CTNETLINK,
+                        IPCTNL_MSG_CT_GET, NLM_F_REQUEST | NLM_F_DUMP);
+    ovsext_dump_start(&dump->dump, &dpif->channel, buf);
+    ofpbuf_delete(buf);
+
+    *dump_ = &dump->up;
+    *ptot_bkts = -1;        /* The kernel does not expose bucket counts. */
+    return 0;
+}
+
+static int
+dpif_windows_ct_dump_next(struct dpif *dpif_ OVS_UNUSED,
+                          struct ct_dpif_dump_state *dump_,
+                          struct ct_dpif_entry *entry)
+{
+    struct dpif_windows_ct_dump_state *dump =
+        CONTAINER_OF(dump_, struct dpif_windows_ct_dump_state, up);
+    struct ofpbuf reply;
+
+    for (;;) {
+        enum nl_ct_event_type type;
+
+        if (!ovsext_dump_next(&dump->dump, &reply)) {
+            return EOF;
+        }
+        if (!nl_ct_parse_entry(&reply, entry, &type)) {
+            continue;       /* Skip a record we cannot decode. */
+        }
+        if (dump->filter_zone && entry->zone != dump->zone) {
+            ct_dpif_entry_uninit(entry);
+            continue;
+        }
+        return 0;
+    }
+}
+
+static int
+dpif_windows_ct_dump_done(struct dpif *dpif_ OVS_UNUSED,
+                          struct ct_dpif_dump_state *dump_)
+{
+    struct dpif_windows_ct_dump_state *dump =
+        CONTAINER_OF(dump_, struct dpif_windows_ct_dump_state, up);
+    int error = ovsext_dump_done(&dump->dump);
+
+    free(dump);
+    return error;
+}
+
+static int
+dpif_windows_ct_flush(struct dpif *dpif_, const uint16_t *zone,
+                      const struct ct_dpif_tuple *tuple)
+{
+    struct dpif_windows *dpif = dpif_windows_cast(dpif_);
+    struct ofpbuf *request = ofpbuf_new(1024);
+    int family = tuple ? tuple->l3_type : AF_UNSPEC;
+    int error;
+
+    nl_msg_put_nfgenmsg(request, 0, family, NFNL_SUBSYS_CTNETLINK,
+                        IPCTNL_MSG_CT_DELETE, NLM_F_REQUEST);
+    if (zone) {
+        nl_msg_put_be16(request, CTA_ZONE, htons(*zone));
+    }
+    if (tuple) {
+        if (!nl_ct_put_ct_tuple(request, tuple, CTA_TUPLE_ORIG)) {
+            ofpbuf_delete(request);
+            return EOPNOTSUPP;
+        }
+    }
+
+    error = ovsext_transact(&dpif->channel, request, NULL);
+    ofpbuf_delete(request);
+    return error;
+}
+
+/* ====================================================================
  * OpenFlow meters (mirrors dpif-netlink's meter_* members).
  *
  * The ovsext kernel serves the OVS_METER genl family at the fixed id
@@ -2750,6 +2866,10 @@ const struct dpif_class dpif_windows_class = {
     .recv_wait = dpif_windows_recv_wait,
     .recv_purge = dpif_windows_recv_purge,
     .get_datapath_version = dpif_windows_get_datapath_version,
+    .ct_dump_start = dpif_windows_ct_dump_start,
+    .ct_dump_next = dpif_windows_ct_dump_next,
+    .ct_dump_done = dpif_windows_ct_dump_done,
+    .ct_flush = dpif_windows_ct_flush,
     .ct_set_limits = dpif_windows_ct_set_limits,
     .ct_get_limits = dpif_windows_ct_get_limits,
     .ct_del_limits = dpif_windows_ct_del_limits,

--- a/lib/netlink-conntrack.c
+++ b/lib/netlink-conntrack.c
@@ -99,11 +99,9 @@ static const struct nl_policy nfnlgrp_conntrack_policy[] = {
      * CTA_LABELS_MASK are not received from kernel. */
 };
 
-/* Declarations for conntrack netlink dumping. */
-static void nl_msg_put_nfgenmsg(struct ofpbuf *msg, size_t expected_payload,
-                                int family, uint8_t subsystem, uint8_t cmd,
-                                uint32_t flags);
-
+/* Declarations for conntrack netlink dumping.  nl_msg_put_nfgenmsg() and
+ * nl_ct_put_ct_tuple() are declared (non-static) in netlink-conntrack.h so the
+ * native Windows dpif provider can reuse them over its own transport. */
 static bool nl_ct_parse_header_policy(struct ofpbuf *buf,
         enum nl_ct_event_type *event_type,
         uint8_t *nfgen_family,
@@ -112,9 +110,8 @@ static bool nl_ct_parse_header_policy(struct ofpbuf *buf,
 static bool nl_ct_attrs_to_ct_dpif_entry(struct ct_dpif_entry *entry,
         struct nlattr *attrs[ARRAY_SIZE(nfnlgrp_conntrack_policy)],
         uint8_t nfgen_family);
-static bool nl_ct_put_ct_tuple(struct ofpbuf *buf,
-        const struct ct_dpif_tuple *tuple, enum ctattr_type type);
 
+#ifndef _WIN32
 struct nl_ct_dump_state {
     struct nl_dump dump;
     struct ofpbuf buf;
@@ -210,6 +207,7 @@ nl_ct_dump_done(struct nl_ct_dump_state *state)
     free(state);
     return error;
 }
+#endif /* !_WIN32 */
 
 /* Format conntrack event 'entry' of 'type' to 'ds'. */
 void
@@ -225,6 +223,7 @@ nl_ct_format_event_entry(const struct ct_dpif_entry *entry,
     ct_dpif_format_entry(entry, ds, verbose, print_stats);
 }
 
+#ifndef _WIN32
 int
 nl_ct_flush(void)
 {
@@ -388,6 +387,7 @@ nl_ct_flush_zone(uint16_t flush_zone)
     return 0;
 }
 #endif
+#endif /* !_WIN32 */
 
 /* Conntrack netlink parsing. */
 
@@ -633,7 +633,7 @@ nl_ct_put_tuple_proto(struct ofpbuf *buf, const struct ct_dpif_tuple *tuple)
     return true;
 }
 
-static bool
+bool
 nl_ct_put_ct_tuple(struct ofpbuf *buf, const struct ct_dpif_tuple *tuple,
                    enum ctattr_type type)
 {
@@ -890,6 +890,7 @@ nl_ct_parse_helper(struct nlattr *nla, struct ct_dpif_helper *helper)
     return parsed;
 }
 
+#ifndef _WIN32
 static int nl_ct_timeout_policy_max_attr[] = {
     [IPPROTO_TCP] = CTA_TIMEOUT_TCP_MAX,
     [IPPROTO_UDP] = CTA_TIMEOUT_UDP_MAX,
@@ -1190,6 +1191,7 @@ nl_ct_timeout_policy_dump_done(struct nl_ct_timeout_policy_dump_state *state)
     free(state);
     return err;
 }
+#endif /* !_WIN32 */
 
 /* Translate netlink entry status flags to CT_DPIF_TCP status flags. */
 static uint32_t
@@ -1364,7 +1366,7 @@ nl_ct_parse_entry(struct ofpbuf *buf, struct ct_dpif_entry *entry,
  *
  * nl_msg_put_nlmsghdr() should be used to compose Netlink messages that are
  * not NetFilter Netlink messages. */
-static void
+void
 nl_msg_put_nfgenmsg(struct ofpbuf *msg, size_t expected_payload,
                     int family, uint8_t subsystem, uint8_t cmd,
                     uint32_t flags)

--- a/lib/netlink-conntrack.c
+++ b/lib/netlink-conntrack.c
@@ -283,14 +283,6 @@ nl_ct_flush_zone_with_cta_zone(uint16_t flush_zone)
     return err;
 }
 
-#ifdef _WIN32
-int
-nl_ct_flush_zone(uint16_t flush_zone)
-{
-    return nl_ct_flush_zone_with_cta_zone(flush_zone);
-}
-#else
-
 static bool
 netlink_flush_supports_zone(void)
 {
@@ -386,7 +378,6 @@ nl_ct_flush_zone(uint16_t flush_zone)
      * have a parent connection anymore */
     return 0;
 }
-#endif
 #endif /* !_WIN32 */
 
 /* Conntrack netlink parsing. */

--- a/lib/netlink-conntrack.h
+++ b/lib/netlink-conntrack.h
@@ -17,6 +17,7 @@
 #ifndef NETLINK_CONNTRACK_H
 #define NETLINK_CONNTRACK_H
 
+#include <linux/netfilter/nfnetlink_conntrack.h>
 #include <linux/netfilter/nfnetlink_cttimeout.h>
 
 #include "byte-order.h"
@@ -48,6 +49,12 @@ struct nl_ct_timeout_policy {
 struct nl_ct_dump_state;
 struct nl_ct_timeout_policy_dump_state;
 
+/* The conntrack/timeout-policy dump and flush helpers below drive the Linux
+ * NETLINK_NETFILTER socket transport (nl_dump/nl_transact), which is not built
+ * on Windows.  There the native dpif-windows provider issues the equivalent
+ * ovsext CT-family requests over ovsext-channel and reuses the parser/encoder
+ * helpers that remain available on both platforms (see below). */
+#ifndef _WIN32
 int nl_ct_dump_start(struct nl_ct_dump_state **, const uint16_t *zone,
                      int *ptot_bkts);
 int nl_ct_dump_next(struct nl_ct_dump_state *, struct ct_dpif_entry *);
@@ -68,6 +75,14 @@ int nl_ct_timeout_policy_dump_next(
     struct nl_ct_timeout_policy *nl_tp);
 int nl_ct_timeout_policy_dump_done(
     struct nl_ct_timeout_policy_dump_state *state);
+#endif /* !_WIN32 */
+
+/* Transport-free ctnetlink message helpers, available on all platforms. */
+void nl_msg_put_nfgenmsg(struct ofpbuf *msg, size_t expected_payload,
+                         int family, uint8_t subsystem, uint8_t cmd,
+                         uint32_t flags);
+bool nl_ct_put_ct_tuple(struct ofpbuf *buf, const struct ct_dpif_tuple *tuple,
+                        enum ctattr_type type);
 
 bool nl_ct_parse_entry(struct ofpbuf *, struct ct_dpif_entry *,
                        enum nl_ct_event_type *);

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -270,7 +270,7 @@ build_flow_bad(struct mock_record *r)
  * tuples, status and id.  Built with the shared ctnetlink encoders so the
  * record is exactly what nl_ct_parse_entry() (used by the provider) decodes. */
 static void
-build_ct_record(struct mock_record *r)
+build_ct_record(struct mock_record *r, uint16_t zone)
 {
     uint64_t stub[MOCK_RECORD_CAP / 8];
     struct ofpbuf b;
@@ -294,6 +294,10 @@ build_ct_record(struct mock_record *r)
     nl_ct_put_ct_tuple(&b, &reply, CTA_TUPLE_REPLY);
     nl_msg_put_be32(&b, CTA_STATUS, htonl(0x8 /* IPS_CONFIRMED */));
     nl_msg_put_be32(&b, CTA_ID, htonl(0xabcd));
+    /* The kernel emits CTA_ZONE only for a non-default zone. */
+    if (zone) {
+        nl_msg_put_be16(&b, CTA_ZONE, htons(zone));
+    }
     nl_msg_nlmsghdr(&b)->nlmsg_len = b.size;
     finish_record(r, &b);
 }
@@ -681,12 +685,25 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
         return TRUE;                   /* ack, empty reply */
     }
 
-    case (NFNL_SUBSYS_CTNETLINK << 8 | IPCTNL_MSG_CT_DELETE):
-        /* Conntrack flush.  Record that it happened; the request is framed as
-         * nfgenmsg + ovs_header (the Windows nfgenmsg carries the ovs_header)
-         * optionally followed by CTA_ZONE. */
+    case (NFNL_SUBSYS_CTNETLINK << 8 | IPCTNL_MSG_CT_DELETE): {
+        /* Conntrack flush.  The request is framed as nfgenmsg + ovs_header (the
+         * Windows nfgenmsg embeds the ovs_header) optionally followed by
+         * CTA_ZONE / CTA_TUPLE_ORIG.  Record the flush and the requested zone. */
+        size_t hdrlen = NLMSG_HDRLEN + sizeof(struct nfgenmsg);
+
         m->ct_flushed = true;
+        m->ct_flush_zone = 0;
+        if (in_len > hdrlen) {
+            const struct nlattr *attrs = ALIGNED_CAST(const struct nlattr *,
+                                            (const char *) in + hdrlen);
+            const struct nlattr *za =
+                nl_attr_find__(attrs, in_len - hdrlen, CTA_ZONE);
+            if (za) {
+                m->ct_flush_zone = ntohs(nl_attr_get_be16(za));
+            }
+        }
         return TRUE;                   /* ack, empty reply */
+    }
 
     case OVS_WIN_NL_METER_FAMILY_ID:
         return mock_meter(m, in, in_len, out, out_len, bytes);
@@ -1762,17 +1779,20 @@ test_ct_dump_flush(struct dpif *dpif, struct mock_kernel *m)
 {
     struct ct_dpif_dump_state *dump = NULL;
     struct ct_dpif_entry entry;
+    uint16_t zone5 = 5;
     int tot_bkts = 0;
     int n = 0;
     int error;
 
     mock_reset_content(m);
-    build_ct_record(&m->ct[0]);
-    m->n_ct = 1;
+    build_ct_record(&m->ct[0], 0);     /* default zone */
+    build_ct_record(&m->ct[1], 5);     /* zone 5 */
+    m->n_ct = 2;
 
+    /* Unfiltered dump returns both entries and terminates at EOF. */
     error = ct_dpif_dump_start(dpif, &dump, NULL, &tot_bkts);
     CHECK(error == 0);
-
+    n = 0;
     while (!(error = ct_dpif_dump_next(dump, &entry))) {
         CHECK(entry.tuple_orig.l3_type == AF_INET);
         CHECK(entry.tuple_orig.ip_proto == IPPROTO_TCP);
@@ -1782,14 +1802,36 @@ test_ct_dump_flush(struct dpif *dpif, struct mock_kernel *m)
         ct_dpif_entry_uninit(&entry);
     }
     CHECK(error == EOF);
+    CHECK(n == 2);
+    CHECK(ct_dpif_dump_done(dump) == 0);
+
+    /* The kernel dumps all zones; the provider filters client-side, so a
+     * zone-5 dump returns only the zone-5 entry. */
+    error = ct_dpif_dump_start(dpif, &dump, &zone5, &tot_bkts);
+    CHECK(error == 0);
+    n = 0;
+    while (!(error = ct_dpif_dump_next(dump, &entry))) {
+        CHECK(entry.zone == 5);
+        n++;
+        ct_dpif_entry_uninit(&entry);
+    }
+    CHECK(error == EOF);
     CHECK(n == 1);
-    ct_dpif_dump_done(dump);
+    CHECK(ct_dpif_dump_done(dump) == 0);
 
     /* Flush all zones. */
     m->ct_flushed = false;
     error = ct_dpif_flush(dpif, NULL, NULL);
     CHECK(error == 0);
     CHECK(m->ct_flushed);
+
+    /* Zone-scoped flush carries CTA_ZONE. */
+    m->ct_flushed = false;
+    m->ct_flush_zone = 0xffff;
+    error = ct_dpif_flush(dpif, &zone5, NULL);
+    CHECK(error == 0);
+    CHECK(m->ct_flushed);
+    CHECK(m->ct_flush_zone == 5);
 }
 
 /* Datapath feature negotiation: the open requested OVS_DP_F_UNALIGNED |

--- a/tests/test-dpif-windows.c
+++ b/tests/test-dpif-windows.c
@@ -37,6 +37,7 @@
 
 #include "dpif.h"
 #include "ct-dpif.h"
+#include "netlink-conntrack.h"
 #include "netdev.h"
 #include "netdev-provider.h"
 #include "openvswitch/ofp-meter.h"
@@ -81,7 +82,7 @@ static int failures;
 
 /* ---- mock "kernel" state ------------------------------------------------- */
 
-enum mock_dump { DUMP_NONE, DUMP_VPORT, DUMP_FLOW, DUMP_DP };
+enum mock_dump { DUMP_NONE, DUMP_VPORT, DUMP_FLOW, DUMP_DP, DUMP_CT };
 
 /* How an OVS_IOCTL_TRANSACT against the FLOW family answers. */
 enum flow_reply {
@@ -114,8 +115,13 @@ struct mock_kernel {
     struct mock_record dp[MOCK_MAX_RECORDS];    int n_dp;
     struct mock_record vport[MOCK_MAX_RECORDS]; int n_vport;
     struct mock_record flow[MOCK_MAX_RECORDS];  int n_flow;
+    struct mock_record ct[MOCK_MAX_RECORDS];    int n_ct;
     bool flow_dump_done;        /* FLOW dump ends with an NLMSG_DONE record
                                  * (as the kernel does), not a zero-length read. */
+
+    /* CT flush (IPCTNL_MSG_CT_DELETE) bookkeeping. */
+    bool ct_flushed;
+    uint16_t ct_flush_zone;
 
     /* Queued packet upcalls, delivered one per OVS_IOCTL_READ_PACKET. */
     struct mock_record pkt[MOCK_MAX_RECORDS];   int pkt_head, pkt_len;
@@ -256,6 +262,39 @@ build_flow_bad(struct mock_record *r)
                           OVS_FLOW_CMD_NEW, OVS_FLOW_VERSION);
     ovs_header = ofpbuf_put_uninit(&b, sizeof *ovs_header);
     ovs_header->dp_ifindex = MOCK_DP_IFINDEX;
+    finish_record(r, &b);
+}
+
+/* Builds a conntrack dump record as the kernel's OvsCreateNlMsgFromCtEntry
+ * does: an IPCTNL_MSG_CT_NEW ctnetlink message with the mandatory orig/reply
+ * tuples, status and id.  Built with the shared ctnetlink encoders so the
+ * record is exactly what nl_ct_parse_entry() (used by the provider) decodes. */
+static void
+build_ct_record(struct mock_record *r)
+{
+    uint64_t stub[MOCK_RECORD_CAP / 8];
+    struct ofpbuf b;
+    struct ct_dpif_tuple orig = {
+        .l3_type = AF_INET, .ip_proto = IPPROTO_TCP,
+        .src = { .ip = htonl(0x0a000064) },     /* 10.0.0.100 */
+        .dst = { .ip = htonl(0x0a000065) },     /* 10.0.0.101 */
+        .src_port = htons(12345), .dst_port = htons(80),
+    };
+    struct ct_dpif_tuple reply = {
+        .l3_type = AF_INET, .ip_proto = IPPROTO_TCP,
+        .src = { .ip = htonl(0x0a000065) },
+        .dst = { .ip = htonl(0x0a000064) },
+        .src_port = htons(80), .dst_port = htons(12345),
+    };
+
+    ofpbuf_use_stub(&b, stub, sizeof stub);
+    nl_msg_put_nfgenmsg(&b, 0, AF_INET, NFNL_SUBSYS_CTNETLINK,
+                        IPCTNL_MSG_CT_NEW, NLM_F_CREATE);
+    nl_ct_put_ct_tuple(&b, &orig, CTA_TUPLE_ORIG);
+    nl_ct_put_ct_tuple(&b, &reply, CTA_TUPLE_REPLY);
+    nl_msg_put_be32(&b, CTA_STATUS, htonl(0x8 /* IPS_CONFIRMED */));
+    nl_msg_put_be32(&b, CTA_ID, htonl(0xabcd));
+    nl_msg_nlmsghdr(&b)->nlmsg_len = b.size;
     finish_record(r, &b);
 }
 
@@ -642,6 +681,13 @@ mock_transact(struct mock_kernel *m, const void *in, DWORD in_len,
         return TRUE;                   /* ack, empty reply */
     }
 
+    case (NFNL_SUBSYS_CTNETLINK << 8 | IPCTNL_MSG_CT_DELETE):
+        /* Conntrack flush.  Record that it happened; the request is framed as
+         * nfgenmsg + ovs_header (the Windows nfgenmsg carries the ovs_header)
+         * optionally followed by CTA_ZONE. */
+        m->ct_flushed = true;
+        return TRUE;                   /* ack, empty reply */
+
     case OVS_WIN_NL_METER_FAMILY_ID:
         return mock_meter(m, in, in_len, out, out_len, bytes);
 
@@ -705,6 +751,8 @@ mock_write(struct mock_kernel *m, struct mock_handle *h,
         case OVS_WIN_NL_VPORT_FAMILY_ID:    h->dump = DUMP_VPORT; break;
         case OVS_WIN_NL_FLOW_FAMILY_ID:     h->dump = DUMP_FLOW;  break;
         case OVS_WIN_NL_DATAPATH_FAMILY_ID: h->dump = DUMP_DP;    break;
+        case (NFNL_SUBSYS_CTNETLINK << 8 | IPCTNL_MSG_CT_GET):
+            h->dump = DUMP_CT; break;
         default:                            h->dump = DUMP_NONE;  break;
         }
     }
@@ -747,6 +795,7 @@ mock_read_dump(struct mock_kernel *m, struct mock_handle *h,
     case DUMP_DP:    recs = m->dp;    n = m->n_dp;    break;
     case DUMP_VPORT: recs = m->vport; n = m->n_vport; break;
     case DUMP_FLOW:  recs = m->flow;  n = m->n_flow;  break;
+    case DUMP_CT:    recs = m->ct;    n = m->n_ct;    break;
     case DUMP_NONE:  default:         return TRUE;    /* nothing armed */
     }
 
@@ -881,6 +930,9 @@ mock_reset_content(struct mock_kernel *m)
 {
     m->n_vport = 0;
     m->n_flow = 0;
+    m->n_ct = 0;
+    m->ct_flushed = false;
+    m->ct_flush_zone = 0;
     m->pkt_head = 0;
     m->pkt_len = 0;
     m->evt_head = 0;
@@ -1701,6 +1753,45 @@ test_ct_limits(struct dpif *dpif, struct mock_kernel *m)
     CHECK(feat == 0);
 }
 
+/* Conntrack dump & flush: the kernel serves the conntrack table over the
+ * netfilter-framed CT family.  A dump round-trips one ctnetlink record into a
+ * ct_dpif_entry (orig/reply tuple, proto), terminates with a zero-length EOF,
+ * and a flush issues IPCTNL_MSG_CT_DELETE. */
+static void
+test_ct_dump_flush(struct dpif *dpif, struct mock_kernel *m)
+{
+    struct ct_dpif_dump_state *dump = NULL;
+    struct ct_dpif_entry entry;
+    int tot_bkts = 0;
+    int n = 0;
+    int error;
+
+    mock_reset_content(m);
+    build_ct_record(&m->ct[0]);
+    m->n_ct = 1;
+
+    error = ct_dpif_dump_start(dpif, &dump, NULL, &tot_bkts);
+    CHECK(error == 0);
+
+    while (!(error = ct_dpif_dump_next(dump, &entry))) {
+        CHECK(entry.tuple_orig.l3_type == AF_INET);
+        CHECK(entry.tuple_orig.ip_proto == IPPROTO_TCP);
+        CHECK(entry.tuple_orig.dst_port == htons(80));
+        CHECK(entry.tuple_reply.src_port == htons(80));
+        n++;
+        ct_dpif_entry_uninit(&entry);
+    }
+    CHECK(error == EOF);
+    CHECK(n == 1);
+    ct_dpif_dump_done(dump);
+
+    /* Flush all zones. */
+    m->ct_flushed = false;
+    error = ct_dpif_flush(dpif, NULL, NULL);
+    CHECK(error == 0);
+    CHECK(m->ct_flushed);
+}
+
 /* Datapath feature negotiation: the open requested OVS_DP_F_UNALIGNED |
  * OVS_DP_F_VPORT_PIDS, the kernel stored and echoed them, and
  * get_features/get_stats reflect the negotiated mask.  An unsupported bit is
@@ -2000,6 +2091,7 @@ main(int argc, char *argv[])
     test_operate_batch(dpif, &mock);
     test_port_poll(dpif, &mock);
     test_ct_limits(dpif, &mock);
+    test_ct_dump_flush(dpif, &mock);
     test_meters(dpif, &mock);
     test_feature_negotiation(dpif, &mock);
 


### PR DESCRIPTION
Implements the `ct_dump_start/next/done` and `ct_flush` dpif provider methods for the native Windows datapath. They were left NULL, so `ovs-appctl dpctl/dump-conntrack` and `dpctl/flush-conntrack` returned *operation not supported* on Windows — even though the ovsext kernel fully serves the conntrack table over its netfilter-framed CT family (`IPCTNL_MSG_CT_GET` dump, `IPCTNL_MSG_CT_DELETE` flush).

- The dump rides the ordinary dump-IOCTL cursor over ovsext-channel; each ctnetlink record is decoded by `nl_ct_parse_entry()`. Flush issues `IPCTNL_MSG_CT_DELETE`, optionally scoped by zone and/or the original tuple.
- `lib/netlink-conntrack.c` (its ctnetlink parser/encoder) is now built on Windows; only its `NETLINK_NETFILTER` socket-transport functions are compiled out (`#ifndef _WIN32`). `nl_msg_put_nfgenmsg()` and `nl_ct_put_ct_tuple()` are exposed for the provider to reuse — no duplicated parsing, and no change to the Linux build beyond the guards.
- Restores conntrack observability on Windows, which makes the datapath conntrack paths debuggable on a live box.

Covered by a new mock-kernel CT dump/flush case in `tests/test-dpif-windows.c` (decodes a ctnetlink record into a `ct_dpif_entry`, terminates at EOF, and flushes). Builds clean (CMake/VS2022) and the test suite passes; live verification on the eryph stack is pending a userspace deploy.