### PR TITLE
datapath-windows: ETW driver logging + registry log configuration

### DIFF
--- a/datapath-windows/deploy-driver.ps1
+++ b/datapath-windows/deploy-driver.ps1
@@ -59,8 +59,10 @@ Write-Host "local DBO_OVSE.sys = $localHash" -ForegroundColor DarkGray
 Invoke-Remote 'Get-ChildItem C:\ovs-test\driver -File -EA SilentlyContinue | Remove-Item -Force'
 & $egs upload-directory $VmId $pkg 'C:\ovs-test\driver' | Select-Object -Last 1
 
-# refresh the diagnostics helper (ovs-tcpdump.ps1 pktmon capture) alongside it.
+# refresh the diagnostics helpers alongside it: ovs-tcpdump.ps1 (pktmon capture)
+# and ovs-drvtrace.ps1 (driver ETW log capture).
 & $egs upload-file $VmId (Join-Path $here 'utilities\ovs-tcpdump.ps1') 'C:\ovs-test\ovs-tcpdump.ps1' --overwrite | Select-Object -Last 1
+& $egs upload-file $VmId (Join-Path $here 'utilities\ovs-drvtrace.ps1') 'C:\ovs-test\ovs-drvtrace.ps1' --overwrite | Select-Object -Last 1
 
 $stopList = if ($KeepNestedRunning) { '@()' } else { "@('" + ($NestedVMs -join "','") + "')" }
 $startBackLit = if ($KeepNestedRunning) { '$false' } else { '$true' }

--- a/datapath-windows/ovsext/Debug.c
+++ b/datapath-windows/ovsext/Debug.c
@@ -17,6 +17,9 @@
 #include "precomp.h"
 
 #include "Debug.h"
+#include <evntrace.h>            /* TRACE_LEVEL_* (winmeta.h is user-mode only) */
+#include <TraceLoggingProvider.h>
+
 #ifdef DBG
 #define OVS_DBG_DEFAULT  OVS_DBG_INFO
 #else
@@ -30,11 +33,72 @@ BUILD_ASSERT(OVS_DBG_LAST < 31); /* 'ovsLogLevel' is 32 bits. */
 #define OVS_LOG_BUFFER_SIZE 384
 
 /*
+ * TraceLogging provider for capturing driver logs without a kernel debugger.
+ * Decodes self-describing (no TMF/PDB needed) with stock tools:
+ *   wpr -start <profile> / tracelog / logman, read with WPA / tracefmt / PerfView.
+ * The DbgPrintEx sink below is retained for the in-debugger dev loop.
+ */
+TRACELOGGING_DEFINE_PROVIDER(
+    g_OvsTraceLoggingProvider,
+    "Dbosoft.OVS.Ovsext",
+    /* {b2d1f6a4-9c3e-4f7a-a15b-6d8e2c4f7093} */
+    (0xb2d1f6a4, 0x9c3e, 0x4f7a, 0xa1, 0x5b, 0x6d, 0x8e, 0x2c, 0x4f, 0x70, 0x93));
+
+/*
+ * Map the driver's DPFLTR-style severity (lower == more severe) to the ETW
+ * level scale (higher == more verbose) so ETW session level filtering behaves
+ * intuitively.
+ */
+static __inline UCHAR
+OvsLogEtwLevel(UINT32 level)
+{
+    switch (level) {
+    case OVS_DBG_ERROR: return TRACE_LEVEL_ERROR;
+    case OVS_DBG_WARN:  return TRACE_LEVEL_WARNING;
+    case OVS_DBG_TRACE: return TRACE_LEVEL_INFORMATION;
+    case OVS_DBG_INFO:  return TRACE_LEVEL_INFORMATION;
+    default:            return TRACE_LEVEL_VERBOSE;
+    }
+}
+
+NTSTATUS
+OvsTraceLoggingRegister(VOID)
+{
+    return TraceLoggingRegister(g_OvsTraceLoggingProvider);
+}
+
+VOID
+OvsTraceLoggingUnregister(VOID)
+{
+    TraceLoggingUnregister(g_OvsTraceLoggingProvider);
+}
+
+/*
  * --------------------------------------------------------------------------
  * OvsLog --
- *  Utility function to log to the Windows debug console.
+ *  Utility function to log to the Windows debug console (DbgPrintEx, gated by
+ *  ovsLogLevel/ovsLogFlags for the in-debugger dev loop) and to the ETW
+ *  TraceLogging provider (gated independently by the listening session, so a
+ *  production capture can collect levels the debug console is configured to
+ *  drop). The module bitmask rides as the "Module" payload field for
+ *  post-capture per-subsystem filtering.
  * --------------------------------------------------------------------------
  */
