### PR TITLE
datapath-windows: keep the ICMP id when picking up the ct tuple key

### DIFF
--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -791,8 +791,19 @@ OvsPickupCtTupleAsLookupKey(POVS_CT_KEY ctKey, UINT16 zone, OvsFlowKey *flowKey)
             ctKey->src.addr.ipv4 = flowKey->ct.tuple_ipv4.ipv4_src;
             ctKey->dst.addr.ipv4 = flowKey->ct.tuple_ipv4.ipv4_dst;
             ctKey->nw_proto = flowKey->ct.tuple_ipv4.ipv4_proto;
-            ctKey->src.port = flowKey->ct.tuple_ipv4.src_port;
-            ctKey->dst.port = flowKey->ct.tuple_ipv4.dst_port;
+            /* For ICMP the ct tuple's src_port/dst_port encode the ICMP
+             * type/code rather than transport ports (see OvsCtUpdateTuple),
+             * and src.port aliases src.icmp_id in struct ct_endpoint. The
+             * caller OvsCtSetupLookupCtx already sets src.icmp_id and
+             * src.icmp_type from the packet (icmp_code stays 0, as required
+             * for echo request/reply). Copying the tuple's src_port into
+             * src.port here would overwrite that icmp_id with htons(icmp_type)
+             * and leave the reply icmp_id zero, so the reply would never match
+             * the entry. Carry the transport ports over only for non-ICMP. */
+            if (flowKey->ct.tuple_ipv4.ipv4_proto != IPPROTO_ICMP) {
+                ctKey->src.port = flowKey->ct.tuple_ipv4.src_port;
+                ctKey->dst.port = flowKey->ct.tuple_ipv4.dst_port;
+            }
         }
    }
 }


### PR DESCRIPTION
`OvsPickupCtTupleAsLookupKey` restores a committed connection's original tuple into the conntrack lookup key when the flow key carries one. It copied the tuple's `src_port`/`dst_port` into `ctKey->src.port`/`dst.port` unconditionally.

For ICMP those tuple fields don't hold a transport port — `src_port` is `htons(icmp_type)` and `dst_port` is `htons(icmp_code)` (see `OvsCtUpdateTuple`). Because `src.port` and `src.icmp_id` share a union in `struct ct_endpoint`, this overwrote the packet-derived `icmp_id` with `htons(icmp_type)` and left the reply-direction `icmp_id` zero, so the entry's reply tuple never matched the echo reply and the reply was dropped.

This only bit the second `ct()` of a recirculated, multi-stage same-zone pipeline (the first stage commits and populates `flowKey->ct.tuple_ipv4`; the second stage then trips the pickup path) — which is exactly the shape OVN emits for stateful ACLs. The result was ~100% loss for guest-to-guest traffic under any stateful ACL. The defect has been present since the function was introduced and is independent of the protocol family for non-ICMP traffic.

The fix skips the port copy for ICMP; the `icmp_id`, type and code are already set from the packet. Addresses and `nw_proto` are still carried over.

Validated live on the Windows datapath: a synthetic two-stage same-zone `ct()` pipeline reproduced the corrupt entry (orig `id=2048`, reply `id=0`) before the change and produces a single correct entry after; with a real OVN `allow-related` ACL on the guests' logical switch, intra-switch ping went from 100% loss to 0%, and both the pre- and post-recirculation conntrack entries carry matching original/reply ids.