### PR TITLE
cmake: remove stale in-source generated .inc before building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,23 @@ file(WRITE "${OVS_ROOT}/python/ovs/dirs.py" "${_dpy}")
 
 set(BA "${OVS_ROOT}/build-aux")
 set(INCO "${OVS_ROOT}/include/openvswitch")
+
+# Defend against a stale in-source autotools build: the autotools flow generates
+# these .inc next to their .c (e.g. lib/meta-flow.inc), and a quoted
+# #include "meta-flow.inc" resolves the compiland's own directory before any -I
+# path, so a leftover in-source copy silently shadows the ${GEN} one this build
+# generates -- compiling an out-of-date mf_fields[] (wrong field widths, e.g.
+# xreg/xxreg). They are .gitignore'd generated artifacts, so a clean checkout
+# never has them; remove any that a prior in-source build left behind.
+file(REMOVE
+  "${OVS_ROOT}/lib/meta-flow.inc"
+  "${OVS_ROOT}/lib/nx-match.inc"
+  "${OVS_ROOT}/lib/ofp-actions.inc1"
+  "${OVS_ROOT}/lib/ofp-actions.inc2"
+  "${OVS_ROOT}/lib/ofp-errors.inc"
+  "${OVS_ROOT}/lib/ofp-msgs.inc"
+  "${OVS_ROOT}/ovsdb/_server.ovsschema.inc")
+
 # OpenFlow field/action/error/msg extractors (all pure python3)
 ovs_gen("${GEN}/lib/meta-flow.inc"    "${BA}/extract-ofp-fields"  meta-flow "${INCO}/meta-flow.h")
 ovs_gen("${GEN}/lib/nx-match.inc"     "${BA}/extract-ofp-fields"  nx-match  "${INCO}/meta-flow.h")


### PR DESCRIPTION
The CMake build generates `lib/meta-flow.inc` and the other `.inc` into `gen/` and relies on them being searched ahead of the source tree. But a quoted `#include "meta-flow.inc"` (from `lib/meta-flow.c`) resolves the compiland's **own directory first**, before any `-I` path. So if a prior in-source autotools build left a stale `lib/meta-flow.inc` behind, it **silently shadows** the freshly generated `gen/` copy.

That compiles an out-of-date `mf_fields[]`: when the table has fewer entries than the current `MFF_N_IDS`, positional initialization + direct indexing (`mf_fields[id]`) makes high-numbered fields read the wrong slot. Concretely, a stale 183-entry table against today's 211-id enum makes `xreg`/`xxreg` resolve to small fields, so they report **2-/8-bit instead of 64/128-bit** — which surfaces downstream in OVN as `expr|WARN|... Cannot select bits 64 to 127 of 2-bit field xxreg0` and broken northd flow generation.

These `.inc` are `.gitignore`'d generated artifacts, so a clean checkout never has them and CI is unaffected — but a local dev tree that was once autotools-built hits it silently. This adds a configure-time `file(REMOVE ...)` of the known in-source generated includes so the `gen/` copies always win.

Verified: with the stale `ovn/ovs/lib/*.inc` removed and OVN rebuilt, `ovntest test-ovn parse-expr` normalizes `xxreg0[0..127]` → `xxreg0` and accepts `xxreg0[64..127]` (no error); OVS `build-on-main` re-configures and builds `ovsdb-server` cleanly with the guard.