### PR TITLE
datapath-windows: extract flow key for RARP frames

### DIFF
--- a/datapath-windows/ovsext/Flow.c
+++ b/datapath-windows/ovsext/Flow.c
@@ -2951,7 +2951,9 @@ OvsExtractFlow(const NET_BUFFER_LIST *packet,
             OvsParseIcmpV6(packet, &flow->ipv6Key, &flow->icmp6Key, layers);
             flow->l2.keyLen += (OVS_ICMPV6_KEY_SIZE - OVS_IPV6_KEY_SIZE);
         }
-    } else if (flow->l2.dlType == htons(ETH_TYPE_ARP)) {
+    } else if (flow->l2.dlType == htons(ETH_TYPE_ARP) ||
+               flow->l2.dlType == htons(ETH_TYPE_RARP)) {
+        /* RARP shares the ARP wire format, so it populates the same key. */
         EtherArp arpStorage;
         const EtherArp *arp;
         ArpKey *arpKey = &flow->arpKey;
@@ -2969,7 +2971,9 @@ OvsExtractFlow(const NET_BUFFER_LIST *packet,
                 arpKey->nwProto = (UINT8)ntohs(arp->ea_hdr.ar_op);
             }
             if (arpKey->nwProto == ARPOP_REQUEST
-                || arpKey->nwProto == ARPOP_REPLY) {
+                || arpKey->nwProto == ARPOP_REPLY
+                || arpKey->nwProto == RARPOP_REQUEST
+                || arpKey->nwProto == RARPOP_REPLY) {
                 RtlCopyMemory(&arpKey->nwSrc, arp->arp_spa, 4);
                 RtlCopyMemory(&arpKey->nwDst, arp->arp_tpa, 4);
                 RtlCopyMemory(arpKey->arpSha, arp->arp_sha, ETH_ADDR_LENGTH);


### PR DESCRIPTION
The Windows kernel flow-key extractor (`OvsExtractFlow`) populated the ARP key only for EtherType 0x0806 (ARP). A RARP frame (0x8035), which shares the byte-identical `arp_eth_header` wire format, fell through the ethertype chain with its ARP key left all-zero.

This is a Linux-parity / contract-faithfulness fix, not a new feature. OVS userspace already treats RARP as ARP-format everywhere — the `rarp` match keyword (`lib/ofp-parse.c`), `lib/flow.c`, `lib/match.c`, `nx-match`, `odp-util` — and this driver's own Netlink key encode/decode already handle `ETH_TYPE_ARP` and `ETH_TYPE_RARP` identically. The runtime extractor was the one place out of step: a flow written with `rarp,...` predicates installs but can never match on Windows, whereas it matches on Linux.

Two edits in the existing ARP arm, mirroring Linux (`lib/flow.c`):
- Accept `ETH_TYPE_RARP` alongside `ETH_TYPE_ARP`.
- Widen the address-copy opcode gate to the RARP request/reply opcodes (3/4) so the sender/target addresses are populated for RARP frames that carry them, not just the opcode.

Live-validated on a Hyper-V test datapath: with the patched driver, a raw RARP request (op=3, with a non-zero sender address) injected from a guest is matched by a flow `dl_type=0x8035,arp_op=3,arp_spa=192.168.99.50` (n_packets climbs) — which requires the extractor to populate both the opcode and the sender address. Ordinary ARP extraction is unchanged.

Scope: extractor-only. `set(arp)` rewrite on RARP frames and the pre-existing `RARPOP_REPLY_NBO` NBO-constant typo are intentionally left to separate changes.