### PR TITLE
datapath-windows: validate flow-action attribute sizes at install time

### DIFF
--- a/datapath-windows/ovsext/Actions.c
+++ b/datapath-windows/ovsext/Actions.c
@@ -2116,8 +2116,11 @@ OvsOutputUserspaceAction(OvsForwardingContext *ovsFwdCtx,
         tunKey.flow_hash = tunKey.flow_hash ? tunKey.flow_hash : MAXINT16;
     }
 
-    elem = OvsCreateQueueNlPacket(NlAttrData(userdataAttr),
-                                  NlAttrGetSize(userdataAttr),
+    /* OVS_USERSPACE_ATTR_USERDATA is optional, so userdataAttr may be NULL;
+     * OvsCreateQueueNlPacket accepts a NULL/zero-length userdata. Do not pass
+     * it through NlAttrData/NlAttrGetSize, which would dereference NULL. */
+    elem = OvsCreateQueueNlPacket(userdataAttr ? NlAttrData(userdataAttr) : NULL,
+                                  userdataAttr ? NlAttrGetSize(userdataAttr) : 0,
                                   OVS_PACKET_CMD_ACTION,
                                   vport, key,
                                   egrTunAttr ? &(tunKey) : NULL,

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -1632,42 +1632,68 @@ OvsValidateActionSizes(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
                         return FALSE;
                     }
                 }
+                /* A non-zero remainder means a malformed tunnel sub-attribute
+                 * stopped the walk early; OvsTunnelAttrToIPTunnelKey walks the
+                 * same stream and would read past it. Reject the stream. */
+                if (trem != 0) {
+                    return FALSE;
+                }
             }
             break;
         }
         case OVS_ACTION_ATTR_SAMPLE: {
-            const PNL_ATTR prob =
-                NlAttrFindNested(a, OVS_SAMPLE_ATTR_PROBABILITY);
-            const PNL_ATTR nested =
-                NlAttrFindNested(a, OVS_SAMPLE_ATTR_ACTIONS);
-            if (prob && NlAttrGetSize(prob) < sizeof(UINT32)) {
-                return FALSE;
+            /* OvsExecuteSampleAction walks the sample's sub-attributes with
+             * NL_ATTR_FOR_EACH_UNSAFE, so walk them here with bounds checking
+             * and reject any malformed remainder rather than relying on a
+             * lookup that stops silently. */
+            PNL_ATTR sub;
+            INT srem;
+            NL_ATTR_FOR_EACH (sub, srem, NlAttrData(a), NlAttrGetSize(a)) {
+                switch (NlAttrType(sub)) {
+                case OVS_SAMPLE_ATTR_PROBABILITY:
+                    if (NlAttrGetSize(sub) < sizeof(UINT32)) {
+                        return FALSE;
+                    }
+                    break;
+                case OVS_SAMPLE_ATTR_ACTIONS:
+                    if (!OvsValidateActionSizes(NlAttrData(sub),
+                                                NlAttrGetSize(sub),
+                                                depth + 1)) {
+                        return FALSE;
+                    }
+                    break;
+                }
             }
-            if (nested &&
-                !OvsValidateActionSizes(NlAttrData(nested),
-                                        NlAttrGetSize(nested), depth + 1)) {
+            if (srem != 0) {
                 return FALSE;
             }
             break;
         }
         case OVS_ACTION_ATTR_CHECK_PKT_LEN: {
-            const PNL_ATTR pktLen =
-                NlAttrFindNested(a, OVS_CHECK_PKT_LEN_ATTR_PKT_LEN);
-            const PNL_ATTR gtr = NlAttrFindNested(a,
-                OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER);
-            const PNL_ATTR leq = NlAttrFindNested(a,
-                OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_LESS_EQUAL);
-            if (pktLen && NlAttrGetSize(pktLen) < sizeof(UINT16)) {
-                return FALSE;
+            /* OvsExecuteCheckPktLen walks the sub-attributes with
+             * NL_ATTR_FOR_EACH_UNSAFE, so walk them here with bounds checking
+             * and reject any malformed remainder rather than relying on a
+             * lookup that stops silently. */
+            PNL_ATTR sub;
+            INT crem;
+            NL_ATTR_FOR_EACH (sub, crem, NlAttrData(a), NlAttrGetSize(a)) {
+                switch (NlAttrType(sub)) {
+                case OVS_CHECK_PKT_LEN_ATTR_PKT_LEN:
+                    if (NlAttrGetSize(sub) < sizeof(UINT16)) {
+                        return FALSE;
+                    }
+                    break;
+                case OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER:
+                case OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_LESS_EQUAL:
+                    if (!OvsValidateActionSizes(NlAttrData(sub),
+                                                NlAttrGetSize(sub),
+                                                depth + 1)) {
+                        return FALSE;
+                    }
+                    break;
+                }
             }
-            if (gtr &&
-                !OvsValidateActionSizes(NlAttrData(gtr),
-                                        NlAttrGetSize(gtr), depth + 1)) {
-                return FALSE;
-            }
-            if (leq &&
-                !OvsValidateActionSizes(NlAttrData(leq),
-                                        NlAttrGetSize(leq), depth + 1)) {
+            if (crem != 0) {
                 return FALSE;
             }
             break;
@@ -1679,11 +1705,20 @@ OvsValidateActionSizes(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
             }
             break;
         case OVS_ACTION_ATTR_DEC_TTL: {
-            const PNL_ATTR nested =
-                NlAttrFindNested(a, OVS_DEC_TTL_ATTR_ACTION);
-            if (nested &&
-                !OvsValidateActionSizes(NlAttrData(nested),
-                                        NlAttrGetSize(nested), depth + 1)) {
+            /* On TTL expiry the executor runs the embedded
+             * OVS_DEC_TTL_ATTR_ACTION list. Walk the sub-attributes here with
+             * bounds checking and reject any malformed remainder rather than
+             * relying on a lookup that stops silently. */
+            PNL_ATTR sub;
+            INT drem;
+            NL_ATTR_FOR_EACH (sub, drem, NlAttrData(a), NlAttrGetSize(a)) {
+                if (NlAttrType(sub) == OVS_DEC_TTL_ATTR_ACTION &&
+                    !OvsValidateActionSizes(NlAttrData(sub),
+                                            NlAttrGetSize(sub), depth + 1)) {
+                    return FALSE;
+                }
+            }
+            if (drem != 0) {
                 return FALSE;
             }
             break;
@@ -1695,6 +1730,16 @@ OvsValidateActionSizes(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
              * validated by the action's own handler. */
             break;
         }
+    }
+
+    /* NL_ATTR_FOR_EACH stops as soon as it meets an attribute whose length is
+     * malformed, leaving 'rem' non-zero. The executor walks the same stream
+     * with NL_ATTR_FOR_EACH_UNSAFE, which does no such bounds check and would
+     * read past a short attribute. A non-zero remainder therefore means the
+     * stream cannot be safely replayed: reject it. This also covers every
+     * recursed action list, since each recursion runs this same loop. */
+    if (rem != 0) {
+        return FALSE;
     }
 
     return TRUE;

--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -1530,6 +1530,178 @@ done:
 
 /*
  *----------------------------------------------------------------------------
+ *  OvsValidateActionSizes --
+ *    Validates, once at flow-install time (PASSIVE_LEVEL), that every action
+ *    attribute the executor later reads at DISPATCH_LEVEL is large enough for
+ *    that read. Installed actions are stored verbatim and replayed by
+ *    OvsDoExecuteActions with no per-read size check (the NlAttrGet* accessors
+ *    only ASSERT the size, so a short attribute is an out-of-bounds read in the
+ *    hot path / a checked-build bugcheck). Rejecting an undersized action here
+ *    keeps the executor safe without a guard on every DISPATCH read.
+ *
+ *    Only minimum sizes are enforced (>=), never an exact match, so a
+ *    well-formed action carrying trailing bytes is still accepted. Variable
+ *    length actions whose payload is validated by their own handler (CT) or
+ *    that the executor reads without a fixed-size accessor are left untouched.
+ *    Recursion into nested action lists is bounded like the executor's
+ *    deferred-action nesting capacity.
+ *
+ *  Results:
+ *    TRUE if every checked attribute is adequately sized; FALSE otherwise.
+ *----------------------------------------------------------------------------
+ */
+static BOOLEAN
+OvsValidateActionSizes(const PNL_ATTR actions, INT actionsLen, UINT32 depth)
+{
+    const UINT32 maxDepth = DEFERRED_ACTION_QUEUE_SIZE;
+    PNL_ATTR a;
+    INT rem;
+
+    if (depth > maxDepth) {
+        return FALSE;
+    }
+
+    NL_ATTR_FOR_EACH (a, rem, actions, actionsLen) {
+        UINT32 size = NlAttrGetSize(a);
+
+        switch (NlAttrType(a)) {
+        case OVS_ACTION_ATTR_OUTPUT:
+        case OVS_ACTION_ATTR_RECIRC:
+        case OVS_ACTION_ATTR_METER:
+            if (size < sizeof(UINT32)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_POP_MPLS:
+            if (size < sizeof(ovs_be16)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_PUSH_VLAN:
+            if (size < sizeof(struct ovs_action_push_vlan)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_PUSH_MPLS:
+            if (size < sizeof(struct ovs_action_push_mpls)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_ADD_MPLS:
+            if (size < sizeof(struct ovs_action_add_mpls)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_HASH:
+            if (size < sizeof(struct ovs_action_hash)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_SET: {
+            /* The SET payload is a single nested flow-key attribute that
+             * OvsExecuteSetAction reads. Enforce that key attribute's minimum
+             * length, and for a tunnel set validate the sub-attributes
+             * OvsTunnelAttrToIPTunnelKey reads. */
+            PNL_ATTR setKey;
+            UINT32 keyType;
+
+            if (size < NLA_HDRLEN) {
+                return FALSE;
+            }
+            setKey = (PNL_ATTR)NlAttrData(a);
+            /* The nested key attribute must itself fit within the SET payload
+             * before its length/type are trusted below. */
+            if (!NlAttrIsValid(setKey, size)) {
+                return FALSE;
+            }
+            keyType = NlAttrType(setKey);
+            if (keyType < ARRAY_SIZE(nlFlowKeyPolicy) &&
+                nlFlowKeyPolicy[keyType].minLen &&
+                NlAttrGetSize(setKey) < nlFlowKeyPolicy[keyType].minLen) {
+                return FALSE;
+            }
+            if (keyType == OVS_KEY_ATTR_TUNNEL) {
+                PNL_ATTR t;
+                INT trem;
+                NL_ATTR_FOR_EACH (t, trem, NlAttrData(setKey),
+                                  NlAttrGetSize(setKey)) {
+                    UINT32 tt = NlAttrType(t);
+                    if (tt < ARRAY_SIZE(nlFlowTunnelKeyPolicy) &&
+                        nlFlowTunnelKeyPolicy[tt].minLen &&
+                        NlAttrGetSize(t) < nlFlowTunnelKeyPolicy[tt].minLen) {
+                        return FALSE;
+                    }
+                }
+            }
+            break;
+        }
+        case OVS_ACTION_ATTR_SAMPLE: {
+            const PNL_ATTR prob =
+                NlAttrFindNested(a, OVS_SAMPLE_ATTR_PROBABILITY);
+            const PNL_ATTR nested =
+                NlAttrFindNested(a, OVS_SAMPLE_ATTR_ACTIONS);
+            if (prob && NlAttrGetSize(prob) < sizeof(UINT32)) {
+                return FALSE;
+            }
+            if (nested &&
+                !OvsValidateActionSizes(NlAttrData(nested),
+                                        NlAttrGetSize(nested), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        case OVS_ACTION_ATTR_CHECK_PKT_LEN: {
+            const PNL_ATTR pktLen =
+                NlAttrFindNested(a, OVS_CHECK_PKT_LEN_ATTR_PKT_LEN);
+            const PNL_ATTR gtr = NlAttrFindNested(a,
+                OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_GREATER);
+            const PNL_ATTR leq = NlAttrFindNested(a,
+                OVS_CHECK_PKT_LEN_ATTR_ACTIONS_IF_LESS_EQUAL);
+            if (pktLen && NlAttrGetSize(pktLen) < sizeof(UINT16)) {
+                return FALSE;
+            }
+            if (gtr &&
+                !OvsValidateActionSizes(NlAttrData(gtr),
+                                        NlAttrGetSize(gtr), depth + 1)) {
+                return FALSE;
+            }
+            if (leq &&
+                !OvsValidateActionSizes(NlAttrData(leq),
+                                        NlAttrGetSize(leq), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        case OVS_ACTION_ATTR_CLONE:
+            if (!OvsValidateActionSizes(NlAttrData(a), NlAttrGetSize(a),
+                                        depth + 1)) {
+                return FALSE;
+            }
+            break;
+        case OVS_ACTION_ATTR_DEC_TTL: {
+            const PNL_ATTR nested =
+                NlAttrFindNested(a, OVS_DEC_TTL_ATTR_ACTION);
+            if (nested &&
+                !OvsValidateActionSizes(NlAttrData(nested),
+                                        NlAttrGetSize(nested), depth + 1)) {
+                return FALSE;
+            }
+            break;
+        }
+        default:
+            /* Variable-length or payload-less actions (USERSPACE, CT,
+             * CT_CLEAR, POP_VLAN, TRUNC, DROP, ...): no fixed-size field is
+             * read here through a size-unchecked accessor, or the payload is
+             * validated by the action's own handler. */
+            break;
+        }
+    }
+
+    return TRUE;
+}
+
+/*
+ *----------------------------------------------------------------------------
  *  _MapNlToFlowPut --
  *    Maps input netlink message to OvsFlowPut.
  *----------------------------------------------------------------------------
@@ -1623,6 +1795,17 @@ _MapNlToFlowPut(POVS_MESSAGE msgIn, PNL_ATTR keyAttr,
     if (actionAttr) {
         mappedFlow->actionsLen = NlAttrGetSize(actionAttr);
         mappedFlow->actions = NlAttrGet(actionAttr);
+        /* The actions are stored verbatim and replayed at DISPATCH_LEVEL
+         * without per-read size checks; reject malformed action lengths now,
+         * at install time, so the executor's accessors never read past an
+         * attribute. */
+        if (!OvsValidateActionSizes(mappedFlow->actions,
+                                    mappedFlow->actionsLen, 0)) {
+            OVS_LOG_ERROR("Flow actions failed size validation, msg: %p",
+                          &(msgIn->nlMsg));
+            rc = STATUS_INVALID_PARAMETER;
+            goto done;
+        }
     }
 
     mappedFlow->dpNo = ovsHdr->dp_ifindex;


### PR DESCRIPTION
Installed flow actions are stored verbatim and replayed by `OvsDoExecuteActions` at `DISPATCH_LEVEL` with no per-read size check — the `NlAttrGet*` accessors only `ASSERT` the attribute length, so an action attribute shorter than the field the executor reads is an out-of-bounds read in the forwarding hot path (a bugcheck on checked builds, a silent over-read on free builds). The policy that should have caught this (`nlFlowActionPolicy`) was defined but never referenced, and the only other check (`OvsProbeActionsSupported`) is type-only and runs on the probe path.

This validates the action list **once, at flow-install time** (`PASSIVE_LEVEL`, in `_MapNlToFlowPut`) so the DISPATCH replay needs no per-read guards: it walks the actions and requires each attribute the executor reads with a fixed-size accessor to be large enough (OUTPUT/RECIRC/METER u32, POP_MPLS be16, PUSH_VLAN/PUSH_MPLS/ADD_MPLS/HASH structs), recursing into clone/sample/check_pkt_len/dec_ttl and validating their sized leaves (sample probability, check_pkt_len pkt_len) and the nested set key (including tunnel sub-attributes). Only minimum sizes are enforced, so a well-formed action carrying trailing bytes is still accepted, and recursion is depth-bounded. A malformed action list is rejected with an error instead of reaching the executor.

Also guards `OvsOutputUserspaceAction` against a missing (optional) `OVS_USERSPACE_ATTR_USERDATA`, which was passed through `NlAttrData`/`NlAttrGetSize` and would dereference NULL at `DISPATCH_LEVEL`.

Validated live on the Windows datapath: a full eryph/OVN stack installs its entire pipeline (912 br-int OpenFlow flows) with no flow rejected, and guest-to-guest forwarding is unaffected both for plain output and through the action-rich stateful-ACL ct/recirc path (0% loss in both cases).