+
+/*
+ * TraceLoggingLevel() must be a compile-time constant (it is baked into the
+ * static event descriptor), so the runtime level is dispatched to a per-level
+ * write. The field set is identical across levels.
+ */
+#define OVS_ETW_WRITE(_lvl)                                              \
+    TraceLoggingWrite(g_OvsTraceLoggingProvider, "OvsLog",              \
+        TraceLoggingLevel(_lvl),                                        \
+        TraceLoggingUInt32(level, "OvsLevel"),                          \
+        TraceLoggingUInt32(flag, "Module"),                             \
+        TraceLoggingString(funcName, "Function"),                       \
+        TraceLoggingUInt32(line, "Line"),                               \
+        TraceLoggingString(buf, "Message"))
+
 VOID
 OvsLog(UINT32 level,
        UINT32 flag,
@@ -45,8 +109,12 @@ OvsLog(UINT32 level,
 {
     va_list args;
     CHAR buf[OVS_LOG_BUFFER_SIZE];
+    BOOLEAN dbgWanted = (level <= ovsLogLevel && (ovsLogFlags & flag) != 0);
+    UCHAR etwLevel = OvsLogEtwLevel(level);
+    BOOLEAN etwWanted = TraceLoggingProviderEnabled(g_OvsTraceLoggingProvider,
+                                                    etwLevel, 0);
 
-    if (level > ovsLogLevel || (ovsLogFlags & flag) == 0) {
+    if (!dbgWanted && !etwWanted) {
         return;
     }
 
@@ -55,5 +123,17 @@ OvsLog(UINT32 level,
     RtlStringCbVPrintfA(buf, sizeof (buf), format, args);
     va_end(args);
 
-    DbgPrintEx(DPFLTR_IHVNETWORK_ID, level, "%s:%lu %s\n", funcName, line, buf);
+    if (dbgWanted) {
+        DbgPrintEx(DPFLTR_IHVNETWORK_ID, level, "%s:%lu %s\n",
+                   funcName, line, buf);
+    }
+
+    if (etwWanted) {
+        switch (etwLevel) {
+        case TRACE_LEVEL_ERROR:       OVS_ETW_WRITE(TRACE_LEVEL_ERROR); break;
+        case TRACE_LEVEL_WARNING:     OVS_ETW_WRITE(TRACE_LEVEL_WARNING); break;
+        case TRACE_LEVEL_INFORMATION: OVS_ETW_WRITE(TRACE_LEVEL_INFORMATION); break;
+        default:                      OVS_ETW_WRITE(TRACE_LEVEL_VERBOSE); break;
+        }
+    }
 }

--- a/datapath-windows/ovsext/Debug.h
+++ b/datapath-windows/ovsext/Debug.h
@@ -54,8 +54,20 @@
 
 
 
+/*
+ * Logging verbosity (max OVS_DBG_* level emitted) and the per-module enable
+ * mask. Compile-time defaults; overridable at load from the registry
+ * (see Registry.c). Read on the hot path, so plain globals (no lock).
+ */
+extern UINT32 ovsLogLevel;
+extern UINT32 ovsLogFlags;
+
 VOID OvsLog(UINT32 level, UINT32 flag, CHAR *funcName,
             UINT32 line, CHAR *format, ...);
+
+/* ETW TraceLogging provider lifecycle (registered for the driver's lifetime). */
+NTSTATUS OvsTraceLoggingRegister(VOID);
+VOID OvsTraceLoggingUnregister(VOID);
 
 
 #define OVS_LOG_LOUD(_format, ...) \

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -28,7 +28,7 @@
 #ifdef OVS_DBG_MOD
 #undef OVS_DBG_MOD
 #endif
-#define OVS_DBG_MOD OVS_DBG_DRIVER
+#define OVS_DBG_MOD OVS_DBG_INIT
 #include "Debug.h"
 
 /* Global handles. XXX: Some of them need not be global. */
@@ -100,14 +100,20 @@ DriverEntry(PDRIVER_OBJECT driverObject,
             PUNICODE_STRING registryPath)
 {
     NDIS_STATUS status;
+    NTSTATUS tlStatus;
     NDIS_FILTER_DRIVER_CHARACTERISTICS driverChars;
 
     /*
      * Register the ETW provider first so logging is captured for the whole load
-     * sequence. A registration failure is non-fatal: DbgPrintEx still works and
-     * the driver must still load, so the result is intentionally not checked.
+     * sequence. A registration failure is non-fatal - DbgPrintEx still works and
+     * the driver must still load - but report it so the absence of ETW logs is
+     * diagnosable rather than mysterious.
      */
-    OvsTraceLoggingRegister();
+    tlStatus = OvsTraceLoggingRegister();
+    if (!NT_SUCCESS(tlStatus)) {
+        OVS_LOG_WARN("ETW provider registration failed (status 0x%08x); "
+                     "driver logs available via DbgPrint only", tlStatus);
+    }
 
     /*
      * Apply registry logging overrides before any further logging so the rest

--- a/datapath-windows/ovsext/Driver.c
+++ b/datapath-windows/ovsext/Driver.c
@@ -23,6 +23,7 @@
 #include "IpFragment.h"
 #include "Ip6Fragment.h"
 #include "Meter.h"
+#include "Registry.h"
 
 #ifdef OVS_DBG_MOD
 #undef OVS_DBG_MOD
@@ -101,7 +102,19 @@ DriverEntry(PDRIVER_OBJECT driverObject,
     NDIS_STATUS status;
     NDIS_FILTER_DRIVER_CHARACTERISTICS driverChars;
 
-    UNREFERENCED_PARAMETER(registryPath);
+    /*
+     * Register the ETW provider first so logging is captured for the whole load
+     * sequence. A registration failure is non-fatal: DbgPrintEx still works and
+     * the driver must still load, so the result is intentionally not checked.
+     */
+    OvsTraceLoggingRegister();
+
+    /*
+     * Apply registry logging overrides before any further logging so the rest
+     * of the load sequence honours the configured level/module mask. Failure is
+     * non-fatal (the compile-time defaults stand).
+     */
+    OvsReadDriverConfig(registryPath);
 
     /* Initialize driver associated data structures. */
     status = OvsInit();
@@ -274,6 +287,8 @@ DriverEntry(PDRIVER_OBJECT driverObject,
 cleanup:
     if (status != NDIS_STATUS_SUCCESS){
         OvsCleanup();
+        /* OvsExtUnload does not run when DriverEntry fails; unregister here. */
+        OvsTraceLoggingUnregister();
     }
 
     return status;
@@ -316,6 +331,9 @@ OvsExtUnload(struct _DRIVER_OBJECT *driverObject)
 
     /* Release driver associated data structures. */
     OvsCleanup();
+
+    /* Unregister the ETW provider last so teardown logging is still captured. */
+    OvsTraceLoggingUnregister();
 }
 
 

--- a/datapath-windows/ovsext/Registry.c
+++ b/datapath-windows/ovsext/Registry.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 dbosoft GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "precomp.h"
+#include "Registry.h"
+
+#ifdef OVS_DBG_MOD
+#undef OVS_DBG_MOD
+#endif
+#define OVS_DBG_MOD OVS_DBG_INIT
+#include "Debug.h"
+
+/*
+ * Read the driver-global configuration from <service key>\Parameters. The
+ * service key absolute path is the registryPath the I/O manager hands to
+ * DriverEntry; the values live under its Parameters subkey by convention.
+ *
+ * RTL_QUERY_REGISTRY_DIRECT writes straight into the target global; seeding
+ * DefaultData with the current value makes an absent value a no-op, so the
+ * compile-time defaults stand on a clean install. TYPECHECK rejects a value of
+ * the wrong type rather than mis-coercing it.
+ */
+NTSTATUS
+OvsReadDriverConfig(PUNICODE_STRING registryPath)
+{
+    static const WCHAR paramsSuffix[] = L"\\Parameters";
+    WCHAR path[512];
+    USHORT chars;
+    ULONG defLevel, defMask;
+    RTL_QUERY_REGISTRY_TABLE table[3];
+    NTSTATUS status;
+
+    if (registryPath == NULL || registryPath->Buffer == NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    chars = registryPath->Length / sizeof(WCHAR);
+    if ((SIZE_T)chars + RTL_NUMBER_OF(paramsSuffix) > RTL_NUMBER_OF(path)) {
+        OVS_LOG_WARN("registry path too long (%u chars); using log defaults",
+                     chars);
+        return STATUS_BUFFER_OVERFLOW;
+    }
+
+    /* Build a NUL-terminated "<registryPath>\Parameters". */
+    RtlCopyMemory(path, registryPath->Buffer, registryPath->Length);
+    RtlCopyMemory(&path[chars], paramsSuffix, sizeof(paramsSuffix));
+
+    defLevel = ovsLogLevel;
+    defMask = ovsLogFlags;
+
+    RtlZeroMemory(table, sizeof(table));
+
+    table[0].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    table[0].Name = L"LogLevel";
+    table[0].EntryContext = &ovsLogLevel;
+    table[0].DefaultType =
+        (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT) | REG_DWORD;
+    table[0].DefaultData = &defLevel;
+    table[0].DefaultLength = sizeof(ULONG);
+
+    table[1].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    table[1].Name = L"LogModuleMask";
+    table[1].EntryContext = &ovsLogFlags;
+    table[1].DefaultType =
+        (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT) | REG_DWORD;
+    table[1].DefaultData = &defMask;
+    table[1].DefaultLength = sizeof(ULONG);
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, path, table,
+                                    NULL, NULL);
+    /*
+     * A missing Parameters key is expected (default install) and still leaves
+     * the DIRECT targets at their seeded defaults, so treat that as "no
+     * overrides". Any other failure means a present-but-malformed value (e.g. a
+     * wrong type rejected by TYPECHECK) aborted the whole query and discarded
+     * even the valid sibling value; surface it so a field misconfiguration is
+     * not silently mistaken for a clean install.
+     */
+    if (!NT_SUCCESS(status)) {
+        ovsLogLevel = defLevel;
+        ovsLogFlags = defMask;
+        if (status != STATUS_OBJECT_NAME_NOT_FOUND) {
+            OVS_LOG_WARN("registry log config rejected (status 0x%08x); "
+                         "using defaults", status);
+        }
+    }
+
+    /* Clamp to the valid OVS_DBG_* range; a bad value must not be honoured. */
+    if (ovsLogLevel > OVS_DBG_LOUD) {
+        ovsLogLevel = OVS_DBG_LOUD;
+    }
+
+    OVS_LOG_INFO("log config applied: level=%u moduleMask=0x%08x",
+                 ovsLogLevel, ovsLogFlags);
+
+    return STATUS_SUCCESS;
+}

--- a/datapath-windows/ovsext/Registry.c
+++ b/datapath-windows/ovsext/Registry.c
@@ -24,79 +24,82 @@
 #include "Debug.h"
 
 /*
+ * Read one REG_DWORD knob from the Parameters key into *target, keeping the
+ * passed-in default (the current global) when the value is absent or rejected.
+ *
+ * RTL_QUERY_REGISTRY_DIRECT writes straight into the target; seeding
+ * DefaultData with the current value makes an absent value a no-op, so the
+ * compile-time defaults stand on a clean install. TYPECHECK rejects a value of
+ * the wrong type rather than mis-coercing it. Each knob is queried on its own
+ * so a malformed value cannot discard a valid sibling.
+ */
+static VOID
+OvsReadLogDword(PCWSTR path, PCWSTR name, UINT32 *target)
+{
+    UINT32 def = *target;
+    RTL_QUERY_REGISTRY_TABLE table[2];
+    NTSTATUS status;
+
+    RtlZeroMemory(table, sizeof(table));
+    table[0].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    table[0].Name = (PWSTR)name;
+    table[0].EntryContext = target;
+    table[0].DefaultType =
+        (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT) | REG_DWORD;
+    table[0].DefaultData = &def;
+    table[0].DefaultLength = sizeof(ULONG);
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, (PWSTR)path, table,
+                                    NULL, NULL);
+    /*
+     * A missing value/key is expected (default install) and leaves the DIRECT
+     * target at the seeded default. Any other failure means a present-but-
+     * malformed value (e.g. a wrong type rejected by TYPECHECK); restore the
+     * default and surface it so a field misconfiguration is not silently
+     * mistaken for "not set".
+     */
+    if (!NT_SUCCESS(status)) {
+        *target = def;
+        if (status != STATUS_OBJECT_NAME_NOT_FOUND) {
+            OVS_LOG_WARN("registry value '%S' rejected (status 0x%08x); "
+                         "keeping default 0x%x", name, status, def);
+        }
+    }
+}
+
+/*
  * Read the driver-global configuration from <service key>\Parameters. The
  * service key absolute path is the registryPath the I/O manager hands to
  * DriverEntry; the values live under its Parameters subkey by convention.
  *
- * RTL_QUERY_REGISTRY_DIRECT writes straight into the target global; seeding
- * DefaultData with the current value makes an absent value a no-op, so the
- * compile-time defaults stand on a clean install. TYPECHECK rejects a value of
- * the wrong type rather than mis-coercing it.
+ * Best-effort and non-fatal: any failure leaves the compile-time logging
+ * defaults in place, so there is no status for the caller to act on.
  */
-NTSTATUS
+VOID
 OvsReadDriverConfig(PUNICODE_STRING registryPath)
 {
     static const WCHAR paramsSuffix[] = L"\\Parameters";
     WCHAR path[512];
     USHORT chars;
-    ULONG defLevel, defMask;
-    RTL_QUERY_REGISTRY_TABLE table[3];
-    NTSTATUS status;
 
     if (registryPath == NULL || registryPath->Buffer == NULL) {
-        return STATUS_INVALID_PARAMETER;
+        return;
     }
 
     chars = registryPath->Length / sizeof(WCHAR);
     if ((SIZE_T)chars + RTL_NUMBER_OF(paramsSuffix) > RTL_NUMBER_OF(path)) {
         OVS_LOG_WARN("registry path too long (%u chars); using log defaults",
                      chars);
-        return STATUS_BUFFER_OVERFLOW;
+        return;
     }
 
     /* Build a NUL-terminated "<registryPath>\Parameters". */
     RtlCopyMemory(path, registryPath->Buffer, registryPath->Length);
     RtlCopyMemory(&path[chars], paramsSuffix, sizeof(paramsSuffix));
 
-    defLevel = ovsLogLevel;
-    defMask = ovsLogFlags;
-
-    RtlZeroMemory(table, sizeof(table));
-
-    table[0].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
-    table[0].Name = L"LogLevel";
-    table[0].EntryContext = &ovsLogLevel;
-    table[0].DefaultType =
-        (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT) | REG_DWORD;
-    table[0].DefaultData = &defLevel;
-    table[0].DefaultLength = sizeof(ULONG);
-
-    table[1].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
-    table[1].Name = L"LogModuleMask";
-    table[1].EntryContext = &ovsLogFlags;
-    table[1].DefaultType =
-        (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT) | REG_DWORD;
-    table[1].DefaultData = &defMask;
-    table[1].DefaultLength = sizeof(ULONG);
-
-    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, path, table,
-                                    NULL, NULL);
-    /*
-     * A missing Parameters key is expected (default install) and still leaves
-     * the DIRECT targets at their seeded defaults, so treat that as "no
-     * overrides". Any other failure means a present-but-malformed value (e.g. a
-     * wrong type rejected by TYPECHECK) aborted the whole query and discarded
-     * even the valid sibling value; surface it so a field misconfiguration is
-     * not silently mistaken for a clean install.
-     */
-    if (!NT_SUCCESS(status)) {
-        ovsLogLevel = defLevel;
-        ovsLogFlags = defMask;
-        if (status != STATUS_OBJECT_NAME_NOT_FOUND) {
-            OVS_LOG_WARN("registry log config rejected (status 0x%08x); "
-                         "using defaults", status);
-        }
-    }
+    /* Each knob is read independently: a bad value falls back on its own. */
+    OvsReadLogDword(path, L"LogLevel", &ovsLogLevel);
+    OvsReadLogDword(path, L"LogModuleMask", &ovsLogFlags);
 
     /* Clamp to the valid OVS_DBG_* range; a bad value must not be honoured. */
     if (ovsLogLevel > OVS_DBG_LOUD) {
@@ -105,6 +108,4 @@ OvsReadDriverConfig(PUNICODE_STRING registryPath)
 
     OVS_LOG_INFO("log config applied: level=%u moduleMask=0x%08x",
                  ovsLogLevel, ovsLogFlags);
-
-    return STATUS_SUCCESS;
 }

--- a/datapath-windows/ovsext/Registry.h
+++ b/datapath-windows/ovsext/Registry.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 dbosoft GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGISTRY_H_
+#define __REGISTRY_H_ 1
+
+/*
+ * Driver-global configuration read once from the service Parameters key
+ * (HKLM\SYSTEM\CurrentControlSet\Services\DBO_OVSE\Parameters) at load.
+ *
+ * Currently the diagnostics/logging knobs:
+ *   LogLevel       REG_DWORD  max OVS_DBG_* level emitted (0=Error..4=Loud)
+ *   LogModuleMask  REG_DWORD  per-module OVS_DBG_* enable bitmask
+ *
+ * Each knob defaults to the compile-time value when absent, so a clean install
+ * behaves identically to one with no Parameters key. Must be called at
+ * PASSIVE_LEVEL (it touches the registry); never read config on the datapath.
+ */
+NTSTATUS OvsReadDriverConfig(PUNICODE_STRING registryPath);
+
+#endif /* __REGISTRY_H_ */

--- a/datapath-windows/ovsext/Registry.h
+++ b/datapath-windows/ovsext/Registry.h
@@ -26,9 +26,10 @@
  *   LogModuleMask  REG_DWORD  per-module OVS_DBG_* enable bitmask
  *
  * Each knob defaults to the compile-time value when absent, so a clean install
- * behaves identically to one with no Parameters key. Must be called at
- * PASSIVE_LEVEL (it touches the registry); never read config on the datapath.
+ * behaves identically to one with no Parameters key. Best-effort and non-fatal
+ * (failures leave the defaults in place). Must be called at PASSIVE_LEVEL (it
+ * touches the registry); never read config on the datapath.
  */
-NTSTATUS OvsReadDriverConfig(PUNICODE_STRING registryPath);
+VOID OvsReadDriverConfig(PUNICODE_STRING registryPath);
 
 #endif /* __REGISTRY_H_ */

--- a/datapath-windows/ovsext/ovsext.vcxproj
+++ b/datapath-windows/ovsext/ovsext.vcxproj
@@ -195,6 +195,7 @@
     <ClInclude Include="PacketParser.h" />
     <ClInclude Include="precomp.h" />
     <ClInclude Include="Recirc.h" />
+    <ClInclude Include="Registry.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Switch.h" />
     <ClInclude Include="Tunnel.h" />
@@ -442,6 +443,7 @@
       <PreCompiledHeaderOutputFile>$(IntDir)\precomp.h.pch</PreCompiledHeaderOutputFile>
     </ClCompile>
     <ClCompile Include="Recirc.c" />
+    <ClCompile Include="Registry.c" />
     <ClCompile Include="Switch.c" />
     <ClCompile Include="Tunnel.c" />
     <ClCompile Include="TunnelFilter.c" />

--- a/datapath-windows/test-catlet/README.md
+++ b/datapath-windows/test-catlet/README.md
@@ -24,7 +24,8 @@ $exes = 'ovs-dpctl','ovs-vswitchd','ovsdb-server','ovs-vsctl','ovsdb-tool','ovs-
 & $scp -O ($exes | ForEach-Object { "$rel\$_.exe" }) vswitchd\vswitch.ovsschema `
     "<catlet>:C:/ovs-test/native/"
 & $scp -O datapath-windows\test-catlet\run-full-mgmt-dp-test.ps1 `
-    datapath-windows\utilities\ovs-tcpdump.ps1 "<catlet>:C:/ovs-test/"
+    datapath-windows\utilities\ovs-tcpdump.ps1 `
+    datapath-windows\utilities\ovs-drvtrace.ps1 "<catlet>:C:/ovs-test/"
 & $ssh <catlet> "powershell -NoProfile -ExecutionPolicy Bypass -File C:\ovs-test\run-full-mgmt-dp-test.ps1"
 ```
 
@@ -48,5 +49,8 @@ SFTP subsystem.
   `.pcapng` (the `ovs-tcpdump` replacement; see `../utilities/README.md`). Copied
   to `C:\ovs-test\` by the deploy steps above and by `deploy-driver.ps1`. Point
   `-OvsCtl C:\ovs-test\native\ovs-vsctl.exe` at the test build when needed.
+- **`ovs-drvtrace.ps1`** — driver log capture via ETW (`logman`+`tracerpt`), the
+  no-debugger way to read `OvsLog()` output (see `../utilities/README.md`). Copied
+  to `C:\ovs-test\` by the deploy steps above and by `deploy-driver.ps1`.
 
 These are manual/dev tools; they are not wired into CI.

--- a/datapath-windows/utilities/README.md
+++ b/datapath-windows/utilities/README.md
@@ -32,6 +32,44 @@ resolution is robust regardless of naming.
 Requires an elevated session (pktmon needs admin). pktmon has a single global
 capture session; the tool takes it over (`-Force` evicts a leftover one).
 
+## ovs-drvtrace.ps1 - driver log capture (ETW)
+
+The forwarding extension routes every `OvsLog()` line through an ETW
+TraceLogging provider (`Dbosoft.OVS.Ovsext`,
+`{b2d1f6a4-9c3e-4f7a-a15b-6d8e2c4f7093}`), so the driver's logs can be captured
+on a production/headless box **without a kernel debugger or DebugView**. The
+events are self-describing (no PDB/TMF needed); `ovs-drvtrace.ps1` uses only the
+in-box `logman` + `tracerpt`, so it runs on a stock VM with no WDK.
+
+```powershell
+# capture 20s around a repro, decode to a .csv next to the .etl
+./ovs-drvtrace.ps1 -Seconds 20
+
+# bracket a specific test
+./ovs-drvtrace.ps1 -Start;  <run the test>;  ./ovs-drvtrace.ps1 -Stop
+
+# errors+warnings only (level 3)
+./ovs-drvtrace.ps1 -Seconds 60 -Level 3
+```
+
+Each decoded row carries the `Module` (OVS_DBG_* subsystem bitmask), `Function`,
+`Line` and the formatted `Message`. The `.etl` also opens directly in WPA. Needs
+an elevated session (ETW kernel sessions need admin).
+
+The driver's `DbgPrintEx` verbosity is tunable in the field via the service
+`Parameters` key (read once at load — reload the driver to apply):
+
+```powershell
+$pk = 'HKLM:\SYSTEM\CurrentControlSet\Services\DBO_OVSE\Parameters'
+New-Item $pk -Force | Out-Null
+Set-ItemProperty $pk LogLevel      -Type DWord -Value 4        # 0=Error..4=Loud
+Set-ItemProperty $pk LogModuleMask -Type DWord -Value 0x008000 # OVS_DBG_* mask
+```
+
+These knobs gate the DbgPrint sink only; ETW capture is controlled by the
+session (above) and records every module/level, so post-filter on the `Module`
+field rather than narrowing here. Absent values keep the built-in defaults.
+
 ## Tracing
 
 Flow tracing already works on Windows with the binaries that ship today, so no

--- a/datapath-windows/utilities/ovs-drvtrace.ps1
+++ b/datapath-windows/utilities/ovs-drvtrace.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+  Capture the dbosoft OVS forwarding-extension (DBO_OVSE.sys) ETW log to a
+  .etl and decode it to text -- the production/headless replacement for
+  attaching a kernel debugger or running DebugView to read OvsLog() output.
+
+.DESCRIPTION
+  The driver routes every OvsLog() (OVS_LOG_ERROR/WARN/INFO/...) through an ETW
+  TraceLogging provider:
+
+      Name: Dbosoft.OVS.Ovsext
+      GUID: {b2d1f6a4-9c3e-4f7a-a15b-6d8e2c4f7093}
+
+  TraceLogging events are self-describing, so no PDB/TMF is needed to decode --
+  this script uses only the in-box logman + tracerpt, so it runs on a stock
+  test VM with no WDK installed.
+
+  Each decoded event carries: Module (the OVS_DBG_* subsystem bitmask), Function,
+  Line, and the formatted Message.
+
+.PARAMETER Seconds
+  One-shot mode: start the session, capture for N seconds, stop, decode.
+
+.PARAMETER Start
+  Start a capture session and return immediately (pair with -Stop).
+
+.PARAMETER Stop
+  Stop the running session and decode its .etl.
+
+.PARAMETER Level
+  Max ETW level to capture (2=Error 3=Warning 4=Info 5=Verbose). Default 5.
+
+.EXAMPLE
+  .\ovs-drvtrace.ps1 -Seconds 20                 # capture 20s around a repro
+.EXAMPLE
+  .\ovs-drvtrace.ps1 -Start; <run a test>; .\ovs-drvtrace.ps1 -Stop
+#>
+[CmdletBinding(DefaultParameterSetName = 'OneShot')]
+param(
+    [Parameter(ParameterSetName = 'OneShot')] [ValidateRange(1, [int]::MaxValue)] [int]$Seconds = 15,
+    [Parameter(ParameterSetName = 'Start')]   [switch]$Start,
+    [Parameter(ParameterSetName = 'Stop')]    [switch]$Stop,
+    # The driver emits no events below Error (2), so 2..5 is the useful range.
+    [ValidateRange(2, 5)] [int]$Level = 5,
+    [string]$OutFile = 'C:\ovs-test\ovs-drvtrace.etl',
+    [string]$TextFile = ''
+)
+$ErrorActionPreference = 'Stop'
+$session  = 'OvsExt'
+$provider = '{b2d1f6a4-9c3e-4f7a-a15b-6d8e2c4f7093}'
+if (-not $TextFile) { $TextFile = [IO.Path]::ChangeExtension($OutFile, '.csv') }
+
+function Start-Capture {
+    $dir = Split-Path $OutFile
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    # logman stop is best-effort: a stale session from a killed run must not block a new one.
+    & logman stop $session -ets 2>$null | Out-Null
+    # Driver events carry keyword 0 (the OVS_DBG_* module is a payload field, not
+    # a keyword), so keyword-0 events bypass keyword filtering and the keywordsAny
+    # mask is immaterial — pass all-ones. level per -Level; -ow overwrites the .etl.
+    & logman start $session -p $provider 0xFFFFFFFFFFFFFFFF $Level -ets -o $OutFile -ow
+    if ($LASTEXITCODE -ne 0) { throw "logman start failed ($LASTEXITCODE)" }
+    Write-Host "[ovs-drvtrace] capturing -> $OutFile (level $Level)" -ForegroundColor Green
+}
+
+function Stop-Capture {
+    & logman stop $session -ets
+    if ($LASTEXITCODE -ne 0) { throw "logman stop failed ($LASTEXITCODE) -- session '$session' running?" }
+    if (-not (Test-Path $OutFile)) { throw "no .etl at $OutFile" }
+    & tracerpt $OutFile -o $TextFile -of CSV -y | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "tracerpt failed ($LASTEXITCODE) decoding $OutFile" }
+    Write-Host "[ovs-drvtrace] decoded -> $TextFile" -ForegroundColor Green
+    $n = [Math]::Max(0, (@(Get-Content $TextFile -EA SilentlyContinue)).Count - 1)
+    Write-Host "[ovs-drvtrace] ~$n event row(s); open $TextFile or load $OutFile in WPA." -ForegroundColor DarkGray
+}
+
+switch ($PSCmdlet.ParameterSetName) {
+    'Start'   { Start-Capture }
+    'Stop'    { Stop-Capture }
+    'OneShot' {
+        Start-Capture
+        Write-Host "[ovs-drvtrace] capturing for ${Seconds}s ..." -ForegroundColor DarkGray
+        Start-Sleep -Seconds $Seconds
+        Stop-Capture
+    }
+}


### PR DESCRIPTION
Routes `OvsLog()` through an ETW TraceLogging provider (`Dbosoft.OVS.Ovsext`, `{b2d1f6a4-9c3e-4f7a-a15b-6d8e2c4f7093}`) alongside the existing `DbgPrintEx`, so the driver's logs can be captured on a production or headless host with no kernel debugger or DebugView. The two sinks gate independently — DbgPrint by the existing `ovsLogLevel`/`ovsLogFlags` globals, ETW by the listening session — so a capture can collect levels the debug console is configured to drop. Events are self-describing (no PDB/TMF to decode); the per-message level is dispatched to a constant-level write and the module bitmask, function, line and message ride as payload fields.

Adds a small registry configuration layer (`Registry.{c,h}`) read once at `PASSIVE_LEVEL` in `DriverEntry` from `HKLM\SYSTEM\CurrentControlSet\Services\DBO_OVSE\Parameters`, applying `LogLevel` and `LogModuleMask` to the logging globals. Values are type-checked and clamped; absent or malformed values fall back to the compile-time defaults (a malformed value is logged), so a clean install behaves identically.

Adds `ovs-drvtrace.ps1` (in-box `logman` + `tracerpt`, no WDK on the target) to capture and decode the provider, staged to the test VM by `deploy-driver.ps1`.

Built clean under `/WX` for both NDIS 6.60 and 6.85 binaries. Live-validated on the kernel-dev VM: provider registers and emits, captured and decoded via `logman`/`tracerpt`, registry `LogLevel`/`LogModuleMask` overrides applied at load, malformed-value fallback warns, and traffic forwards unaffected after reload.